### PR TITLE
Add Final Resolution field to job dialog (ending_substatus)

### DIFF
--- a/frontend/src/components/JobDialog.spec.tsx
+++ b/frontend/src/components/JobDialog.spec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import JobDialog from "./JobDialog";
-import type { Job } from "../types";
+import type { Job, JobStatus, EndingSubstatus } from "../types";
 
 const BASE_JOB: Job = {
 	id: 42,
@@ -16,9 +16,21 @@ const BASE_JOB: Job = {
 	recruiter: "Jane",
 	notes: "Great team",
 	referred_by: "Alice",
+	job_description: null,
+	ending_substatus: null,
 	favorite: false,
 	created_at: "2024-01-01T00:00:00.000Z",
 };
+
+const terminalJob = (
+	status: JobStatus,
+	ending_substatus: EndingSubstatus | null,
+): Job => ({ ...BASE_JOB, status, ending_substatus });
+
+function changeSelect(labelText: RegExp | string, optionName: string) {
+	fireEvent.mouseDown(screen.getByLabelText(labelText));
+	fireEvent.click(screen.getByRole("option", { name: optionName }));
+}
 
 const DEFAULT_PROPS = {
 	open: true,
@@ -159,6 +171,201 @@ describe("JobDialog", () => {
 			expect(DEFAULT_PROPS.onSave).toHaveBeenCalledWith(
 				expect.objectContaining({ company: "Updated Corp" }),
 			);
+		});
+	});
+
+	describe("Final Resolution field (ending_substatus)", () => {
+		describe("disabled state", () => {
+			it("is disabled for a new job (non-terminal default status)", () => {
+				render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).toHaveAttribute("aria-disabled", "true");
+			});
+
+			it("is disabled when editing a job with a non-terminal status", () => {
+				render(<JobDialog {...DEFAULT_PROPS} initialValues={BASE_JOB} />);
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).toHaveAttribute("aria-disabled", "true");
+			});
+
+			it("is enabled when editing a job that already has a terminal status", () => {
+				render(
+					<JobDialog
+						{...DEFAULT_PROPS}
+						initialValues={terminalJob("Offer!", "Offer accepted")}
+					/>,
+				);
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).not.toHaveAttribute("aria-disabled");
+			});
+
+			it("becomes enabled when the user changes status to a terminal value", () => {
+				render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).toHaveAttribute("aria-disabled", "true");
+
+				changeSelect(/^Status$/i, "Rejected/Withdrawn");
+
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).not.toHaveAttribute("aria-disabled");
+			});
+
+			it("becomes disabled again when status reverts from terminal to non-terminal", () => {
+				render(
+					<JobDialog
+						{...DEFAULT_PROPS}
+						initialValues={terminalJob("Offer!", "Offer accepted")}
+					/>,
+				);
+				changeSelect(/^Status$/i, "Final round interview");
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).toHaveAttribute("aria-disabled", "true");
+			});
+		});
+
+		describe("auto-clear behavior", () => {
+			it("clears the substatus value when status changes from terminal to non-terminal", () => {
+				render(
+					<JobDialog
+						{...DEFAULT_PROPS}
+						initialValues={terminalJob("Offer!", "Offer accepted")}
+					/>,
+				);
+				const field = screen.getByLabelText(/Final Resolution/i);
+				expect(field).toHaveTextContent("Offer accepted");
+
+				changeSelect(/^Status$/i, "Resume submitted");
+
+				expect(field).not.toHaveTextContent("Offer accepted");
+			});
+
+			it("preserves the substatus when switching between two terminal statuses", () => {
+				render(
+					<JobDialog
+						{...DEFAULT_PROPS}
+						initialValues={terminalJob("Offer!", "Offer accepted")}
+					/>,
+				);
+				changeSelect(/^Status$/i, "Rejected/Withdrawn");
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).toHaveTextContent("Offer accepted");
+			});
+		});
+
+		describe("pre-fill", () => {
+			it("displays the existing substatus value when editing a terminal-status job", () => {
+				render(
+					<JobDialog
+						{...DEFAULT_PROPS}
+						initialValues={terminalJob("Rejected/Withdrawn", "Ghosted")}
+					/>,
+				);
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).toHaveTextContent("Ghosted");
+			});
+		});
+
+		describe("validation", () => {
+			it("blocks save and shows error when terminal status has no substatus", () => {
+				render(
+					<JobDialog
+						{...DEFAULT_PROPS}
+						initialValues={terminalJob("Offer!", null)}
+					/>,
+				);
+				fireEvent.click(screen.getByRole("button", { name: "Save" }));
+				expect(
+					screen.getByText("Required for this status"),
+				).toBeInTheDocument();
+				expect(DEFAULT_PROPS.onSave).not.toHaveBeenCalled();
+			});
+
+			it("does not show a substatus error for non-terminal status on save attempt", () => {
+				render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+				fireEvent.click(screen.getByRole("button", { name: "Add Job" }));
+				expect(
+					screen.queryByText("Required for this status"),
+				).not.toBeInTheDocument();
+			});
+
+			it("clears the substatus error when a substatus is subsequently chosen", () => {
+				render(
+					<JobDialog
+						{...DEFAULT_PROPS}
+						initialValues={terminalJob("Offer!", null)}
+					/>,
+				);
+				// Trigger the error
+				fireEvent.click(screen.getByRole("button", { name: "Save" }));
+				expect(screen.getByText("Required for this status")).toBeInTheDocument();
+
+				// Pick a substatus
+				changeSelect(/Final Resolution/i, "Offer accepted");
+
+				expect(
+					screen.queryByText("Required for this status"),
+				).not.toBeInTheDocument();
+			});
+
+			it("clears the substatus error when status changes away from terminal", () => {
+				render(
+					<JobDialog
+						{...DEFAULT_PROPS}
+						initialValues={terminalJob("Offer!", null)}
+					/>,
+				);
+				fireEvent.click(screen.getByRole("button", { name: "Save" }));
+				expect(screen.getByText("Required for this status")).toBeInTheDocument();
+
+				changeSelect(/^Status$/i, "Initial interview");
+
+				expect(
+					screen.queryByText("Required for this status"),
+				).not.toBeInTheDocument();
+			});
+		});
+
+		describe("onSave payload", () => {
+			it("includes ending_substatus in the saved data", () => {
+				render(
+					<JobDialog
+						{...DEFAULT_PROPS}
+						initialValues={terminalJob("Rejected/Withdrawn", "Ghosted")}
+					/>,
+				);
+				fireEvent.click(screen.getByRole("button", { name: "Save" }));
+				expect(DEFAULT_PROPS.onSave).toHaveBeenCalledWith(
+					expect.objectContaining({
+						status: "Rejected/Withdrawn",
+						ending_substatus: "Ghosted",
+					}),
+				);
+			});
+
+			it("sends ending_substatus as null for non-terminal status jobs", () => {
+				render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+				fireEvent.change(screen.getByLabelText(/Company/), {
+					target: { value: "X" },
+				});
+				fireEvent.change(screen.getByLabelText(/Role/), {
+					target: { value: "Y" },
+				});
+				fireEvent.change(screen.getByLabelText(/Link/), {
+					target: { value: "https://x.com" },
+				});
+				fireEvent.click(screen.getByRole("button", { name: "Add Job" }));
+				expect(DEFAULT_PROPS.onSave).toHaveBeenCalledWith(
+					expect.objectContaining({ ending_substatus: null }),
+				);
+			});
 		});
 	});
 });

--- a/frontend/src/components/JobDialog.tsx
+++ b/frontend/src/components/JobDialog.tsx
@@ -15,8 +15,8 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
-import { STATUSES, FIT_SCORES } from "../constants";
-import type { Job, JobFormData, FitScore, JobStatus } from "../types";
+import { STATUSES, FIT_SCORES, ENDING_SUBSTATUSES, TERMINAL_STATUSES } from "../constants";
+import type { Job, JobFormData, FitScore, JobStatus, EndingSubstatus } from "../types";
 
 const EMPTY: JobFormData = {
 	date_applied: null,
@@ -30,6 +30,7 @@ const EMPTY: JobFormData = {
 	recruiter: null,
 	notes: null,
 	job_description: null,
+	ending_substatus: null,
 	favorite: false,
 };
 
@@ -75,6 +76,8 @@ export default function JobDialog({
 		if (!form.company?.trim()) e.company = "Required";
 		if (!form.role?.trim()) e.role = "Required";
 		if (!form.link?.trim()) e.link = "Required";
+		if (TERMINAL_STATUSES.has(form.status) && !form.ending_substatus)
+			e.ending_substatus = "Required for this status";
 		setErrors(e);
 		return Object.keys(e).length === 0;
 	}
@@ -180,11 +183,50 @@ export default function JobDialog({
 								select
 								label="Status"
 								value={form.status}
-								onChange={(e) => set("status", e.target.value as JobStatus)}
+								onChange={(e) => {
+									const newStatus = e.target.value as JobStatus;
+									const isTerminal = TERMINAL_STATUSES.has(newStatus);
+									setForm((f) => ({
+										...f,
+										status: newStatus,
+										ending_substatus: isTerminal ? f.ending_substatus : null,
+									}));
+									if (errors.status) setErrors(({ status: _, ...rest }) => rest);
+									if (!isTerminal)
+										setErrors(({ ending_substatus: _, ...rest }) => rest);
+								}}
 								fullWidth
 								size="small"
 							>
 								{STATUSES.map((s) => (
+									<MenuItem key={s} value={s}>
+										{s}
+									</MenuItem>
+								))}
+							</TextField>
+						</Grid>
+
+						<Grid size={{ xs: 12, sm: 6 }}>
+							<TextField
+								select
+								label="Final Resolution"
+								value={form.ending_substatus ?? ""}
+								onChange={(e) =>
+									set(
+										"ending_substatus",
+										(e.target.value || null) as EndingSubstatus | null,
+									)
+								}
+								disabled={!TERMINAL_STATUSES.has(form.status)}
+								error={!!errors.ending_substatus}
+								helperText={errors.ending_substatus}
+								fullWidth
+								size="small"
+							>
+								<MenuItem value="">
+									<em>None</em>
+								</MenuItem>
+								{ENDING_SUBSTATUSES.map((s) => (
 									<MenuItem key={s} value={s}>
 										{s}
 									</MenuItem>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,4 +1,4 @@
-import type { JobStatus, FitScore } from "./types";
+import type { JobStatus, FitScore, EndingSubstatus } from "./types";
 
 export const STATUSES: JobStatus[] = [
 	"Not started",
@@ -7,6 +7,17 @@ export const STATUSES: JobStatus[] = [
 	"Final round interview",
 	"Offer!",
 	"Rejected/Withdrawn",
+];
+
+export const TERMINAL_STATUSES = new Set<JobStatus>(["Offer!", "Rejected/Withdrawn"]);
+
+export const ENDING_SUBSTATUSES: EndingSubstatus[] = [
+	"Withdrawn",
+	"Rejected",
+	"Ghosted",
+	"No response",
+	"Offer declined",
+	"Offer accepted",
 ];
 
 export const FIT_SCORES: FitScore[] = [


### PR DESCRIPTION
## Summary

- Adds a **Final Resolution** dropdown to the Add/Edit Job modal, mapping to the `ending_substatus` field added in the previous backend PR
- Mirrors the backend's validation rules: field is enabled only when status is `"Offer!"` or `"Rejected/Withdrawn"`, and is required when either of those statuses is set
- Auto-clears and disables the field when status is changed away from a terminal value; preserves the value when switching between terminal statuses
- 14 new unit tests covering all the new behaviors

## Behavior details

| Scenario | Field state |
|---|---|
| New job / non-terminal status | Disabled, empty |
| Status changed to terminal | Enabled, must be set before saving |
| Status changed back to non-terminal | Auto-cleared + disabled |
| Existing job with terminal status | Enabled, pre-filled |
| Save attempted with terminal status but no substatus | Blocked with "Required for this status" error |

## Test plan

- [ ] Open Add Job dialog — Final Resolution is disabled
- [ ] Change status to "Offer!" — field becomes enabled
- [ ] Try to save without choosing a substatus — error shown, save blocked
- [ ] Select a substatus (e.g. "Offer accepted") — error clears, save succeeds
- [ ] Change status back to a non-terminal value — field clears and disables
- [ ] Edit an existing job with "Rejected/Withdrawn" status — substatus pre-filled
- [ ] `npm test` passes (59 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)