### PR TITLE
Redesign UI with custom light mode theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 backend/node_modules/
 frontend/node_modules/
-backend/jobman.db
+backend/jobman.db*
 dist/
 coverage/
 .vite/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <title>JobMan</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/img/logo.svg
+++ b/frontend/public/img/logo.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="40" viewBox="0 0 200 40">
+    <defs>
+        <linearGradient id="briefcaseGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#6366f1"/>
+            <stop offset="100%" style="stop-color:#8b5cf6"/>
+        </linearGradient>
+    </defs>
+
+    <!-- Briefcase icon -->
+    <!-- Handle -->
+    <path d="M13 13 Q13 10 16 10 L22 10 Q25 10 25 13"
+          fill="none" stroke="url(#briefcaseGrad)" stroke-width="2.2" stroke-linecap="round"/>
+    <!-- Body -->
+    <rect x="8" y="14" width="22" height="16" rx="2.5"
+          fill="url(#briefcaseGrad)"/>
+    <!-- Center latch line -->
+    <rect x="8" y="21.5" width="22" height="2" fill="rgba(255,255,255,0.25)"/>
+    <!-- Latch clasp -->
+    <rect x="16.5" y="19.5" width="5" height="5" rx="1.2" fill="white" opacity="0.9"/>
+
+    <!-- Checkmark on clasp -->
+    <polyline points="17.8,22 18.9,23.2 20.5,20.8"
+              fill="none" stroke="#6366f1" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <!-- "jobman" wordmark -->
+    <text x="40" y="26"
+          font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="18"
+          font-weight="700"
+          letter-spacing="-0.3">
+        <tspan fill="#1e1b4b">job</tspan><tspan fill="url(#briefcaseGrad)">man</tspan>
+    </text>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,6 @@ import {
 	CssBaseline,
 	AppBar,
 	Toolbar,
-	Typography,
 	Button,
 	Box,
 	CircularProgress,
@@ -14,7 +13,6 @@ import {
 	TextField,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
-import WorkIcon from "@mui/icons-material/Work";
 import SearchIcon from "@mui/icons-material/Search";
 import theme from "./theme";
 import { api } from "./api";
@@ -128,20 +126,15 @@ export default function App() {
 		<ThemeProvider theme={theme}>
 			<CssBaseline />
 
-			<AppBar
-				position="sticky"
-				elevation={1}
-				sx={{ bgcolor: "white", color: "text.primary" }}
-			>
+			<AppBar position="sticky">
 				<Toolbar sx={{ gap: 1 }}>
-					<WorkIcon color="primary" />
-					<Typography
-						variant="h6"
-						fontWeight={700}
-						sx={{ flexGrow: 1, color: "primary.main" }}
-					>
-						JobMan
-					</Typography>
+					<Box
+						component="img"
+						src="/img/logo.svg"
+						alt="JobMan"
+						sx={{ height: 64 }}
+					/>
+					<Box sx={{ flexGrow: 1 }} />
 					<Button variant="contained" startIcon={<AddIcon />} onClick={openAdd}>
 						Add Job
 					</Button>

--- a/frontend/src/components/JobCard.spec.tsx
+++ b/frontend/src/components/JobCard.spec.tsx
@@ -61,7 +61,7 @@ describe("JobCard", () => {
 		expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
 	});
 
-	it("shows fit score chip when fit_score is set", () => {
+	it("shows fit score indicator when fit_score is set", () => {
 		render(
 			<JobCard
 				job={{ ...BASE_JOB, fit_score: "High" }}
@@ -69,10 +69,10 @@ describe("JobCard", () => {
 				onToggleFavorite={vi.fn()}
 			/>,
 		);
-		expect(screen.getByText("High")).toBeInTheDocument();
+		expect(screen.getByLabelText("Fit: High")).toBeInTheDocument();
 	});
 
-	it("shows referral icon with name when referred_by is set", () => {
+	it("shows referral chip with name when referred_by is set", () => {
 		render(
 			<JobCard
 				job={{ ...BASE_JOB, referred_by: "Jane Doe" }}
@@ -80,11 +80,7 @@ describe("JobCard", () => {
 				onToggleFavorite={vi.fn()}
 			/>,
 		);
-		// MUI v7 Tooltip sets aria-label on the child element instead of title
-		expect(screen.getByTestId("PeopleIcon")).toHaveAttribute(
-			"aria-label",
-			"Referred by Jane Doe",
-		);
+		expect(screen.getByText("Jane Doe")).toBeInTheDocument();
 	});
 
 	it("does not show referral icon when referred_by is null", () => {
@@ -147,7 +143,7 @@ describe("JobCard", () => {
 		render(
 			<JobCard job={BASE_JOB} onClick={onClick} onToggleFavorite={vi.fn()} />,
 		);
-		fireEvent.click(screen.getByText("Acme Corp"));
+		fireEvent.click(screen.getByText("Software Engineer"));
 		expect(onClick).toHaveBeenCalledTimes(1);
 	});
 
@@ -156,7 +152,7 @@ describe("JobCard", () => {
 			<JobCard job={BASE_JOB} onClick={vi.fn()} onToggleFavorite={vi.fn()} />,
 		);
 		// MUI v7 Tooltip sets aria-label on the child element instead of title
-		const link = screen.getByRole("link", { name: "Open job link" });
+		const link = screen.getByRole("link", { name: "Open job listing" });
 		expect(link).toHaveAttribute("href", "https://acme.example.com/job");
 	});
 });

--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -16,8 +16,56 @@ import StarBorderIcon from "@mui/icons-material/StarBorder";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import PeopleIcon from "@mui/icons-material/People";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
-import { FIT_SCORE_COLORS } from "../constants";
-import type { Job } from "../types";
+import type { FitScore, Job } from "../types";
+
+// Maps each fit score to a number of filled bars (out of 5)
+const FIT_SCORE_BARS: Record<FitScore, number> = {
+	"Not sure": 0,
+	"Very Low": 1,
+	Low: 2,
+	Medium: 3,
+	High: 4,
+	"Very High": 5,
+};
+
+// Maps MUI color names to actual hex values for the bar fill
+const FIT_SCORE_HEX: Record<FitScore, string> = {
+	"Not sure": "#9e9e9e",
+	"Very Low": "#ef5350",
+	Low: "#ff7043",
+	Medium: "#ffa726",
+	High: "#66bb6a",
+	"Very High": "#43a047",
+};
+
+function FitScoreBars({ score }: { score: FitScore }) {
+	const filled = FIT_SCORE_BARS[score];
+	const color = FIT_SCORE_HEX[score];
+
+	return (
+		<Box
+			sx={{
+				display: "flex",
+				alignItems: "flex-end",
+				gap: "2px",
+				height: 14,
+				flexShrink: 0,
+			}}
+		>
+			{[1, 2, 3, 4, 5].map((bar) => (
+				<Box
+					key={bar}
+					sx={{
+						width: 3,
+						height: `${(bar / 5) * 100}%`,
+						borderRadius: "1px",
+						bgcolor: bar <= filled ? color : "rgba(0,0,0,0.15)",
+					}}
+				/>
+			))}
+		</Box>
+	);
+}
 
 interface Props {
 	job: Job;
@@ -32,124 +80,147 @@ export default function JobCard({ job, onClick, onToggleFavorite }: Props) {
 			data: { job },
 		});
 
+	const hasChips = job.salary || job.referred_by;
+
 	const style = {
 		transform: CSS.Translate.toString(transform),
 		opacity: isDragging ? 0.4 : 1,
-		cursor: isDragging ? "grabbing" : "grab",
 	};
 
 	return (
 		<Card
 			ref={setNodeRef}
 			style={style}
-			elevation={isDragging ? 0 : 1}
-			sx={{ mb: 1.5, position: "relative", "&:hover": { boxShadow: 3 } }}
+			elevation={0}
+			sx={{
+				mb: 1.5,
+				"&:hover": {
+					boxShadow: `0 0 0 1px rgba(99,102,241,0.3), 0 4px 12px rgba(0,0,0,0.1)`,
+				},
+				transition: "box-shadow 0.15s",
+			}}
 			{...attributes}
 		>
+			{/* Card header — full row is the drag handle */}
 			<Box
 				{...listeners}
 				sx={{
-					position: "absolute",
-					top: 4,
-					left: 4,
-					zIndex: 1,
-					color: "text.disabled",
-					cursor: isDragging ? "grabbing" : "grab",
 					display: "flex",
 					alignItems: "center",
+					gap: 0.5,
+					px: 1,
+					py: 0.5,
+					bgcolor: "rgba(0,0,0,0.035)",
+					borderBottom: "1px solid rgba(0,0,0,0.07)",
+					cursor: isDragging ? "grabbing" : "grab",
 					touchAction: "none",
 				}}
 			>
-				<DragIndicatorIcon sx={{ fontSize: 16 }} />
+				<DragIndicatorIcon
+					sx={{ fontSize: 16, color: "text.disabled", flexShrink: 0 }}
+				/>
+				<Typography
+					variant="subtitle2"
+					fontWeight={700}
+					noWrap
+					sx={{ flex: 1, minWidth: 0 }}
+				>
+					{job.company}
+				</Typography>
+
+				{job.fit_score && (
+					<Tooltip title={`Fit: ${job.fit_score}`} placement="top">
+						<Box
+							onPointerDown={(e) => e.stopPropagation()}
+							sx={{ display: "flex", alignItems: "center", cursor: "default" }}
+						>
+							<FitScoreBars score={job.fit_score} />
+						</Box>
+					</Tooltip>
+				)}
+
+				<Tooltip title="Open job listing">
+					<IconButton
+						size="small"
+						component="a"
+						href={job.link}
+						target="_blank"
+						rel="noopener noreferrer"
+						onPointerDown={(e) => e.stopPropagation()}
+						onClick={(e) => e.stopPropagation()}
+						sx={{ color: "text.disabled", flexShrink: 0 }}
+					>
+						<OpenInNewIcon fontSize="small" />
+					</IconButton>
+				</Tooltip>
+				<Tooltip title={job.favorite ? "Unfavorite" : "Favorite"}>
+					<IconButton
+						size="small"
+						onPointerDown={(e) => e.stopPropagation()}
+						onClick={(e) => {
+							e.stopPropagation();
+							onToggleFavorite(job);
+						}}
+						sx={{
+							color: job.favorite ? "warning.main" : "text.disabled",
+							flexShrink: 0,
+						}}
+					>
+						{job.favorite ? (
+							<StarIcon fontSize="small" />
+						) : (
+							<StarBorderIcon fontSize="small" />
+						)}
+					</IconButton>
+				</Tooltip>
 			</Box>
 
-			<Tooltip title={job.favorite ? "Unfavorite" : "Favorite"}>
-				<IconButton
-					size="small"
-					onPointerDown={(e) => e.stopPropagation()}
-					onClick={(e) => {
-						e.stopPropagation();
-						onToggleFavorite(job);
-					}}
-					sx={{
-						position: "absolute",
-						top: 4,
-						right: 4,
-						zIndex: 1,
-						color: job.favorite ? "warning.main" : "text.disabled",
-					}}
-				>
-					{job.favorite ? (
-						<StarIcon fontSize="small" />
-					) : (
-						<StarBorderIcon fontSize="small" />
-					)}
-				</IconButton>
-			</Tooltip>
-
+			{/* Card body — clickable to open edit dialog */}
 			<CardActionArea
 				onPointerDown={(e) => e.stopPropagation()}
 				onClick={onClick}
 				sx={{ p: 0 }}
 			>
-				<CardContent sx={{ pb: "12px !important", pt: 1.5, pl: 3.5, pr: 4 }}>
-					<Typography variant="subtitle2" fontWeight={700} noWrap>
-						{job.company}
-					</Typography>
+				<CardContent sx={{ pt: 1, pb: "10px !important", px: 1.5 }}>
 					<Typography
 						variant="body2"
 						color="text.secondary"
 						noWrap
-						sx={{ mb: 0.75 }}
+						sx={{ mb: hasChips || job.recruiter ? 0.75 : 0 }}
 					>
 						{job.role}
 					</Typography>
 
-					<Box
-						sx={{
-							display: "flex",
-							flexWrap: "wrap",
-							gap: 0.5,
-							alignItems: "center",
-						}}
-					>
-						{job.salary && (
-							<Chip label={job.salary} size="small" variant="outlined" />
-						)}
-						{job.fit_score && (
-							<Chip
-								label={job.fit_score}
-								size="small"
-								color={FIT_SCORE_COLORS[job.fit_score]}
-								variant="outlined"
-							/>
-						)}
-						{job.referred_by && (
-							<Tooltip title={`Referred by ${job.referred_by}`}>
-								<PeopleIcon fontSize="small" color="primary" />
-							</Tooltip>
-						)}
-						<Tooltip title="Open job link">
-							<IconButton
-								size="small"
-								component="a"
-								href={job.link}
-								target="_blank"
-								rel="noopener noreferrer"
-								onPointerDown={(e) => e.stopPropagation()}
-								onClick={(e) => e.stopPropagation()}
-								sx={{ ml: "auto", color: "text.disabled" }}
-							>
-								<OpenInNewIcon fontSize="small" />
-							</IconButton>
-						</Tooltip>
-					</Box>
+					{hasChips && (
+						<Box
+							sx={{
+								display: "flex",
+								flexWrap: "wrap",
+								gap: 0.5,
+								alignItems: "center",
+								mb: job.recruiter ? 0.5 : 0,
+							}}
+						>
+							{job.salary && (
+								<Chip label={job.salary} size="small" variant="filled" />
+							)}
+							{job.referred_by && (
+								<Chip
+									icon={<PeopleIcon />}
+									label={job.referred_by}
+									size="small"
+									variant="outlined"
+									sx={{ maxWidth: 120 }}
+								/>
+							)}
+						</Box>
+					)}
 
 					{job.recruiter && (
 						<Typography
 							variant="caption"
 							color="text.secondary"
-							sx={{ mt: 0.5, display: "block" }}
+							sx={{ display: "block" }}
 						>
 							Recruiter: {job.recruiter}
 						</Typography>

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -55,11 +55,11 @@ export default function KanbanBoard({
 			<Box
 				sx={{
 					display: "flex",
-					gap: 2,
+					gap: 0,
 					overflowX: "auto",
 					pb: 2,
 					px: 3,
-					alignItems: "flex-start",
+					alignItems: "stretch",
 					minHeight: "calc(100vh - 80px)",
 				}}
 			>

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useDroppable } from "@dnd-kit/core";
-import { Box, Typography, Paper, Badge } from "@mui/material";
+import { Box, Typography, Chip } from "@mui/material";
 import { STATUS_COLORS } from "../constants";
 import type { Job, JobStatus } from "../types";
 import JobCard from "./JobCard";
@@ -29,53 +29,65 @@ export default function KanbanColumn({
 				minWidth: 240,
 				maxWidth: 280,
 				flex: "0 0 260px",
+				borderRadius: 0,
+				overflow: "hidden",
+				bgcolor: "rgba(0,0,0,0.025)",
+				border: "1px solid rgba(0,0,0,0.08)",
+				ml: "-1px",
+				"&:first-of-type": { borderRadius: "10px 0 0 10px" },
+				"&:last-of-type": { borderRadius: "0 10px 10px 0" },
 			}}
 		>
-			<Box sx={{ display: "flex", alignItems: "center", mb: 1, gap: 1 }}>
-				<Box
-					sx={{
-						width: 10,
-						height: 10,
-						borderRadius: "50%",
-						bgcolor: color,
-						flexShrink: 0,
-					}}
-				/>
+			{/* Colored top bar */}
+			<Box sx={{ height: 3, bgcolor: color }} />
+
+			{/* Column header */}
+			<Box
+				sx={{
+					display: "flex",
+					alignItems: "center",
+					px: 1.5,
+					py: 1,
+					gap: 1,
+				}}
+			>
 				<Typography
 					variant="caption"
 					fontWeight={700}
-					color="text.secondary"
-					sx={{ textTransform: "uppercase", letterSpacing: 0.8, flexGrow: 1 }}
+					sx={{
+						textTransform: "uppercase",
+						letterSpacing: 0.8,
+						flexGrow: 1,
+						color: "text.secondary",
+					}}
 				>
 					{status}
 				</Typography>
-				<Badge
-					badgeContent={jobs.length}
-					color="default"
+				<Chip
+					label={jobs.length}
+					size="small"
 					sx={{
-						"& .MuiBadge-badge": {
-							fontSize: 10,
-							height: 16,
-							minWidth: 16,
-							bgcolor: color,
-							color: "#fff",
-						},
+						height: 18,
+						fontSize: 10,
+						fontWeight: 700,
+						bgcolor: `${color}22`,
+						color: color,
+						border: `1px solid ${color}44`,
+						"& .MuiChip-label": { px: 0.75 },
 					}}
 				/>
 			</Box>
 
-			<Paper
+			{/* Drop zone */}
+			<Box
 				ref={setNodeRef}
-				elevation={0}
 				sx={{
 					flex: 1,
 					minHeight: 80,
 					p: 1,
-					bgcolor: isOver ? "action.hover" : "background.paper",
-					borderRadius: 2,
-					border: "2px solid",
-					borderColor: isOver ? color : "transparent",
-					transition: "border-color 0.15s, background-color 0.15s",
+					bgcolor: isOver ? `${color}33` : "transparent",
+					borderTop: "1px solid rgba(0,0,0,0.05)",
+					transition: "background-color 0.15s",
 				}}
 			>
 				{jobs.map((job) => (
@@ -95,7 +107,7 @@ export default function KanbanColumn({
 						Drop here
 					</Typography>
 				)}
-			</Paper>
+			</Box>
 		</Box>
 	);
 }

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,23 +1,78 @@
 import { createTheme } from "@mui/material/styles";
 
 const theme = createTheme({
-	typography: {
-		fontFamily: "Inter, sans-serif",
-	},
 	palette: {
 		mode: "light",
-		primary: { main: "#1976d2" },
-		background: { default: "#f0f4f8" },
+		primary: { main: "#6366f1" },
+		secondary: { main: "#f59e0b" },
+		background: {
+			default: "#e8ecf3",
+			paper: "#ffffff",
+		},
+		divider: "rgba(0,0,0,0.08)",
 	},
+	typography: {
+		fontFamily: "Inter, sans-serif",
+		h6: { fontWeight: 800, letterSpacing: "-0.02em" },
+	},
+	shape: { borderRadius: 10 },
 	components: {
+		MuiCssBaseline: {
+			styleOverrides: {
+				body: {
+					scrollbarColor: "#c1c9d6 transparent",
+					"&::-webkit-scrollbar": { width: 8, height: 8 },
+					"&::-webkit-scrollbar-thumb": {
+						background: "#c1c9d6",
+						borderRadius: 4,
+					},
+					"&::-webkit-scrollbar-track": { background: "transparent" },
+				},
+			},
+		},
+		MuiAppBar: {
+			defaultProps: { elevation: 0 },
+			styleOverrides: {
+				root: {
+					backgroundColor: "#e0e7ff",
+					borderBottom: "1px solid rgba(99,102,241,0.2)",
+				},
+			},
+		},
 		MuiCard: {
 			styleOverrides: {
-				root: { borderRadius: 10 },
+				root: {
+					backgroundImage: "none",
+					border: "1px solid rgba(0,0,0,0.08)",
+					boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+				},
+			},
+		},
+		MuiButton: {
+			styleOverrides: {
+				containedPrimary: {
+					borderRadius: 20,
+					fontWeight: 600,
+					boxShadow: "none",
+					"&:hover": { boxShadow: "none" },
+				},
 			},
 		},
 		MuiChip: {
 			styleOverrides: {
-				root: { fontWeight: 500 },
+				root: { fontWeight: 500, borderRadius: 6 },
+			},
+		},
+		MuiPaper: {
+			styleOverrides: {
+				root: { backgroundImage: "none" },
+			},
+		},
+		MuiOutlinedInput: {
+			styleOverrides: {
+				notchedOutline: {
+					borderColor: "rgba(0,0,0,0.18)",
+				},
 			},
 		},
 	},


### PR DESCRIPTION
## Summary
- Replaces generic default MUI appearance with a distinctive light mode design
- Cool gray background (`#e8ecf3`) with white card surfaces for clear contrast
- Indigo primary (`#6366f1`), pill buttons, custom scrollbars
- SVG logo in the AppBar with a light lavender-indigo header background
- Kanban columns redesigned with a colored status top-bar (replacing dot indicator), adjacent layout with shared borders, uniform height, rounded outer corners, and stronger drop-target highlight
- Job cards redesigned with a distinct drag header row (gripper + company + fit indicator + link + favorite), role/chips/recruiter in a separate clickable body section
- Fit score replaced with a 5-bar signal-strength indicator (color-coded, tooltip on hover)
- Referred-by shown as a labeled chip instead of a bare icon
- Unit tests updated to match new card structure

## Test plan
- [x] Visually verify Kanban board in a browser — columns should be adjacent, same height, with rounded outer corners
- [x] Drag a card between columns using the header grip area; confirm drop-target highlight is visible
- [x] Hover the fit score bars to confirm tooltip shows the score label
- [x] Click a card body to open the edit dialog; confirm header area does not trigger it
- [x] Open the job dialog and verify form fields are readable
- [x] Check favorite star, salary chip, referred-by chip, and recruiter text styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)