### PR TITLE
feat: add phone screen and last onsite date tracking

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,52 @@
+# Create a Pull Request
+
+Create a branch (if needed), commit staged/unstaged changes, push, and open/update a PR.
+
+## Steps
+
+1. **Check branch status**: Run `git status` and `git branch --show-current`
+   - If on `master` or `main`, create a new branch:
+     - Analyze the changes to determine a descriptive branch name
+     - Use lower-kebab-case (e.g., `add-user-authentication`, `fix-login-bug`)
+     - Run `git checkout -b <branch-name>`
+   - If already on a feature branch, continue on that branch
+
+2. **Fix linting errors** by running `npm run lint:fix`. If there are any failures,
+   stop here and let the user fix them.
+
+3. **Fix formatting errors** by running `npm run format:fix`. If there are any failures,
+   stop here and let the user fix them.
+
+4. **Review changes**: Run `git status` and `git diff` to understand what will be committed
+
+5. **Stage and commit**:
+   - Stage relevant files (prefer specific files over `git add -A`)
+   - Determine the commit strategy:
+     - If the feature branch has no prior commits: create a new commit
+     - If the feature branch has a prior commit and a draft PR exists (`gh pr view --json isDraft`): amend the existing commit (`git commit --amend`)
+     - If the feature branch has a prior commit and no PR exists, or the PR is not in draft: create a new commit
+   - Write a commit message (or update the existing one if needed) using the [conventional commit style](https://www.conventionalcommits.org/en/v1.0.0/)
+     - Don't read the conventional commit site/URL if you already know the style
+     - Use "!" after the type to indicate a breaking change
+     - Use "build(deps)" for dependency bumps
+     - Besides dependencies, don't worry too much about adding a scope to the commit type unless it's a larger
+       change concentrated on a specific component or area
+   - Do NOT run `npm run test`; let the CI run it for you
+   - Include `Co-Authored-By: Claude <noreply@anthropic.com>` in the commit message
+
+6. **Push**:
+   - If the commit was amended: `git push --force-with-lease`
+   - Otherwise: `git push -u origin <branch-name>`
+
+7. **Create or update PR**:
+   - Check if a PR already exists for this branch with `gh pr view`
+   - If no PR exists: use `gh pr create --draft` with the title, body, and labels below
+   - If a PR exists: use `gh pr edit` to update the title, body, and labels
+   - Title: concise, matching the commit style
+   - Body: formatted using this repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`),
+     with an additional footer: `🤖 Generated with [Claude Code](https://claude.ai/claude-code)`
+   - Labels — add any that are relevant:
+     - `bug`, `build`, `ci/cd`, `dependencies`, `enhancement`, `refactor`
+     - Only add a `tests` label if the PR is *only* adding test coverage
+
+If any step fails, report the error and ask how to proceed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- For fixes, patches, or other small changes, a one- or two-line summary suffices.
+     For larger changes, a few sentences describing what the change is and why we're making it. -->
+
+## Details
+
+<!-- Bullet points covering the important changes in this PR. -->
+
+## Test plan
+
+<!-- Checkboxes for any manual testing/verification steps that should be done. -->
+- [ ]

--- a/backend/db.ts
+++ b/backend/db.ts
@@ -19,7 +19,9 @@ db.exec(`
     favorite INTEGER DEFAULT 0,
     created_at TEXT DEFAULT (datetime('now')),
     job_description TEXT,
-    ending_substatus TEXT
+    ending_substatus TEXT,
+    date_phone_screen TEXT,
+    date_last_onsite TEXT
   )
 `);
 

--- a/backend/server.spec.ts
+++ b/backend/server.spec.ts
@@ -24,7 +24,9 @@ testDb.exec(`
     favorite INTEGER DEFAULT 0,
     created_at TEXT DEFAULT (datetime('now')),
     job_description TEXT,
-    ending_substatus TEXT
+    ending_substatus TEXT,
+    date_phone_screen TEXT,
+    date_last_onsite TEXT
   )
 `);
 
@@ -303,6 +305,81 @@ describe("ending_substatus validation", () => {
 			expect(res.status).toBe(200);
 			expect(res.body.ending_substatus).toBeNull();
 		});
+	});
+});
+
+describe("date_phone_screen and date_last_onsite fields", () => {
+	it("stores null for both date fields when omitted on create", async () => {
+		const res = await request(app).post("/api/jobs").send(BASE_JOB);
+		expect(res.status).toBe(201);
+		expect(res.body.date_phone_screen).toBeNull();
+		expect(res.body.date_last_onsite).toBeNull();
+	});
+
+	it("stores provided date_phone_screen and date_last_onsite on create", async () => {
+		const res = await request(app)
+			.post("/api/jobs")
+			.send({
+				...BASE_JOB,
+				date_phone_screen: "2026-03-20T10:00",
+				date_last_onsite: "2026-03-23T09:00",
+			});
+		expect(res.status).toBe(201);
+		expect(res.body.date_phone_screen).toBe("2026-03-20T10:00");
+		expect(res.body.date_last_onsite).toBe("2026-03-23T09:00");
+	});
+
+	it("updates date_phone_screen and date_last_onsite via PUT", async () => {
+		const createRes = await request(app).post("/api/jobs").send(BASE_JOB);
+		const id: number = createRes.body.id;
+
+		const res = await request(app)
+			.put(`/api/jobs/${id}`)
+			.send({
+				...BASE_JOB,
+				date_phone_screen: "2026-03-20T10:00",
+				date_last_onsite: "2026-03-23T09:00",
+			});
+		expect(res.status).toBe(200);
+		expect(res.body.date_phone_screen).toBe("2026-03-20T10:00");
+		expect(res.body.date_last_onsite).toBe("2026-03-23T09:00");
+	});
+
+	it("clears both date fields when PUT sends null values", async () => {
+		const createRes = await request(app)
+			.post("/api/jobs")
+			.send({
+				...BASE_JOB,
+				date_phone_screen: "2026-03-20T10:00",
+				date_last_onsite: "2026-03-23T09:00",
+			});
+		const id: number = createRes.body.id;
+
+		const res = await request(app)
+			.put(`/api/jobs/${id}`)
+			.send({
+				...BASE_JOB,
+				date_phone_screen: null,
+				date_last_onsite: null,
+			});
+		expect(res.status).toBe(200);
+		expect(res.body.date_phone_screen).toBeNull();
+		expect(res.body.date_last_onsite).toBeNull();
+	});
+
+	it("returns both date fields in GET /api/jobs", async () => {
+		await request(app)
+			.post("/api/jobs")
+			.send({
+				...BASE_JOB,
+				date_phone_screen: "2026-03-20T10:00",
+				date_last_onsite: "2026-03-23T09:00",
+			});
+
+		const res = await request(app).get("/api/jobs");
+		expect(res.status).toBe(200);
+		expect(res.body[0].date_phone_screen).toBe("2026-03-20T10:00");
+		expect(res.body[0].date_last_onsite).toBe("2026-03-23T09:00");
 	});
 });
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -18,6 +18,8 @@ interface JobRow {
 	notes: string | null;
 	job_description: string | null;
 	ending_substatus: string | null;
+	date_phone_screen: string | null;
+	date_last_onsite: string | null;
 	favorite: number;
 	created_at: string;
 }
@@ -88,8 +90,8 @@ export function createApp(db: DatabaseSync) {
 		}
 		const result = db
 			.prepare(`
-      INSERT INTO jobs (date_applied, company, role, link, salary, fit_score, referred_by, status, recruiter, notes, job_description, ending_substatus, favorite)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO jobs (date_applied, company, role, link, salary, fit_score, referred_by, status, recruiter, notes, job_description, ending_substatus, date_phone_screen, date_last_onsite, favorite)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `)
 			.run(
 				f.date_applied ?? null,
@@ -104,6 +106,8 @@ export function createApp(db: DatabaseSync) {
 				f.notes ?? null,
 				f.job_description ?? null,
 				f.ending_substatus ?? null,
+				f.date_phone_screen ?? null,
+				f.date_last_onsite ?? null,
 				f.favorite ? 1 : 0,
 			);
 		const job = db
@@ -125,7 +129,7 @@ export function createApp(db: DatabaseSync) {
 			.prepare(`
       UPDATE jobs SET
         date_applied = ?, company = ?, role = ?, link = ?, salary = ?,
-        fit_score = ?, referred_by = ?, status = ?, recruiter = ?, notes = ?, job_description = ?, ending_substatus = ?, favorite = ?
+        fit_score = ?, referred_by = ?, status = ?, recruiter = ?, notes = ?, job_description = ?, ending_substatus = ?, date_phone_screen = ?, date_last_onsite = ?, favorite = ?
       WHERE id = ?
     `)
 			.run(
@@ -141,6 +145,8 @@ export function createApp(db: DatabaseSync) {
 				f.notes ?? null,
 				f.job_description ?? null,
 				f.ending_substatus ?? null,
+				f.date_phone_screen ?? null,
+				f.date_last_onsite ?? null,
 				f.favorite ? 1 : 0,
 				id,
 			);

--- a/frontend/src/App.spec.tsx
+++ b/frontend/src/App.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import App from "./App";
+import App, { computeDateUpdates } from "./App";
 import { api } from "./api";
 import type { Job } from "./types";
 
@@ -45,6 +45,8 @@ const makeJob = (overrides: Partial<Job> & Pick<Job, "id">): Job => ({
 	recruiter: null,
 	notes: null,
 	referred_by: null,
+	date_phone_screen: null,
+	date_last_onsite: null,
 	favorite: false,
 	created_at: "2024-01-01T00:00:00.000Z",
 	...overrides,
@@ -138,5 +140,66 @@ describe("App", () => {
 		expect(
 			screen.getByRole("heading", { name: "Add Job" }),
 		).toBeInTheDocument();
+	});
+});
+
+describe("computeDateUpdates", () => {
+	const NOW = "2026-03-25T14:30";
+	const jobWithDates = {
+		date_phone_screen: "2026-03-20T10:00",
+		date_last_onsite: "2026-03-23T09:00",
+	};
+	const jobNoDates = { date_phone_screen: null, date_last_onsite: null };
+
+	it("sets date_phone_screen to now and clears date_last_onsite when moving to Initial interview", () => {
+		const result = computeDateUpdates(jobWithDates, "Initial interview", NOW);
+		expect(result.date_phone_screen).toBe(NOW);
+		expect(result.date_last_onsite).toBeNull();
+	});
+
+	it("sets date_phone_screen to now when moving to Initial interview from a job with no prior dates", () => {
+		const result = computeDateUpdates(jobNoDates, "Initial interview", NOW);
+		expect(result.date_phone_screen).toBe(NOW);
+		expect(result.date_last_onsite).toBeNull();
+	});
+
+	it("sets date_last_onsite to now and preserves date_phone_screen when moving to Final round interview", () => {
+		const result = computeDateUpdates(
+			jobWithDates,
+			"Final round interview",
+			NOW,
+		);
+		expect(result.date_last_onsite).toBe(NOW);
+		expect(result.date_phone_screen).toBe(jobWithDates.date_phone_screen);
+	});
+
+	it("sets date_last_onsite to now when moving to Final round interview with no prior phone screen", () => {
+		const result = computeDateUpdates(jobNoDates, "Final round interview", NOW);
+		expect(result.date_last_onsite).toBe(NOW);
+		expect(result.date_phone_screen).toBeNull();
+	});
+
+	it("clears both dates when moving back to Not started", () => {
+		const result = computeDateUpdates(jobWithDates, "Not started", NOW);
+		expect(result.date_phone_screen).toBeNull();
+		expect(result.date_last_onsite).toBeNull();
+	});
+
+	it("clears both dates when moving back to Resume submitted", () => {
+		const result = computeDateUpdates(jobWithDates, "Resume submitted", NOW);
+		expect(result.date_phone_screen).toBeNull();
+		expect(result.date_last_onsite).toBeNull();
+	});
+
+	it("preserves both dates when moving to Offer!", () => {
+		const result = computeDateUpdates(jobWithDates, "Offer!", NOW);
+		expect(result.date_phone_screen).toBe(jobWithDates.date_phone_screen);
+		expect(result.date_last_onsite).toBe(jobWithDates.date_last_onsite);
+	});
+
+	it("preserves both dates when moving to Rejected/Withdrawn", () => {
+		const result = computeDateUpdates(jobWithDates, "Rejected/Withdrawn", NOW);
+		expect(result.date_phone_screen).toBe(jobWithDates.date_phone_screen);
+		expect(result.date_last_onsite).toBe(jobWithDates.date_last_onsite);
 	});
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,42 @@ import JobDialog from "./components/JobDialog";
 
 type Severity = "success" | "error" | "info" | "warning";
 
+function formatDatetime(value: string) {
+	return new Date(value).toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
+}
+
+function nowDatetimeLocal() {
+	const d = new Date();
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function computeDateUpdates(
+	job: Pick<Job, "date_phone_screen" | "date_last_onsite">,
+	newStatus: JobStatus,
+	now: string,
+): Pick<Job, "date_phone_screen" | "date_last_onsite"> {
+	if (newStatus === "Initial interview") {
+		return { date_phone_screen: now, date_last_onsite: null };
+	}
+	if (newStatus === "Final round interview") {
+		return { date_phone_screen: job.date_phone_screen, date_last_onsite: now };
+	}
+	if (newStatus === "Not started" || newStatus === "Resume submitted") {
+		return { date_phone_screen: null, date_last_onsite: null };
+	}
+	return {
+		date_phone_screen: job.date_phone_screen,
+		date_last_onsite: job.date_last_onsite,
+	};
+}
+
 export default function App() {
 	const [jobs, setJobs] = useState<Job[]>([]);
 	const [search, setSearch] = useState("");
@@ -97,14 +133,32 @@ export default function App() {
 	}
 
 	async function handleStatusChange(job: Job, newStatus: JobStatus) {
-		const optimistic = { ...job, status: newStatus };
+		const dateUpdates = computeDateUpdates(job, newStatus, nowDatetimeLocal());
+		const optimistic = { ...job, status: newStatus, ...dateUpdates };
 		setJobs((prev) => prev.map((j) => (j.id === job.id ? optimistic : j)));
 		try {
 			const updated = await api.updateJob(job.id, {
 				...job,
 				status: newStatus,
+				...dateUpdates,
 			});
 			setJobs((prev) => prev.map((j) => (j.id === updated.id ? updated : j)));
+			const lines = ["Job status updated successfully"];
+			if (dateUpdates.date_phone_screen !== job.date_phone_screen) {
+				lines.push(
+					dateUpdates.date_phone_screen
+						? `Phone screen date set to ${formatDatetime(dateUpdates.date_phone_screen)}`
+						: "Phone screen date cleared",
+				);
+			}
+			if (dateUpdates.date_last_onsite !== job.date_last_onsite) {
+				lines.push(
+					dateUpdates.date_last_onsite
+						? `Last onsite date set to ${formatDatetime(dateUpdates.date_last_onsite)}`
+						: "Last onsite date cleared",
+				);
+			}
+			notify(lines.join("\n"));
 		} catch {
 			setJobs((prev) => prev.map((j) => (j.id === job.id ? job : j)));
 			notify("Failed to move job", "error");
@@ -208,7 +262,11 @@ export default function App() {
 					variant="filled"
 					sx={{ width: "100%" }}
 				>
-					{snack.message}
+					{snack.message.includes("\n")
+						? snack.message
+								.split("\n")
+								.map((line, i) => <div key={i}>{line}</div>)
+						: snack.message}
 				</Alert>
 			</Snackbar>
 		</ThemeProvider>

--- a/frontend/src/components/JobDialog.tsx
+++ b/frontend/src/components/JobDialog.tsx
@@ -42,6 +42,8 @@ const EMPTY: JobFormData = {
 	notes: null,
 	job_description: null,
 	ending_substatus: null,
+	date_phone_screen: null,
+	date_last_onsite: null,
 	favorite: false,
 };
 
@@ -274,6 +276,33 @@ export default function JobDialog({
 								type="date"
 								value={form.date_applied ?? ""}
 								onChange={(e) => set("date_applied", e.target.value || null)}
+								fullWidth
+								size="small"
+								slotProps={{ inputLabel: { shrink: true } }}
+							/>
+						</Grid>
+
+						<Grid size={{ xs: 12, sm: 6 }}>
+							<TextField
+								label="Phone Screen Date"
+								type="datetime-local"
+								value={form.date_phone_screen?.slice(0, 16) ?? ""}
+								onChange={(e) =>
+									set("date_phone_screen", e.target.value || null)
+								}
+								fullWidth
+								size="small"
+								slotProps={{ inputLabel: { shrink: true } }}
+							/>
+						</Grid>
+						<Grid size={{ xs: 12, sm: 6 }}>
+							<TextField
+								label="Last Onsite Date"
+								type="datetime-local"
+								value={form.date_last_onsite?.slice(0, 16) ?? ""}
+								onChange={(e) =>
+									set("date_last_onsite", e.target.value || null)
+								}
 								fullWidth
 								size="small"
 								slotProps={{ inputLabel: { shrink: true } }}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,8 @@ export interface Job {
 	notes: string | null;
 	job_description: string | null;
 	ending_substatus: EndingSubstatus | null;
+	date_phone_screen: string | null;
+	date_last_onsite: string | null;
 	favorite: boolean;
 	created_at: string;
 }

--- a/import-jobs.mjs
+++ b/import-jobs.mjs
@@ -1,0 +1,118 @@
+import { DatabaseSync } from "node:sqlite";
+import { execSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Status mapping ────────────────────────────────────────────────────────────
+const STATUS_MAP = {
+  "Not started": "Not started",
+  "Resume sent": "Resume submitted",
+  "Application submitted": "Resume submitted",
+  "Chatted with recruiter": "Initial interview",
+  "Recruiter/Initial Chat scheduled": "Initial interview",
+  "Awaiting recruiter call scheduling": "Initial interview",
+  "Initial eng screen": "Initial interview",
+  "No good fit roles open": "Rejected/Withdrawn",
+  "Job closed": "Rejected/Withdrawn",
+};
+
+function mapStatus(raw) {
+  if (!raw) return "Not started";
+  const mapped = STATUS_MAP[raw.trim()];
+  if (!mapped) {
+    console.warn(`  ⚠ Unknown status "${raw}" — defaulting to "Not started"`);
+    return "Not started";
+  }
+  return mapped;
+}
+
+function parseDate(dateStr) {
+  if (!dateStr) return null;
+  const parts = dateStr.split("/");
+  if (parts.length !== 3) return null;
+  const [m, d, y] = parts;
+  return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}`;
+}
+
+// ── Fetch sheet data ──────────────────────────────────────────────────────────
+console.log("Fetching sheet data...");
+const raw = execSync(
+  "gws sheets +read --spreadsheet 1tfaScAzDsPJDxaNDmeXsM15T-kbmXVoSkpFychFeHcE --range 'Jobs!A1:K200'",
+  { encoding: "utf8" }
+);
+const json = raw.replace(/^Using keyring backend: keyring\n/, "");
+const { values } = JSON.parse(json);
+const [_header, ...rows] = values;
+console.log(`Found ${rows.length} rows.\n`);
+
+// ── Open DB ───────────────────────────────────────────────────────────────────
+const db = new DatabaseSync(join(__dirname, "backend/jobman.db"));
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    date_applied TEXT,
+    company TEXT NOT NULL,
+    role TEXT NOT NULL,
+    link TEXT NOT NULL,
+    salary TEXT,
+    fit_score TEXT,
+    referred_by TEXT,
+    status TEXT DEFAULT 'Not started',
+    recruiter TEXT,
+    notes TEXT,
+    favorite INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now'))
+  )
+`);
+
+const insert = db.prepare(`
+  INSERT INTO jobs (date_applied, company, role, link, salary, fit_score, referred_by, status, recruiter, notes, favorite)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`);
+
+// ── Insert rows ───────────────────────────────────────────────────────────────
+let inserted = 0;
+let failed = 0;
+
+for (const row of rows) {
+  const [date, company, role, link, salary, fitScore, referredBy, status, recruiter, notes, discoveryStrategy] = row;
+
+  // Build notes: append discovery strategy if present
+  let notesValue = notes || null;
+  if (discoveryStrategy && discoveryStrategy.trim()) {
+    notesValue = notesValue
+      ? `${notesValue}\n[Discovery: ${discoveryStrategy.trim()}]`
+      : `[Discovery: ${discoveryStrategy.trim()}]`;
+  }
+
+  // Special handling for the recruiter-only row
+  if (company === "(recruiter)") {
+    notesValue = `Recruiter-only contact — no specific role open.${notesValue ? " " + notesValue : ""}`;
+  }
+
+  try {
+    insert.run(
+      parseDate(date),
+      company || "(unknown)",
+      role || "",
+      link || "",
+      salary || null,
+      fitScore || null,
+      (referredBy && referredBy !== "None") ? referredBy : null,
+      mapStatus(status),
+      recruiter || null,
+      notesValue,
+      0,
+    );
+    console.log(`  OK  ${company} — ${role || "(no role)"}`);
+    inserted++;
+  } catch (err) {
+    console.error(`  FAIL  ${company} — ${role}: ${err.message}`);
+    failed++;
+  }
+}
+
+console.log(`\nDone. ${inserted} inserted, ${failed} failed.`);


### PR DESCRIPTION
## Summary

Adds two new datetime fields — `date_phone_screen` and `date_last_onsite` — to track when interviews occurred. These are automatically set or cleared as jobs are dragged between Kanban columns, and are also manually editable in the job dialog.

## Details

- **Data model**: Added `date_phone_screen TEXT` and `date_last_onsite TEXT` columns to the SQLite schema (db.ts) and migrated the existing database in-place
- **Auto-update on drag-and-drop**:
  - → "Initial interview": sets `date_phone_screen` to now, clears `date_last_onsite`
  - → "Final round interview": sets `date_last_onsite` to now, preserves `date_phone_screen`
  - → "Not started" / "Resume submitted": clears both fields
  - → "Offer!" / "Rejected/Withdrawn": preserves both fields unchanged
- **Toast notifications**: Success toast on drag-and-drop now includes lines for any date field changes (e.g. "Phone screen date set to Mar 25, 2026, 2:30 PM" or "Last onsite date cleared"), formatted using the user's locale
- **Job dialog**: Added `datetime-local` inputs for both fields, placed between Date Applied and Salary
- **Tests**: Extracted date logic into `computeDateUpdates` (exported pure function); 8 frontend unit tests cover all status transitions; 5 backend integration tests cover field persistence via POST/PUT/GET
- **Tooling**: Added `.claude/commands/pr.md` slash command and `.github/PULL_REQUEST_TEMPLATE.md`

## Test plan

- [x] Drag a job to "Initial interview" — phone screen date is set with a formatted date/time in the toast and is visible in the edit dialog
- [x] Drag a job to "Final round interview" — last onsite date is set to now; phone screen date is preserved
- [x] Drag a job back to "Not started" or "Resume submitted" — both dates are cleared
- [x] Drag to "Offer!" or "Rejected/Withdrawn" — both dates are unchanged
- [x] Manually edit dates in the job dialog and verify they save correctly
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)