### PR TITLE
feat: add updated_at tracking and per-status date labels on job cards

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -21,7 +21,8 @@ db.exec(`
     job_description TEXT,
     ending_substatus TEXT,
     date_phone_screen TEXT,
-    date_last_onsite TEXT
+    date_last_onsite TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   )
 `);
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -22,6 +22,7 @@ interface JobRow {
 	date_last_onsite: string | null;
 	favorite: number;
 	created_at: string;
+	updated_at: string;
 }
 
 // TODO: Share types with frontend

--- a/frontend/src/components/JobCard.test.tsx
+++ b/frontend/src/components/JobCard.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { DndContext } from "@dnd-kit/core";
+import JobCard from "./JobCard";
+import type { Job } from "../types";
+
+const baseJob: Job = {
+	id: 1,
+	company: "Acme Corp",
+	role: "Engineer",
+	link: "https://example.com",
+	status: "Rejected/Withdrawn",
+	fit_score: null,
+	salary: null,
+	date_applied: null,
+	recruiter: null,
+	notes: null,
+	job_description: null,
+	ending_substatus: "Rejected",
+	referred_by: null,
+	date_phone_screen: null,
+	date_last_onsite: null,
+	favorite: false,
+	created_at: "2025-01-01T00:00:00",
+	updated_at: "2025-06-15T00:00:00",
+};
+
+function renderCard(job: Job) {
+	return render(
+		<DndContext>
+			<JobCard job={job} onClick={() => {}} onToggleFavorite={() => {}} />
+		</DndContext>,
+	);
+}
+
+describe("JobCard — Rejected/Withdrawn date label", () => {
+	it("displays 'Last updated' with the formatted updated_at date", () => {
+		renderCard(baseJob);
+		expect(screen.getByText(/Last updated/)).toBeInTheDocument();
+		expect(screen.getByText(/Jun 15, 2025/)).toBeInTheDocument();
+	});
+
+	it("renders nothing when updated_at is missing", () => {
+		// updated_at is non-nullable in the type, but guard the formatting logic
+		const job = { ...baseJob, updated_at: "" };
+		renderCard(job);
+		expect(screen.queryByText(/Last updated/)).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -16,7 +16,45 @@ import StarBorderIcon from "@mui/icons-material/StarBorder";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import PeopleIcon from "@mui/icons-material/People";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
-import type { FitScore, Job } from "../types";
+import type { FitScore, Job, JobStatus } from "../types";
+
+function formatDate(dateStr: string | null): string | null {
+	if (!dateStr) return null;
+	const d = new Date(dateStr);
+	if (isNaN(d.getTime())) return null;
+	return d.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
+const STATUS_DATE_LABEL: Record<
+	JobStatus,
+	{ label: string; getDate: (job: Job) => string | null }
+> = {
+	"Not started": {
+		label: "Last updated",
+		getDate: (job) => formatDate(job.created_at),
+	},
+	"Resume submitted": {
+		label: "Applied",
+		getDate: (job) => formatDate(job.date_applied),
+	},
+	"Initial interview": {
+		label: "Phone screen",
+		getDate: (job) => formatDate(job.date_phone_screen),
+	},
+	"Final round interview": {
+		label: "Last onsite",
+		getDate: (job) => formatDate(job.date_last_onsite),
+	},
+	"Offer!": { label: "Last updated", getDate: () => null },
+	"Rejected/Withdrawn": {
+		label: "Last updated",
+		getDate: (job) => formatDate(job.updated_at),
+	},
+};
 
 // Maps each fit score to a number of filled bars (out of 5)
 const FIT_SCORE_BARS: Record<FitScore, number> = {
@@ -225,6 +263,21 @@ export default function JobCard({ job, onClick, onToggleFavorite }: Props) {
 							Recruiter: {job.recruiter}
 						</Typography>
 					)}
+
+					{(() => {
+						const { label, getDate } = STATUS_DATE_LABEL[job.status];
+						const date = getDate(job);
+						if (!date) return null;
+						return (
+							<Typography
+								variant="caption"
+								color="text.disabled"
+								sx={{ display: "block", mt: 0.5 }}
+							>
+								{label} {date}
+							</Typography>
+						);
+					})()}
 				</CardContent>
 			</CardActionArea>
 		</Card>

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -40,6 +40,7 @@ export interface Job {
 	date_last_onsite: string | null;
 	favorite: boolean;
 	created_at: string;
+	updated_at: string;
 }
 
 export type JobFormData = Omit<Job, "id" | "created_at">;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    globals: true,
+  },
   plugins: [react()],
   build: {
     target: 'es2023',


### PR DESCRIPTION
## Summary

Adds an `updated_at` column to the jobs schema and displays a contextual date label at the bottom of each job card based on its current status.

## Details

- **Schema**: Added `updated_at TEXT NOT NULL DEFAULT (datetime('now'))` to the `jobs` CREATE TABLE; existing DB rows backfilled with `MAX(date_applied, created_at, date_phone_screen, date_last_onsite)`
- **Type updates**: Added `updated_at: string` to `JobRow` (backend) and `Job` (frontend)
- **Job cards**: Each status now shows the most meaningful date:
  - Not started → "Last updated \<created_at\>"
  - Resume submitted → "Applied \<date_applied\>"
  - Initial interview → "Phone screen \<date_phone_screen\>"
  - Final round interview → "Last onsite \<date_last_onsite\>"
  - Rejected/Withdrawn → "Last updated \<updated_at\>"
- **Tests**: Configured vitest with jsdom + `@testing-library/react`; added unit tests for the Rejected/Withdrawn date label

## Test plan

- [x] Rejected/Withdrawn cards show "Last updated \<date\>"
- [x] Other statuses show their respective date labels (only when date is non-null)
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)