### PR TITLE
feat(JobCard): polish card UI for consistent sizing and salary visibility

### DIFF
--- a/frontend/src/components/JobCard.spec.tsx
+++ b/frontend/src/components/JobCard.spec.tsx
@@ -54,11 +54,11 @@ describe("JobCard", () => {
 		expect(screen.getByText("$120k–$150k")).toBeInTheDocument();
 	});
 
-	it("does not show salary chip when salary is null", () => {
+	it("shows $??? chip when salary is null", () => {
 		render(
 			<JobCard job={BASE_JOB} onClick={vi.fn()} onToggleFavorite={vi.fn()} />,
 		);
-		expect(screen.queryByText(/\$/)).not.toBeInTheDocument();
+		expect(screen.getByText("$???")).toBeInTheDocument();
 	});
 
 	it("shows fit score indicator when fit_score is set", () => {

--- a/frontend/src/components/JobCard.test.tsx
+++ b/frontend/src/components/JobCard.test.tsx
@@ -40,10 +40,9 @@ describe("JobCard — Rejected/Withdrawn date label", () => {
 		expect(screen.getByText(/Jun 15, 2025/)).toBeInTheDocument();
 	});
 
-	it("renders nothing when updated_at is missing", () => {
-		// updated_at is non-nullable in the type, but guard the formatting logic
+	it("renders label without a date when updated_at is empty", () => {
 		const job = { ...baseJob, updated_at: "" };
 		renderCard(job);
-		expect(screen.queryByText(/Last updated/)).not.toBeInTheDocument();
+		expect(screen.getByText("Last updated")).toBeInTheDocument();
 	});
 });

--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -17,6 +17,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import PeopleIcon from "@mui/icons-material/People";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import type { FitScore, Job, JobStatus } from "../types";
+import { STATUS_COLORS } from "../constants";
 
 function formatDate(dateStr: string | null): string | null {
 	if (!dateStr) return null;
@@ -118,8 +119,6 @@ export default function JobCard({ job, onClick, onToggleFavorite }: Props) {
 			data: { job },
 		});
 
-	const hasChips = job.salary || job.referred_by;
-
 	const style = {
 		transform: CSS.Translate.toString(transform),
 		opacity: isDragging ? 0.4 : 1,
@@ -148,8 +147,12 @@ export default function JobCard({ job, onClick, onToggleFavorite }: Props) {
 					gap: 0.5,
 					px: 1,
 					py: 0.5,
-					bgcolor: "rgba(0,0,0,0.035)",
-					borderBottom: "1px solid rgba(0,0,0,0.07)",
+					bgcolor: isDragging
+						? "rgba(0,0,0,0.035)"
+						: `${STATUS_COLORS[job.status]}26`,
+					borderBottom: isDragging
+						? "1px solid rgba(0,0,0,0.07)"
+						: `1px solid ${STATUS_COLORS[job.status]}40`,
 					cursor: isDragging ? "grabbing" : "grab",
 					touchAction: "none",
 				}}
@@ -224,35 +227,40 @@ export default function JobCard({ job, onClick, onToggleFavorite }: Props) {
 						variant="body2"
 						color="text.secondary"
 						noWrap
-						sx={{ mb: hasChips || job.recruiter ? 0.75 : 0 }}
+						sx={{ mb: job.recruiter ? 0.75 : 0 }}
 					>
 						{job.role}
 					</Typography>
 
-					{hasChips && (
-						<Box
-							sx={{
-								display: "flex",
-								flexWrap: "wrap",
-								gap: 0.5,
-								alignItems: "center",
-								mb: job.recruiter ? 0.5 : 0,
-							}}
-						>
-							{job.salary && (
-								<Chip label={job.salary} size="small" variant="filled" />
-							)}
-							{job.referred_by && (
-								<Chip
-									icon={<PeopleIcon />}
-									label={job.referred_by}
-									size="small"
-									variant="outlined"
-									sx={{ maxWidth: 120 }}
-								/>
-							)}
-						</Box>
-					)}
+					<Box
+						sx={{
+							display: "flex",
+							flexWrap: "wrap",
+							gap: 0.5,
+							alignItems: "center",
+							mb: job.recruiter ? 0.5 : 0,
+						}}
+					>
+						<Chip
+							label={job.salary ?? "$???"}
+							size="small"
+							variant="filled"
+							sx={
+								job.salary
+									? { bgcolor: "#c8e6c9", color: "#1b5e20" }
+									: { bgcolor: "#e0e0e0", color: "#757575" }
+							}
+						/>
+						{job.referred_by && (
+							<Chip
+								icon={<PeopleIcon />}
+								label={job.referred_by}
+								size="small"
+								variant="outlined"
+								sx={{ maxWidth: 120 }}
+							/>
+						)}
+					</Box>
 
 					{job.recruiter && (
 						<Typography
@@ -267,14 +275,14 @@ export default function JobCard({ job, onClick, onToggleFavorite }: Props) {
 					{(() => {
 						const { label, getDate } = STATUS_DATE_LABEL[job.status];
 						const date = getDate(job);
-						if (!date) return null;
 						return (
 							<Typography
 								variant="caption"
 								color="text.disabled"
 								sx={{ display: "block", mt: 0.5 }}
 							>
-								{label} {date}
+								{label}
+								{date ? ` ${date}` : ""}
 							</Typography>
 						);
 					})()}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -38,7 +38,7 @@ export const STATUS_COLORS = {
 	"Not started": "#90a4ae",
 	"Resume submitted": "#ffa726",
 	"Initial interview": "#ab47bc",
-	"Final round interview": "#7e57c2",
+	"Final round interview": "#1e88e5",
 	"Offer!": "#66bb6a",
 	"Rejected/Withdrawn": "#ef5350",
 } satisfies Record<JobStatus, string>;


### PR DESCRIPTION
## Summary

UI polish pass on job cards for visual consistency, better salary visibility, and column color theming.

## Details

- **Salary chip always renders**: green background with dark green text when set; gray with "\$???" when unknown — chip row is always present
- **Status date label always renders**: shows label-only (e.g. "Applied", "Phone screen") when the date is missing, preventing card height variation
- **Card header tinting**: each card's drag-handle header is tinted with a 15% opacity version of its column's color; reverts to gray while dragging
- **Final round interview color**: changed from deep purple (`#7e57c2`) to blue (`#1e88e5`) — affects column top bar, count chip, drop-zone hover, and card headers
- **Test updated**: asserts date label renders without a date when `updated_at` is empty

## Test plan

- [x] Cards with no salary show a gray "\$???" chip
- [x] Cards with salary show a green chip with the salary value
- [x] Cards with no date for their status still show the label text
- [x] Card header color matches the column (blue for Final round interview, etc.)
- [x] Card header turns gray while being dragged
- [x] Final round interview column is blue throughout (top bar, chip, hover, card headers)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)