### PR TITLE
feat(api): add GET /api/interviews cross-job search endpoint

### DIFF
--- a/backend/db/interviews.ts
+++ b/backend/db/interviews.ts
@@ -40,6 +40,42 @@ export interface QuestionCreateData {
 
 export type QuestionUpdateData = Omit<QuestionCreateData, "interview_id">;
 
+export interface EnrichedInterviewRow extends InterviewRow {
+	company: string;
+	role: string;
+	link: string;
+}
+
+export function listEnrichedInterviews(
+	db: Database.Database,
+	userId: number,
+	from?: string,
+	to?: string,
+): EnrichedInterviewRow[] {
+	const conditions: string[] = ["j.user_id = ?"];
+	const params: (number | string)[] = [userId];
+
+	if (from !== undefined) {
+		conditions.push("i.interview_dttm >= ?");
+		params.push(from);
+	}
+	if (to !== undefined) {
+		conditions.push("i.interview_dttm <= ?");
+		params.push(to);
+	}
+
+	const sql = `
+		SELECT i.id, i.job_id, i.interview_type, i.interview_dttm,
+		       i.interview_interviewers, i.interview_vibe, i.interview_notes,
+		       j.company, j.role, j.link
+		FROM interviews i
+		JOIN jobs j ON j.id = i.job_id
+		WHERE ${conditions.join(" AND ")}
+		ORDER BY i.interview_dttm ASC
+	`;
+	return db.prepare(sql).all(...params) as EnrichedInterviewRow[];
+}
+
 export function jobBelongsToUser(
 	db: Database.Database,
 	jobId: number,

--- a/backend/routes/interviews.spec.ts
+++ b/backend/routes/interviews.spec.ts
@@ -594,3 +594,153 @@ describe("DELETE /api/jobs/:jobId/interviews/:interviewId/questions/:questionId"
 		expect(res.status).toBe(404);
 	});
 });
+
+// --- GET /api/interviews (cross-job interview search) ---
+
+describe("GET /api/interviews", () => {
+	it("returns 200 with an empty array when there are no interviews", async () => {
+		const res = await req("get", "/api/interviews");
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual([]);
+	});
+
+	it("returns enriched interviews with a nested job object", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_interviewers: "Alice",
+			interview_vibe: "casual",
+		});
+
+		const res = await req("get", "/api/interviews");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(1);
+		const interview = res.body[0];
+		expect(interview.interview_type).toBe("phone_screen");
+		expect(interview.interview_interviewers).toBe("Alice");
+		expect(interview.interview_vibe).toBe("casual");
+		expect(interview.job).toMatchObject({
+			id: jobId,
+			company: BASE_JOB.company,
+			role: BASE_JOB.role,
+			link: BASE_JOB.link,
+		});
+	});
+
+	it("returns interviews ordered by interview_dttm ascending", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_dttm: "2026-04-20T10:00",
+		});
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_dttm: "2026-04-05T10:00",
+		});
+
+		const res = await req("get", "/api/interviews");
+		expect(res.status).toBe(200);
+		expect(res.body[0].interview_dttm).toBe("2026-04-05T10:00");
+		expect(res.body[1].interview_dttm).toBe("2026-04-20T10:00");
+	});
+
+	it("filters to interviews on or after ?from", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_dttm: "2026-03-01T10:00",
+		});
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_dttm: "2026-04-15T10:00",
+		});
+
+		const res = await req("get", "/api/interviews?from=2026-04-01T00:00:00");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(1);
+		expect(res.body[0].interview_dttm).toBe("2026-04-15T10:00");
+	});
+
+	it("filters to interviews on or before ?to", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_dttm: "2026-03-01T10:00",
+		});
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_dttm: "2026-04-15T10:00",
+		});
+
+		const res = await req("get", "/api/interviews?to=2026-04-01T23:59:59");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(1);
+		expect(res.body[0].interview_dttm).toBe("2026-03-01T10:00");
+	});
+
+	it("filters to interviews within a ?from+?to range", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_dttm: "2026-03-01T10:00",
+		});
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_dttm: "2026-04-10T10:00",
+		});
+		await req("post", `/api/jobs/${jobId}/interviews`).send({
+			...BASE_INTERVIEW,
+			interview_dttm: "2026-05-01T10:00",
+		});
+
+		const res = await req(
+			"get",
+			"/api/interviews?from=2026-04-01T00:00:00&to=2026-04-30T23:59:59",
+		);
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(1);
+		expect(res.body[0].interview_dttm).toBe("2026-04-10T10:00");
+	});
+
+	it("returns 400 for an invalid ?from value", async () => {
+		const res = await req("get", "/api/interviews?from=not-a-date");
+		expect(res.status).toBe(400);
+		expect(res.body.error).toMatch(/from/);
+	});
+
+	it("returns 400 for an invalid ?to value", async () => {
+		const res = await req("get", "/api/interviews?to=not-a-date");
+		expect(res.status).toBe(400);
+		expect(res.body.error).toMatch(/to/);
+	});
+
+	it("only returns interviews belonging to the authenticated user", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send(BASE_INTERVIEW);
+
+		// Insert a job + interview for a different user directly
+		testDb
+			.prepare(
+				"INSERT INTO jobs (user_id, company, role, link, status) VALUES (?, ?, ?, ?, ?)",
+			)
+			.run(2, "Other Corp", "PM", "https://other.example.com", "Not started");
+		const otherJobId = (
+			testDb.prepare("SELECT last_insert_rowid() AS id").get() as { id: number }
+		).id;
+		testDb
+			.prepare(
+				"INSERT INTO interviews (job_id, interview_type, interview_dttm) VALUES (?, ?, ?)",
+			)
+			.run(otherJobId, "phone_screen", "2026-04-02T14:00");
+
+		const res = await req("get", "/api/interviews");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(1);
+		expect(res.body[0].job.company).toBe(BASE_JOB.company);
+	});
+
+	it("returns 401 when unauthenticated", async () => {
+		const res = await request(app).get("/api/interviews");
+		expect(res.status).toBe(401);
+	});
+});

--- a/backend/routes/interviews.ts
+++ b/backend/routes/interviews.ts
@@ -4,6 +4,38 @@ import expressLib from "express";
 import * as InterviewsDb from "../db/interviews.js";
 import { validateInterview, validateInterviewQuestion } from "../validators.js";
 
+// GET /api/interviews — cross-job interview search with optional ?from and ?to filters
+export function createInterviewSearchRouter(db: Database.Database) {
+	const router = expressLib.Router();
+
+	router.get("/", (req, res) => {
+		const { from, to } = req.query as { from?: string; to?: string };
+
+		if (from !== undefined && isNaN(Date.parse(from))) {
+			return res.status(400).json({ error: "Invalid 'from' date" });
+		}
+		if (to !== undefined && isNaN(Date.parse(to))) {
+			return res.status(400).json({ error: "Invalid 'to' date" });
+		}
+
+		const rows = InterviewsDb.listEnrichedInterviews(
+			db,
+			req.session.userId!,
+			from,
+			to,
+		);
+
+		return res.json(
+			rows.map(({ company, role, link, ...interview }) => ({
+				...interview,
+				job: { id: interview.job_id, company, role, link },
+			})),
+		);
+	});
+
+	return router;
+}
+
 // Verifies the job belongs to the user and the interview belongs to the job.
 // Sends 404 and returns null if either check fails.
 function resolveInterview(

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -6,7 +6,10 @@ import SqliteStoreFactory from "better-sqlite3-session-store";
 import type Database from "better-sqlite3";
 
 import { createAuthRouter } from "./routes/auth.js";
-import { createInterviewsRouter } from "./routes/interviews.js";
+import {
+	createInterviewSearchRouter,
+	createInterviewsRouter,
+} from "./routes/interviews.js";
 import { createJobsRouter } from "./routes/jobs.js";
 import { createStatsRouter } from "./routes/stats.js";
 
@@ -60,6 +63,7 @@ export function createApp(db: Database.Database) {
 	app.use(passport.initialize());
 
 	app.use("/api/auth", createAuthRouter(db));
+	app.use("/api/interviews", requireAuth, createInterviewSearchRouter(db));
 	app.use("/api/jobs", requireAuth, createJobsRouter(db));
 	app.use(
 		"/api/jobs/:jobId/interviews",


### PR DESCRIPTION
## Summary

Adds a new top-level `GET /api/interviews` endpoint for querying interviews across all jobs for the authenticated user, with optional `?from` and `?to` ISO 8601 date filters. This is the backend foundation for the upcoming Interviews calendar page.

## Details

- **New DB function** `listEnrichedInterviews` in `backend/db/interviews.ts` — joins `interviews` with `jobs`, supports dynamic `from`/`to` date range filters, and returns a flat row type (`EnrichedInterviewRow`) that includes `company`, `role`, and `link` alongside all interview fields
- **New router** `createInterviewSearchRouter` in `backend/routes/interviews.ts` — mounts at `/api/interviews` (separate from the existing job-scoped `/api/jobs/:jobId/interviews` CRUD); validates `from`/`to` as parseable dates (400 on bad input), maps flat DB rows into nested `{ ...interview, job: { id, company, role, link } }` objects
- **Registered** before the job-scoped routes in `server.ts`
- **10 new tests** covering: empty result, enriched shape, ascending order, `?from` filter, `?to` filter, `?from+?to` range, invalid `from` (400), invalid `to` (400), user isolation (other users' interviews excluded), and unauthenticated access (401)

## Test plan

- [x] `cd backend && npx vitest run routes/interviews.spec.ts` — all 66 tests pass
- [x] `npm run tsc && npm run lint` — no errors
- [x] Manual: `GET /api/interviews` returns all interviews with nested `job` object
- [x] Manual: `GET /api/interviews?from=2026-04-08T00:00:00&to=2026-04-21T23:59:59` returns only interviews in the next two weeks

🤖 Generated with [Claude Code](https://claude.ai/claude-code)