### PR TITLE
feat(frontend): add Interviews page with cross-job interview search

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import type { User } from "./types";
 import LoginPage from "./components/LoginPage";
 import AppShell from "./components/AppShell";
 import JobManagementPage from "./components/JobManagementPage";
+import InterviewsPage from "./components/InterviewsPage";
 import StatsPage from "./components/StatsPage";
 
 export default function App() {
@@ -78,6 +79,7 @@ export default function App() {
 						<Route path="/" element={<Navigate to="/jobs" replace />} />
 						<Route path="/jobs" element={<JobManagementPage />} />
 						<Route path="/jobs/:jobId" element={<JobManagementPage />} />
+						<Route path="/interviews" element={<InterviewsPage />} />
 						<Route path="/stats" element={<StatsPage />} />
 						<Route path="*" element={<Navigate to="/jobs" replace />} />
 					</Route>

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -411,7 +411,12 @@ describe("api", () => {
 				interview_interviewers: null,
 				interview_vibe: null,
 				interview_notes: null,
-				job: { id: 10, company: "Acme", role: "Engineer", link: "https://acme.com" },
+				job: {
+					id: 10,
+					company: "Acme",
+					role: "Engineer",
+					link: "https://acme.com",
+				},
 			},
 		];
 
@@ -455,7 +460,9 @@ describe("api", () => {
 		});
 
 		it("throws when the response is not ok", async () => {
-			mockFetch.mockResolvedValue(makeResponse({ error: "Unauthorized" }, false));
+			mockFetch.mockResolvedValue(
+				makeResponse({ error: "Unauthorized" }, false),
+			);
 			await expect(api.searchInterviews()).rejects.toThrow("API error 400");
 		});
 	});

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -401,6 +401,65 @@ describe("api", () => {
 		});
 	});
 
+	describe("searchInterviews", () => {
+		const MOCK_ENRICHED = [
+			{
+				id: 1,
+				job_id: 10,
+				interview_type: "phone_screen",
+				interview_dttm: "2026-03-15T14:00:00Z",
+				interview_interviewers: null,
+				interview_vibe: null,
+				interview_notes: null,
+				job: { id: 10, company: "Acme", role: "Engineer", link: "https://acme.com" },
+			},
+		];
+
+		it("GETs /api/interviews with no params when no dates provided", async () => {
+			mockFetch.mockResolvedValue(makeResponse(MOCK_ENRICHED));
+			const result = await api.searchInterviews();
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/interviews",
+				expect.objectContaining({
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+			expect(result).toEqual(MOCK_ENRICHED);
+		});
+
+		it("includes ?from param when from is provided", async () => {
+			mockFetch.mockResolvedValue(makeResponse(MOCK_ENRICHED));
+			await api.searchInterviews("2026-01-01");
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/interviews?from=2026-01-01",
+				expect.any(Object),
+			);
+		});
+
+		it("includes ?to param when to is provided", async () => {
+			mockFetch.mockResolvedValue(makeResponse(MOCK_ENRICHED));
+			await api.searchInterviews(undefined, "2026-12-31");
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/interviews?to=2026-12-31",
+				expect.any(Object),
+			);
+		});
+
+		it("includes both ?from and ?to params when both are provided", async () => {
+			mockFetch.mockResolvedValue(makeResponse(MOCK_ENRICHED));
+			await api.searchInterviews("2026-01-01", "2026-12-31");
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/interviews?from=2026-01-01&to=2026-12-31",
+				expect.any(Object),
+			);
+		});
+
+		it("throws when the response is not ok", async () => {
+			mockFetch.mockResolvedValue(makeResponse({ error: "Unauthorized" }, false));
+			await expect(api.searchInterviews()).rejects.toThrow("API error 400");
+		});
+	});
+
 	describe("getStats", () => {
 		const MOCK_STATS: StatsResponse = {
 			totalApplications: 5,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,7 @@ import type {
 	JobFormData,
 	User,
 	Interview,
+	EnrichedInterview,
 	InterviewFormData,
 	InterviewQuestion,
 	InterviewQuestionFormData,
@@ -55,6 +56,15 @@ export const api = {
 	// Stats
 	getStats: (window: StatsWindow) =>
 		request<StatsResponse>(`/stats?window=${window}`),
+
+	// Cross-job interview search
+	searchInterviews: (from?: string, to?: string) => {
+		const params = new URLSearchParams();
+		if (from) params.set("from", from);
+		if (to) params.set("to", to);
+		const qs = params.toString();
+		return request<EnrichedInterview[]>(`/interviews${qs ? `?${qs}` : ""}`);
+	},
 
 	// Interviews
 	getInterviews: (jobId: number) =>

--- a/frontend/src/components/AppShell.spec.tsx
+++ b/frontend/src/components/AppShell.spec.tsx
@@ -49,6 +49,11 @@ describe("AppShell", () => {
 		expect(screen.getByRole("button", { name: "Board" })).toBeInTheDocument();
 	});
 
+	it("renders the Interviews nav button", () => {
+		renderAppShell();
+		expect(screen.getByRole("button", { name: "Interviews" })).toBeInTheDocument();
+	});
+
 	it("renders the Stats nav button", () => {
 		renderAppShell();
 		expect(screen.getByRole("button", { name: "Stats" })).toBeInTheDocument();
@@ -63,6 +68,12 @@ describe("AppShell", () => {
 		renderAppShell();
 		fireEvent.click(screen.getByRole("button", { name: "Board" }));
 		expect(mockNavigate).toHaveBeenCalledWith("/jobs");
+	});
+
+	it("navigates to /interviews when Interviews is clicked", () => {
+		renderAppShell();
+		fireEvent.click(screen.getByRole("button", { name: "Interviews" }));
+		expect(mockNavigate).toHaveBeenCalledWith("/interviews");
 	});
 
 	it("navigates to /stats when Stats is clicked", () => {

--- a/frontend/src/components/AppShell.spec.tsx
+++ b/frontend/src/components/AppShell.spec.tsx
@@ -51,7 +51,9 @@ describe("AppShell", () => {
 
 	it("renders the Interviews nav button", () => {
 		renderAppShell();
-		expect(screen.getByRole("button", { name: "Interviews" })).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Interviews" }),
+		).toBeInTheDocument();
 	});
 
 	it("renders the Stats nav button", () => {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -14,6 +14,7 @@ import {
 import AccountCircleOutlinedIcon from "@mui/icons-material/AccountCircleOutlined";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
+import CalendarMonthOutlinedIcon from "@mui/icons-material/CalendarMonthOutlined";
 import InsightsIcon from "@mui/icons-material/Insights";
 import ViewKanbanOutlinedIcon from "@mui/icons-material/ViewKanbanOutlined";
 import Tooltip from "@mui/material/Tooltip";
@@ -22,6 +23,7 @@ import type { User } from "../types";
 
 const NAV_ITEMS = [
 	{ path: "/jobs", icon: <ViewKanbanOutlinedIcon />, label: "Board" },
+	{ path: "/interviews", icon: <CalendarMonthOutlinedIcon />, label: "Interviews" },
 	{ path: "/stats", icon: <InsightsIcon />, label: "Stats" },
 ] as const;
 

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -23,7 +23,11 @@ import type { User } from "../types";
 
 const NAV_ITEMS = [
 	{ path: "/jobs", icon: <ViewKanbanOutlinedIcon />, label: "Board" },
-	{ path: "/interviews", icon: <CalendarMonthOutlinedIcon />, label: "Interviews" },
+	{
+		path: "/interviews",
+		icon: <CalendarMonthOutlinedIcon />,
+		label: "Interviews",
+	},
 	{ path: "/stats", icon: <InsightsIcon />, label: "Stats" },
 ] as const;
 

--- a/frontend/src/components/InterviewsPage.spec.tsx
+++ b/frontend/src/components/InterviewsPage.spec.tsx
@@ -1,0 +1,265 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import InterviewsPage from "./InterviewsPage";
+import { api } from "../api";
+import type { EnrichedInterview } from "../types";
+
+vi.mock("../api", () => ({
+	api: { searchInterviews: vi.fn() },
+}));
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-router-dom")>();
+	return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockSearchInterviews = vi.mocked(api.searchInterviews);
+
+function makeInterview(
+	overrides: Partial<EnrichedInterview> = {},
+): EnrichedInterview {
+	return {
+		id: 1,
+		job_id: 10,
+		interview_type: "phone_screen",
+		interview_dttm: "2026-03-15T14:00:00Z",
+		interview_interviewers: null,
+		interview_vibe: null,
+		interview_notes: null,
+		job: { id: 10, company: "Acme Corp", role: "Software Engineer", link: "https://example.com/job" },
+		...overrides,
+	};
+}
+
+function renderPage() {
+	return render(
+		<MemoryRouter>
+			<InterviewsPage />
+		</MemoryRouter>,
+	);
+}
+
+describe("InterviewsPage", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("shows a loading spinner while fetching", () => {
+		mockSearchInterviews.mockReturnValue(new Promise(() => {}));
+		renderPage();
+		expect(screen.getByRole("progressbar")).toBeInTheDocument();
+	});
+
+	it("hides the spinner after data loads", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+		);
+	});
+
+	it("shows an error message when the fetch fails", async () => {
+		mockSearchInterviews.mockRejectedValue(new Error("Network error"));
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByText(/Failed to load interviews/),
+			).toBeInTheDocument(),
+		);
+	});
+
+	it("shows generic empty state when no date filter is set and no results", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByText(/No interviews recorded yet/),
+			).toBeInTheDocument(),
+		);
+	});
+
+	it("shows filtered empty state when a date filter is set and no results", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+
+		fireEvent.change(screen.getByLabelText("From"), {
+			target: { value: "2026-01-01" },
+		});
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(/No interviews found in this date range/),
+			).toBeInTheDocument(),
+		);
+	});
+
+	it("calls searchInterviews with no args on initial render", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(mockSearchInterviews).toHaveBeenCalledWith(undefined, undefined),
+		);
+	});
+
+	it("re-fetches with from param when From date is entered", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() => expect(mockSearchInterviews).toHaveBeenCalledTimes(1));
+
+		fireEvent.change(screen.getByLabelText("From"), {
+			target: { value: "2026-01-01" },
+		});
+
+		await waitFor(() =>
+			expect(mockSearchInterviews).toHaveBeenLastCalledWith("2026-01-01", undefined),
+		);
+	});
+
+	it("re-fetches with to param when To date is entered", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() => expect(mockSearchInterviews).toHaveBeenCalledTimes(1));
+
+		fireEvent.change(screen.getByLabelText("To"), {
+			target: { value: "2026-12-31" },
+		});
+
+		await waitFor(() =>
+			expect(mockSearchInterviews).toHaveBeenLastCalledWith(undefined, "2026-12-31"),
+		);
+	});
+
+	it("renders interview type and date after data loads", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview()]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Phone Screen")).toBeInTheDocument(),
+		);
+	});
+
+	it("renders the job company and role as a link", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview()]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText(/Acme Corp.*Software Engineer/)).toBeInTheDocument(),
+		);
+	});
+
+	it("renders the vibe chip when present", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ interview_vibe: "casual" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Casual")).toBeInTheDocument(),
+		);
+	});
+
+	it("renders interviewers when present", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ interview_interviewers: "Jane Smith, Bob Lee" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Jane Smith, Bob Lee")).toBeInTheDocument(),
+		);
+	});
+
+	it("renders first line of notes when present", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ interview_notes: "First line\nSecond line" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("First line")).toBeInTheDocument(),
+		);
+		expect(screen.queryByText("Second line")).not.toBeInTheDocument();
+	});
+
+	it("navigates to job page when company/role link is clicked", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview()]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText(/Acme Corp.*Software Engineer/)).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByText(/Acme Corp.*Software Engineer/));
+		expect(mockNavigate).toHaveBeenCalledWith("/jobs/10");
+	});
+
+	it("groups interviews by month", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ id: 1, interview_dttm: "2026-03-15T14:00:00Z" }),
+			makeInterview({ id: 2, interview_dttm: "2026-04-02T10:00:00Z", job: { id: 10, company: "Beta Inc", role: "Staff SWE", link: "https://example.com" } }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText(/March 2026/i)).toBeInTheDocument(),
+		);
+		expect(screen.getByText(/April 2026/i)).toBeInTheDocument();
+	});
+
+	it("shows total count after data loads", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ id: 1 }),
+			makeInterview({ id: 2 }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("2 interviews")).toBeInTheDocument(),
+		);
+	});
+
+	it("shows singular 'interview' for count of 1", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview()]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("1 interview")).toBeInTheDocument(),
+		);
+	});
+
+	it("shows Clear button when from date is set", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+
+		expect(screen.queryByRole("button", { name: /Clear/ })).not.toBeInTheDocument();
+		fireEvent.change(screen.getByLabelText("From"), {
+			target: { value: "2026-01-01" },
+		});
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: /Clear/ })).toBeInTheDocument(),
+		);
+	});
+
+	it("clears both date filters when Clear is clicked", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+
+		fireEvent.change(screen.getByLabelText("From"), {
+			target: { value: "2026-01-01" },
+		});
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: /Clear/ })).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByRole("button", { name: /Clear/ }));
+
+		await waitFor(() =>
+			expect(mockSearchInterviews).toHaveBeenLastCalledWith(undefined, undefined),
+		);
+		expect(screen.queryByRole("button", { name: /Clear/ })).not.toBeInTheDocument();
+	});
+
+	it("renders onsite type icon for onsite interviews", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ interview_type: "onsite" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Onsite")).toBeInTheDocument(),
+		);
+	});
+});

--- a/frontend/src/components/InterviewsPage.spec.tsx
+++ b/frontend/src/components/InterviewsPage.spec.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import InterviewsPage from "./InterviewsPage";
+import InterviewsPage, { getDefaultDateRange } from "./InterviewsPage";
 import { api } from "../api";
 import type { EnrichedInterview } from "../types";
 
@@ -19,6 +19,12 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 const mockSearchInterviews = vi.mocked(api.searchInterviews);
 
+// Fix "today" to Wednesday Apr 8, 2026 for deterministic date math.
+// Next Sunday = Apr 12, Sunday after that = Apr 19.
+const FIXED_NOW = new Date("2026-04-08T12:00:00Z").getTime();
+const DEFAULT_FROM = "2026-04-08";
+const DEFAULT_TO = "2026-04-19";
+
 function makeInterview(
 	overrides: Partial<EnrichedInterview> = {},
 ): EnrichedInterview {
@@ -30,7 +36,12 @@ function makeInterview(
 		interview_interviewers: null,
 		interview_vibe: null,
 		interview_notes: null,
-		job: { id: 10, company: "Acme Corp", role: "Software Engineer", link: "https://example.com/job" },
+		job: {
+			id: 10,
+			company: "Acme Corp",
+			role: "Software Engineer",
+			link: "https://example.com/job",
+		},
 		...overrides,
 	};
 }
@@ -43,8 +54,46 @@ function renderPage() {
 	);
 }
 
+describe("getDefaultDateRange", () => {
+	beforeEach(() => vi.useFakeTimers({ toFake: ["Date"] }));
+	afterEach(() => vi.useRealTimers());
+
+	it("returns today as 'from' on a Wednesday", () => {
+		vi.setSystemTime(FIXED_NOW);
+		const { from } = getDefaultDateRange();
+		expect(from).toBe(DEFAULT_FROM);
+	});
+
+	it("returns the Sunday after next Sunday as 'to' on a Wednesday", () => {
+		vi.setSystemTime(FIXED_NOW);
+		const { to } = getDefaultDateRange();
+		expect(to).toBe(DEFAULT_TO); // next Sun Apr 12, then +7 = Apr 19
+	});
+
+	it("adds a full 14 days when today is Sunday", () => {
+		// Apr 12, 2026 is a Sunday
+		vi.setSystemTime(new Date("2026-04-12T12:00:00Z").getTime());
+		const { from, to } = getDefaultDateRange();
+		expect(from).toBe("2026-04-12");
+		expect(to).toBe("2026-04-26"); // +7 = Apr 19, +7 = Apr 26
+	});
+
+	it("includes only tomorrow through 8 days when today is Saturday", () => {
+		// Apr 11, 2026 is a Saturday
+		vi.setSystemTime(new Date("2026-04-11T12:00:00Z").getTime());
+		const { from, to } = getDefaultDateRange();
+		expect(from).toBe("2026-04-11");
+		expect(to).toBe("2026-04-19"); // next Sun Apr 12, +7 = Apr 19
+	});
+});
+
 describe("InterviewsPage", () => {
-	beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => {
+		vi.useFakeTimers({ toFake: ["Date"] });
+		vi.setSystemTime(FIXED_NOW);
+		vi.clearAllMocks();
+	});
+	afterEach(() => vi.useRealTimers());
 
 	it("shows a loading spinner while fetching", () => {
 		mockSearchInterviews.mockReturnValue(new Promise(() => {}));
@@ -64,26 +113,24 @@ describe("InterviewsPage", () => {
 		mockSearchInterviews.mockRejectedValue(new Error("Network error"));
 		renderPage();
 		await waitFor(() =>
-			expect(
-				screen.getByText(/Failed to load interviews/),
-			).toBeInTheDocument(),
+			expect(screen.getByText(/Failed to load interviews/)).toBeInTheDocument(),
 		);
 	});
 
-	it("shows generic empty state when no date filter is set and no results", async () => {
+	it("shows 'No upcoming interviews' empty state with default filters and no results", async () => {
 		mockSearchInterviews.mockResolvedValue([]);
 		renderPage();
 		await waitFor(() =>
-			expect(
-				screen.getByText(/No interviews recorded yet/),
-			).toBeInTheDocument(),
+			expect(screen.getByText(/No upcoming interviews/)).toBeInTheDocument(),
 		);
 	});
 
-	it("shows filtered empty state when a date filter is set and no results", async () => {
+	it("shows 'No interviews found in this date range' when filters differ from defaults", async () => {
 		mockSearchInterviews.mockResolvedValue([]);
 		renderPage();
-		await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+		await waitFor(() =>
+			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+		);
 
 		fireEvent.change(screen.getByLabelText("From"), {
 			target: { value: "2026-01-01" },
@@ -96,15 +143,32 @@ describe("InterviewsPage", () => {
 		);
 	});
 
-	it("calls searchInterviews with no args on initial render", async () => {
+	it("calls searchInterviews with the default date range on initial render", async () => {
 		mockSearchInterviews.mockResolvedValue([]);
 		renderPage();
 		await waitFor(() =>
-			expect(mockSearchInterviews).toHaveBeenCalledWith(undefined, undefined),
+			expect(mockSearchInterviews).toHaveBeenCalledWith(
+				DEFAULT_FROM,
+				DEFAULT_TO,
+			),
 		);
 	});
 
-	it("re-fetches with from param when From date is entered", async () => {
+	it("pre-populates From and To inputs with default values", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+		);
+		expect(screen.getByLabelText<HTMLInputElement>("From").value).toBe(
+			DEFAULT_FROM,
+		);
+		expect(screen.getByLabelText<HTMLInputElement>("To").value).toBe(
+			DEFAULT_TO,
+		);
+	});
+
+	it("re-fetches with new from param when From date is changed", async () => {
 		mockSearchInterviews.mockResolvedValue([]);
 		renderPage();
 		await waitFor(() => expect(mockSearchInterviews).toHaveBeenCalledTimes(1));
@@ -114,11 +178,14 @@ describe("InterviewsPage", () => {
 		});
 
 		await waitFor(() =>
-			expect(mockSearchInterviews).toHaveBeenLastCalledWith("2026-01-01", undefined),
+			expect(mockSearchInterviews).toHaveBeenLastCalledWith(
+				"2026-01-01",
+				DEFAULT_TO,
+			),
 		);
 	});
 
-	it("re-fetches with to param when To date is entered", async () => {
+	it("re-fetches with new to param when To date is changed", async () => {
 		mockSearchInterviews.mockResolvedValue([]);
 		renderPage();
 		await waitFor(() => expect(mockSearchInterviews).toHaveBeenCalledTimes(1));
@@ -128,7 +195,10 @@ describe("InterviewsPage", () => {
 		});
 
 		await waitFor(() =>
-			expect(mockSearchInterviews).toHaveBeenLastCalledWith(undefined, "2026-12-31"),
+			expect(mockSearchInterviews).toHaveBeenLastCalledWith(
+				DEFAULT_FROM,
+				"2026-12-31",
+			),
 		);
 	});
 
@@ -144,7 +214,9 @@ describe("InterviewsPage", () => {
 		mockSearchInterviews.mockResolvedValue([makeInterview()]);
 		renderPage();
 		await waitFor(() =>
-			expect(screen.getByText(/Acme Corp.*Software Engineer/)).toBeInTheDocument(),
+			expect(
+				screen.getByText(/Acme Corp.*Software Engineer/),
+			).toBeInTheDocument(),
 		);
 	});
 
@@ -153,9 +225,7 @@ describe("InterviewsPage", () => {
 			makeInterview({ interview_vibe: "casual" }),
 		]);
 		renderPage();
-		await waitFor(() =>
-			expect(screen.getByText("Casual")).toBeInTheDocument(),
-		);
+		await waitFor(() => expect(screen.getByText("Casual")).toBeInTheDocument());
 	});
 
 	it("renders interviewers when present", async () => {
@@ -183,7 +253,9 @@ describe("InterviewsPage", () => {
 		mockSearchInterviews.mockResolvedValue([makeInterview()]);
 		renderPage();
 		await waitFor(() =>
-			expect(screen.getByText(/Acme Corp.*Software Engineer/)).toBeInTheDocument(),
+			expect(
+				screen.getByText(/Acme Corp.*Software Engineer/),
+			).toBeInTheDocument(),
 		);
 		fireEvent.click(screen.getByText(/Acme Corp.*Software Engineer/));
 		expect(mockNavigate).toHaveBeenCalledWith("/jobs/10");
@@ -192,7 +264,16 @@ describe("InterviewsPage", () => {
 	it("groups interviews by month", async () => {
 		mockSearchInterviews.mockResolvedValue([
 			makeInterview({ id: 1, interview_dttm: "2026-03-15T14:00:00Z" }),
-			makeInterview({ id: 2, interview_dttm: "2026-04-02T10:00:00Z", job: { id: 10, company: "Beta Inc", role: "Staff SWE", link: "https://example.com" } }),
+			makeInterview({
+				id: 2,
+				interview_dttm: "2026-04-02T10:00:00Z",
+				job: {
+					id: 10,
+					company: "Beta Inc",
+					role: "Staff SWE",
+					link: "https://example.com",
+				},
+			}),
 		]);
 		renderPage();
 		await waitFor(() =>
@@ -220,46 +301,63 @@ describe("InterviewsPage", () => {
 		);
 	});
 
-	it("shows Clear button when from date is set", async () => {
+	it("does not show Reset button when filters match defaults", async () => {
 		mockSearchInterviews.mockResolvedValue([]);
 		renderPage();
-		await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+		await waitFor(() =>
+			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+		);
+		expect(
+			screen.queryByRole("button", { name: /Reset/ }),
+		).not.toBeInTheDocument();
+	});
 
-		expect(screen.queryByRole("button", { name: /Clear/ })).not.toBeInTheDocument();
+	it("shows Reset button when From is changed from default", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+		);
+
 		fireEvent.change(screen.getByLabelText("From"), {
 			target: { value: "2026-01-01" },
 		});
 		await waitFor(() =>
-			expect(screen.getByRole("button", { name: /Clear/ })).toBeInTheDocument(),
+			expect(screen.getByRole("button", { name: /Reset/ })).toBeInTheDocument(),
 		);
 	});
 
-	it("clears both date filters when Clear is clicked", async () => {
+	it("resets both date filters to defaults when Reset is clicked", async () => {
 		mockSearchInterviews.mockResolvedValue([]);
 		renderPage();
-		await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+		await waitFor(() =>
+			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+		);
 
 		fireEvent.change(screen.getByLabelText("From"), {
 			target: { value: "2026-01-01" },
 		});
 		await waitFor(() =>
-			expect(screen.getByRole("button", { name: /Clear/ })).toBeInTheDocument(),
+			expect(screen.getByRole("button", { name: /Reset/ })).toBeInTheDocument(),
 		);
-		fireEvent.click(screen.getByRole("button", { name: /Clear/ }));
+		fireEvent.click(screen.getByRole("button", { name: /Reset/ }));
 
 		await waitFor(() =>
-			expect(mockSearchInterviews).toHaveBeenLastCalledWith(undefined, undefined),
+			expect(mockSearchInterviews).toHaveBeenLastCalledWith(
+				DEFAULT_FROM,
+				DEFAULT_TO,
+			),
 		);
-		expect(screen.queryByRole("button", { name: /Clear/ })).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /Reset/ }),
+		).not.toBeInTheDocument();
 	});
 
-	it("renders onsite type icon for onsite interviews", async () => {
+	it("renders onsite type label for onsite interviews", async () => {
 		mockSearchInterviews.mockResolvedValue([
 			makeInterview({ interview_type: "onsite" }),
 		]);
 		renderPage();
-		await waitFor(() =>
-			expect(screen.getByText("Onsite")).toBeInTheDocument(),
-		);
+		await waitFor(() => expect(screen.getByText("Onsite")).toBeInTheDocument());
 	});
 });

--- a/frontend/src/components/InterviewsPage.tsx
+++ b/frontend/src/components/InterviewsPage.tsx
@@ -44,6 +44,26 @@ function formatDttm(dttm: string): string {
 	});
 }
 
+/**
+ * Returns {from, to} strings (YYYY-MM-DD) covering today through the Sunday
+ * after next Sunday — i.e. "this week and next week".
+ */
+export function getDefaultDateRange(): { from: string; to: string } {
+	const today = new Date();
+	today.setHours(0, 0, 0, 0);
+
+	// Days until the next Sunday (if today is Sunday, that's 7 days away)
+	const daysToNextSunday = today.getDay() === 0 ? 7 : 7 - today.getDay();
+	const nextSunday = new Date(today);
+	nextSunday.setDate(today.getDate() + daysToNextSunday);
+
+	const sundayAfterNext = new Date(nextSunday);
+	sundayAfterNext.setDate(nextSunday.getDate() + 7);
+
+	const fmt = (d: Date) => d.toISOString().slice(0, 10);
+	return { from: fmt(today), to: fmt(sundayAfterNext) };
+}
+
 /** Group interviews by calendar month, returning entries in order. */
 function groupByMonth(
 	interviews: EnrichedInterview[],
@@ -65,8 +85,9 @@ export default function InterviewsPage() {
 	const [interviews, setInterviews] = useState<EnrichedInterview[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState(false);
-	const [from, setFrom] = useState("");
-	const [to, setTo] = useState("");
+	const defaults = getDefaultDateRange();
+	const [from, setFrom] = useState(defaults.from);
+	const [to, setTo] = useState(defaults.to);
 
 	useEffect(() => {
 		setLoading(true);
@@ -93,7 +114,7 @@ export default function InterviewsPage() {
 				}}
 			>
 				<Typography variant="h5" fontWeight={700} sx={{ flex: 1 }}>
-					Interviews
+					Upcoming Interviews
 				</Typography>
 				<Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
 					<TextField
@@ -114,16 +135,16 @@ export default function InterviewsPage() {
 						slotProps={{ inputLabel: { shrink: true } }}
 						sx={{ width: 160 }}
 					/>
-					{(from || to) && (
+					{(from !== defaults.from || to !== defaults.to) && (
 						<Button
 							size="small"
 							variant="text"
 							onClick={() => {
-								setFrom("");
-								setTo("");
+								setFrom(defaults.from);
+								setTo(defaults.to);
 							}}
 						>
-							Clear
+							Reset
 						</Button>
 					)}
 				</Box>
@@ -145,9 +166,9 @@ export default function InterviewsPage() {
 					color="text.disabled"
 					sx={{ textAlign: "center", mt: 10 }}
 				>
-					{from || to
+					{from !== defaults.from || to !== defaults.to
 						? "No interviews found in this date range."
-						: "No interviews recorded yet."}
+						: "No upcoming interviews."}
 				</Typography>
 			) : (
 				grouped.map(({ month, items }) => (
@@ -205,6 +226,7 @@ function InterviewRow({
 				display: "flex",
 				gap: 1.5,
 				alignItems: "flex-start",
+				bgcolor: "background.paper",
 			}}
 		>
 			<TypeIcon
@@ -213,7 +235,12 @@ function InterviewRow({
 			<Box sx={{ flex: 1, minWidth: 0 }}>
 				{/* Top row: type + date + vibe */}
 				<Box
-					sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}
+					sx={{
+						display: "flex",
+						alignItems: "center",
+						gap: 1,
+						flexWrap: "wrap",
+					}}
 				>
 					<Typography variant="body2" fontWeight={600}>
 						{typeLabel}

--- a/frontend/src/components/InterviewsPage.tsx
+++ b/frontend/src/components/InterviewsPage.tsx
@@ -1,0 +1,284 @@
+import React, { useEffect, useState } from "react";
+import {
+	Box,
+	Button,
+	Chip,
+	CircularProgress,
+	Link,
+	TextField,
+	Tooltip,
+	Typography,
+} from "@mui/material";
+import BusinessIcon from "@mui/icons-material/Business";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import PhoneIcon from "@mui/icons-material/Phone";
+import { useNavigate } from "react-router-dom";
+import { api } from "../api";
+import type { EnrichedInterview, InterviewType, InterviewVibe } from "../types";
+
+const INTERVIEW_TYPE_LABELS: Record<InterviewType, string> = {
+	phone_screen: "Phone Screen",
+	onsite: "Onsite",
+};
+
+const VIBE_CHIP_SX: Record<InterviewVibe, object> = {
+	casual: { bgcolor: "#e3f2fd", color: "#1565c0" },
+	intense: { bgcolor: "#fff3e0", color: "#e65100" },
+};
+
+const VIBE_LABELS: Record<InterviewVibe, string> = {
+	casual: "Casual",
+	intense: "Intense",
+};
+
+function formatDttm(dttm: string): string {
+	const d = new Date(dttm);
+	if (isNaN(d.getTime())) return dttm;
+	return d.toLocaleString("en-US", {
+		weekday: "short",
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
+}
+
+/** Group interviews by calendar month, returning entries in order. */
+function groupByMonth(
+	interviews: EnrichedInterview[],
+): { month: string; items: EnrichedInterview[] }[] {
+	const map = new Map<string, EnrichedInterview[]>();
+	for (const iv of interviews) {
+		const d = new Date(iv.interview_dttm);
+		const key = isNaN(d.getTime())
+			? "Unknown"
+			: d.toLocaleString("en-US", { month: "long", year: "numeric" });
+		if (!map.has(key)) map.set(key, []);
+		map.get(key)!.push(iv);
+	}
+	return Array.from(map.entries()).map(([month, items]) => ({ month, items }));
+}
+
+export default function InterviewsPage() {
+	const navigate = useNavigate();
+	const [interviews, setInterviews] = useState<EnrichedInterview[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(false);
+	const [from, setFrom] = useState("");
+	const [to, setTo] = useState("");
+
+	useEffect(() => {
+		setLoading(true);
+		setError(false);
+		api
+			.searchInterviews(from || undefined, to || undefined)
+			.then(setInterviews)
+			.catch(() => setError(true))
+			.finally(() => setLoading(false));
+	}, [from, to]);
+
+	const grouped = groupByMonth(interviews);
+
+	return (
+		<Box sx={{ maxWidth: 860, mx: "auto", px: 3, py: 4 }}>
+			{/* Header */}
+			<Box
+				sx={{
+					display: "flex",
+					alignItems: "center",
+					flexWrap: "wrap",
+					gap: 2,
+					mb: 3,
+				}}
+			>
+				<Typography variant="h5" fontWeight={700} sx={{ flex: 1 }}>
+					Interviews
+				</Typography>
+				<Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
+					<TextField
+						label="From"
+						type="date"
+						value={from}
+						onChange={(e) => setFrom(e.target.value)}
+						size="small"
+						slotProps={{ inputLabel: { shrink: true } }}
+						sx={{ width: 160 }}
+					/>
+					<TextField
+						label="To"
+						type="date"
+						value={to}
+						onChange={(e) => setTo(e.target.value)}
+						size="small"
+						slotProps={{ inputLabel: { shrink: true } }}
+						sx={{ width: 160 }}
+					/>
+					{(from || to) && (
+						<Button
+							size="small"
+							variant="text"
+							onClick={() => {
+								setFrom("");
+								setTo("");
+							}}
+						>
+							Clear
+						</Button>
+					)}
+				</Box>
+			</Box>
+
+			{error && (
+				<Typography color="error" sx={{ mb: 2 }}>
+					Failed to load interviews. Please try again.
+				</Typography>
+			)}
+
+			{loading ? (
+				<Box sx={{ display: "flex", justifyContent: "center", mt: 10 }}>
+					<CircularProgress />
+				</Box>
+			) : interviews.length === 0 ? (
+				<Typography
+					variant="body2"
+					color="text.disabled"
+					sx={{ textAlign: "center", mt: 10 }}
+				>
+					{from || to
+						? "No interviews found in this date range."
+						: "No interviews recorded yet."}
+				</Typography>
+			) : (
+				grouped.map(({ month, items }) => (
+					<Box key={month} sx={{ mb: 3 }}>
+						<Typography
+							variant="overline"
+							color="text.secondary"
+							sx={{ display: "block", mb: 1 }}
+						>
+							{month}
+						</Typography>
+						{items.map((iv) => (
+							<InterviewRow
+								key={iv.id}
+								interview={iv}
+								onJobClick={() => navigate(`/jobs/${iv.job.id}`)}
+							/>
+						))}
+					</Box>
+				))
+			)}
+
+			{!loading && !error && interviews.length > 0 && (
+				<Typography
+					variant="caption"
+					color="text.disabled"
+					sx={{ display: "block", textAlign: "right", mt: 1 }}
+				>
+					{interviews.length} interview{interviews.length !== 1 ? "s" : ""}
+				</Typography>
+			)}
+		</Box>
+	);
+}
+
+function InterviewRow({
+	interview,
+	onJobClick,
+}: {
+	interview: EnrichedInterview;
+	onJobClick: () => void;
+}) {
+	const TypeIcon =
+		interview.interview_type === "phone_screen" ? PhoneIcon : BusinessIcon;
+	const typeLabel = INTERVIEW_TYPE_LABELS[interview.interview_type];
+
+	return (
+		<Box
+			sx={{
+				border: "1px solid",
+				borderColor: "divider",
+				borderRadius: 1,
+				p: 1.5,
+				mb: 1,
+				display: "flex",
+				gap: 1.5,
+				alignItems: "flex-start",
+			}}
+		>
+			<TypeIcon
+				sx={{ fontSize: 18, color: "text.secondary", mt: 0.25, flexShrink: 0 }}
+			/>
+			<Box sx={{ flex: 1, minWidth: 0 }}>
+				{/* Top row: type + date + vibe */}
+				<Box
+					sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}
+				>
+					<Typography variant="body2" fontWeight={600}>
+						{typeLabel}
+					</Typography>
+					<Typography variant="body2" color="text.secondary">
+						&middot; {formatDttm(interview.interview_dttm)}
+					</Typography>
+					{interview.interview_vibe && (
+						<Chip
+							label={VIBE_LABELS[interview.interview_vibe]}
+							size="small"
+							sx={VIBE_CHIP_SX[interview.interview_vibe]}
+						/>
+					)}
+				</Box>
+
+				{/* Job link */}
+				<Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.25 }}>
+					<Link
+						component="button"
+						variant="caption"
+						underline="hover"
+						onClick={onJobClick}
+						sx={{ fontWeight: 500 }}
+					>
+						{interview.job.company} &middot; {interview.job.role}
+					</Link>
+					<Tooltip title="Open job posting">
+						<Link
+							href={interview.job.link}
+							target="_blank"
+							rel="noopener noreferrer"
+							sx={{ display: "flex", color: "text.disabled" }}
+							aria-label="Open job posting"
+						>
+							<OpenInNewIcon sx={{ fontSize: 12 }} />
+						</Link>
+					</Tooltip>
+				</Box>
+
+				{interview.interview_interviewers && (
+					<Typography
+						variant="caption"
+						color="text.secondary"
+						sx={{ display: "block", mt: 0.25 }}
+					>
+						{interview.interview_interviewers}
+					</Typography>
+				)}
+				{interview.interview_notes && (
+					<Typography
+						variant="caption"
+						color="text.secondary"
+						sx={{
+							display: "block",
+							mt: 0.25,
+							overflow: "hidden",
+							textOverflow: "ellipsis",
+							whiteSpace: "nowrap",
+						}}
+					>
+						{interview.interview_notes.split("\n")[0]}
+					</Typography>
+				)}
+			</Box>
+		</Box>
+	);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -67,6 +67,15 @@ export interface Interview {
 
 export type InterviewFormData = Omit<Interview, "id" | "job_id">;
 
+export interface EnrichedInterview extends Interview {
+	job: {
+		id: number;
+		company: string;
+		role: string;
+		link: string;
+	};
+}
+
 export type QuestionType =
 	| "behavioral"
 	| "technical"


### PR DESCRIPTION
## Summary

Adds a dedicated `/interviews` page that surfaces all interviews across all jobs using the new `GET /api/interviews` endpoint. Includes date range filtering, month grouping, and job-link navigation. Also fixes two polish issues: card backgrounds are now white (matching other cards) and the default view shows "this week and next week" rather than an unfiltered list.

## Details

- New `EnrichedInterview` type (`Interview` + nested `job: { id, company, role, link }` field)
- `api.searchInterviews(from?, to?)` wrapping `GET /api/interviews`
- `InterviewsPage` component with:
  - From/To date pickers; re-fetches live on change
  - Default range: today → Sunday after next Sunday ("this week and next week")
  - Reset button restores defaults when filters are changed
  - Interviews grouped by calendar month, sorted ascending by date
  - Each card: type icon, type label, datetime, vibe chip, interviewers, notes first-line preview
  - Company · Role link navigates to `/jobs/:id`; external icon opens job posting in new tab
  - Loading spinner, error state, "No upcoming interviews." / "No interviews found in this date range." empty states
  - `bgcolor: "background.paper"` on cards so they're white against the `#e8ecf3` page background
- Interviews nav item (calendar icon) added to AppShell rail between Board and Stats
- `/interviews` route wired in `App.tsx`
- TS fix: use `.slice(0, 10)` instead of `.split("T")[0]` to avoid `string | undefined` type error

## Test plan

- [ ] Navigate to Interviews page — default date range is pre-populated (today → ~2 weeks out)
- [ ] Interview cards appear white against the gray page background
- [ ] Changing From/To dates re-fetches; Reset restores defaults
- [ ] Clicking a company/role link opens that job's dialog
- [ ] External link icon opens the job posting URL in a new tab
- [ ] Empty state shows correctly when no interviews exist in the range

🤖 Generated with [Claude Code](https://claude.ai/claude-code)