### PR TITLE
Load more in interviews page tweaks

### DIFF
--- a/LOAD_MORE_DESIGN.md
+++ b/LOAD_MORE_DESIGN.md
@@ -1,0 +1,115 @@
+# Load More — Engineering Design
+
+## Context
+
+The Interviews page (`/interviews`) shows all interviews in the user's selected date range in a single request. For users with many scheduled interviews, or who want to browse beyond their default "this week and next week" window, a **Load More** pattern makes exploration natural without requiring manual date edits.
+
+---
+
+## API Design
+
+### Extend `GET /api/interviews`
+
+The existing endpoint already supports `?from` and `?to` date range params. Two new **cursor pagination** params are added:
+
+| Param   | Type            | Meaning                                                   |
+|---------|-----------------|-----------------------------------------------------------|
+| `after` | ISO 8601 string | Return interviews with `interview_dttm` **strictly after** this value |
+| `limit` | integer 1–50    | Cap the number of results returned. Defaults to 10.       |
+
+These are independent of `from`/`to`. Two call modes:
+
+| Mode         | Params used           | Semantics                              |
+|--------------|-----------------------|----------------------------------------|
+| Initial load | `from`, `to`          | Date-range query — unchanged behavior  |
+| Load More    | `after`, `limit`      | Cursor page — next N after last shown  |
+
+### Why `after` instead of reusing `from`
+
+`from` is an **inclusive** lower bound (`>=`). A cursor must be **exclusive** (`>`) so the last visible row isn't repeated. Changing `from`'s semantics would be a silent breaking change. A separate `after` param avoids any ambiguity.
+
+### Response shape
+
+Same flat `EnrichedInterview[]` as today — no wrapper object. The client detects "no more results" by checking `response.length < PAGE_SIZE`. If `response.length === 0`, there are definitively no more interviews.
+
+### Error responses
+
+| Condition                      | Status | Error message               |
+|-------------------------------|--------|-----------------------------|
+| `after` is not a valid date   | 400    | `"Invalid 'after' date"`    |
+| `limit` is not 1–50           | 400    | `"Invalid 'limit' value"`   |
+
+---
+
+## Backend Implementation
+
+### `backend/db/interviews.ts`
+
+New exported function alongside the existing `listEnrichedInterviews`:
+
+```typescript
+export function listEnrichedInterviewsAfter(
+  db: Database.Database,
+  userId: number,
+  after: string,   // exclusive lower bound on interview_dttm
+  limit: number,
+): EnrichedInterviewRow[]
+```
+
+SQL:
+```sql
+SELECT i.id, i.job_id, i.interview_type, i.interview_dttm,
+       i.interview_interviewers, i.interview_vibe, i.interview_notes,
+       j.company, j.role, j.link
+FROM interviews i
+JOIN jobs j ON j.id = i.job_id
+WHERE j.user_id = ? AND i.interview_dttm > ?
+ORDER BY i.interview_dttm ASC
+LIMIT ?
+```
+
+### `backend/routes/interviews.ts`
+
+`createInterviewSearchRouter`'s `GET /` handler branches on whether `after` is present:
+
+- If `after` is provided → validate, parse `limit` (default 10, max 50), call `listEnrichedInterviewsAfter`
+- Otherwise → existing `from`/`to` logic unchanged
+
+`PAGE_SIZE = 10` is defined as a constant at the top of the file.
+
+---
+
+## Frontend Implementation
+
+### `frontend/src/api.ts`
+
+New method `loadMoreInterviews(after, limit?)` separate from `searchInterviews`:
+
+```typescript
+loadMoreInterviews: (after: string, limit = 10) =>
+  request<EnrichedInterview[]>(
+    `/interviews?${new URLSearchParams({ after, limit: String(limit) })}`
+  ),
+```
+
+### `frontend/src/components/InterviewsPage.tsx`
+
+New state: `loadingMore`, `reachedEnd`, `snack` (Snackbar).
+
+**Load More button** appears at the bottom of the list when interviews exist and `reachedEnd` is false. While loading it shows a spinner. Once `reachedEnd` is true it shows disabled text "End of scheduled interviews."
+
+**Snackbar toasts:**
+- Success: `"Loaded N new interview(s)"`
+- No more: `"No more interviews scheduled"` (info severity)
+- Error: `"Failed to load more interviews"` (error severity)
+
+**Filter change resets** `reachedEnd` to false so Load More reappears for the new range.
+
+---
+
+## Out of Scope
+
+- Backward cursor (Load Previous)
+- Infinite scroll / intersection observer
+- Server-sent events or polling for new interviews
+- Persisting pagination state across page navigations

--- a/backend/db/interviews.ts
+++ b/backend/db/interviews.ts
@@ -76,6 +76,25 @@ export function listEnrichedInterviews(
 	return db.prepare(sql).all(...params) as EnrichedInterviewRow[];
 }
 
+export function listEnrichedInterviewsAfter(
+	db: Database.Database,
+	userId: number,
+	after: string,
+	limit: number,
+): EnrichedInterviewRow[] {
+	const sql = `
+		SELECT i.id, i.job_id, i.interview_type, i.interview_dttm,
+		       i.interview_interviewers, i.interview_vibe, i.interview_notes,
+		       j.company, j.role, j.link
+		FROM interviews i
+		JOIN jobs j ON j.id = i.job_id
+		WHERE j.user_id = ? AND i.interview_dttm > ?
+		ORDER BY i.interview_dttm ASC
+		LIMIT ?
+	`;
+	return db.prepare(sql).all(userId, after, limit) as EnrichedInterviewRow[];
+}
+
 export function jobBelongsToUser(
 	db: Database.Database,
 	jobId: number,

--- a/backend/routes/interviews.spec.ts
+++ b/backend/routes/interviews.spec.ts
@@ -744,3 +744,111 @@ describe("GET /api/interviews", () => {
 		expect(res.status).toBe(401);
 	});
 });
+
+describe("GET /api/interviews — cursor pagination (?after + ?limit)", () => {
+	it("returns interviews strictly after ?after", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({ ...BASE_INTERVIEW, interview_dttm: "2026-04-01T10:00" });
+		await req("post", `/api/jobs/${jobId}/interviews`).send({ ...BASE_INTERVIEW, interview_dttm: "2026-04-02T10:00" });
+		await req("post", `/api/jobs/${jobId}/interviews`).send({ ...BASE_INTERVIEW, interview_dttm: "2026-04-03T10:00" });
+
+		const res = await req("get", "/api/interviews?after=2026-04-01T10:00");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(2);
+		expect(res.body[0].interview_dttm).toBe("2026-04-02T10:00");
+		expect(res.body[1].interview_dttm).toBe("2026-04-03T10:00");
+	});
+
+	it("does not return the interview at exactly the cursor dttm", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({ ...BASE_INTERVIEW, interview_dttm: "2026-04-01T10:00" });
+
+		const res = await req("get", "/api/interviews?after=2026-04-01T10:00");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(0);
+	});
+
+	it("returns at most ?limit interviews", async () => {
+		const jobId = await createJob();
+		for (let i = 1; i <= 5; i++) {
+			await req("post", `/api/jobs/${jobId}/interviews`).send({
+				...BASE_INTERVIEW,
+				interview_dttm: `2026-04-0${i}T10:00`,
+			});
+		}
+
+		const res = await req("get", "/api/interviews?after=2026-01-01T00:00:00&limit=2");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(2);
+	});
+
+	it("uses the default page size (10) when ?limit is omitted", async () => {
+		const jobId = await createJob();
+		for (let i = 1; i <= 15; i++) {
+			const day = String(i).padStart(2, "0");
+			await req("post", `/api/jobs/${jobId}/interviews`).send({
+				...BASE_INTERVIEW,
+				interview_dttm: `2026-04-${day}T10:00`,
+			});
+		}
+
+		const res = await req("get", "/api/interviews?after=2026-01-01T00:00:00");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(10);
+	});
+
+	it("returns an empty array when no interviews exist after the cursor", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({ ...BASE_INTERVIEW, interview_dttm: "2026-04-01T10:00" });
+
+		const res = await req("get", "/api/interviews?after=2026-12-31T23:59:59");
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual([]);
+	});
+
+	it("returns 400 for an invalid ?after value", async () => {
+		const res = await req("get", "/api/interviews?after=not-a-date");
+		expect(res.status).toBe(400);
+		expect(res.body.error).toMatch(/after/);
+	});
+
+	it("returns 400 when ?limit is 0", async () => {
+		const res = await req("get", "/api/interviews?after=2026-04-01T00:00:00&limit=0");
+		expect(res.status).toBe(400);
+		expect(res.body.error).toMatch(/limit/);
+	});
+
+	it("returns 400 when ?limit exceeds 50", async () => {
+		const res = await req("get", "/api/interviews?after=2026-04-01T00:00:00&limit=51");
+		expect(res.status).toBe(400);
+		expect(res.body.error).toMatch(/limit/);
+	});
+
+	it("only returns interviews belonging to the authenticated user", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({ ...BASE_INTERVIEW, interview_dttm: "2026-04-10T10:00" });
+
+		// Insert an interview for a different user directly
+		testDb
+			.prepare("INSERT INTO jobs (user_id, company, role, link, status) VALUES (?, ?, ?, ?, ?)")
+			.run(2, "Other Corp", "PM", "https://other.example.com", "Not started");
+		const otherJobId = (testDb.prepare("SELECT last_insert_rowid() AS id").get() as { id: number }).id;
+		testDb
+			.prepare("INSERT INTO interviews (job_id, interview_type, interview_dttm) VALUES (?, ?, ?)")
+			.run(otherJobId, "phone_screen", "2026-04-15T10:00");
+
+		const res = await req("get", "/api/interviews?after=2026-01-01T00:00:00");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(1);
+		expect(res.body[0].job.company).toBe(BASE_JOB.company);
+	});
+
+	it("returns enriched interviews with a nested job object", async () => {
+		const jobId = await createJob();
+		await req("post", `/api/jobs/${jobId}/interviews`).send({ ...BASE_INTERVIEW, interview_dttm: "2026-04-10T10:00" });
+
+		const res = await req("get", "/api/interviews?after=2026-01-01T00:00:00");
+		expect(res.status).toBe(200);
+		expect(res.body[0].job).toMatchObject({ id: jobId, company: BASE_JOB.company });
+	});
+});

--- a/backend/routes/interviews.ts
+++ b/backend/routes/interviews.ts
@@ -4,33 +4,61 @@ import expressLib from "express";
 import * as InterviewsDb from "../db/interviews.js";
 import { validateInterview, validateInterviewQuestion } from "../validators.js";
 
-// GET /api/interviews — cross-job interview search with optional ?from and ?to filters
+const PAGE_SIZE = 10;
+
+function toEnrichedResponse(rows: InterviewsDb.EnrichedInterviewRow[]) {
+	return rows.map(({ company, role, link, ...interview }) => ({
+		...interview,
+		job: { id: interview.job_id, company, role, link },
+	}));
+}
+
+// GET /api/interviews — cross-job interview search
+//   Date-range mode:  ?from=<iso>&to=<iso>   (inclusive bounds, both optional)
+//   Cursor/page mode: ?after=<iso>&limit=<n>  (exclusive lower bound, limit 1–50)
 export function createInterviewSearchRouter(db: Database.Database) {
 	const router = expressLib.Router();
 
 	router.get("/", (req, res) => {
-		const { from, to } = req.query as { from?: string; to?: string };
+		const { from, to, after, limit } = req.query as {
+			from?: string;
+			to?: string;
+			after?: string;
+			limit?: string;
+		};
 
+		// Cursor pagination path
+		if (after !== undefined) {
+			if (isNaN(Date.parse(after))) {
+				return res.status(400).json({ error: "Invalid 'after' date" });
+			}
+			const parsedLimit = limit !== undefined ? parseInt(limit, 10) : PAGE_SIZE;
+			if (isNaN(parsedLimit) || parsedLimit < 1 || parsedLimit > 50) {
+				return res.status(400).json({ error: "Invalid 'limit' value" });
+			}
+			const rows = InterviewsDb.listEnrichedInterviewsAfter(
+				db,
+				req.session.userId!,
+				after,
+				parsedLimit,
+			);
+			return res.json(toEnrichedResponse(rows));
+		}
+
+		// Date-range path (existing behavior, unchanged)
 		if (from !== undefined && isNaN(Date.parse(from))) {
 			return res.status(400).json({ error: "Invalid 'from' date" });
 		}
 		if (to !== undefined && isNaN(Date.parse(to))) {
 			return res.status(400).json({ error: "Invalid 'to' date" });
 		}
-
 		const rows = InterviewsDb.listEnrichedInterviews(
 			db,
 			req.session.userId!,
 			from,
 			to,
 		);
-
-		return res.json(
-			rows.map(({ company, role, link, ...interview }) => ({
-				...interview,
-				job: { id: interview.job_id, company, role, link },
-			})),
-		);
+		return res.json(toEnrichedResponse(rows));
 	});
 
 	return router;

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -401,6 +401,54 @@ describe("api", () => {
 		});
 	});
 
+	describe("loadMoreInterviews", () => {
+		const MOCK_ENRICHED = [
+			{
+				id: 1,
+				job_id: 10,
+				interview_type: "phone_screen",
+				interview_dttm: "2026-04-20T10:00:00Z",
+				interview_interviewers: null,
+				interview_vibe: null,
+				interview_notes: null,
+				job: {
+					id: 10,
+					company: "Acme",
+					role: "Engineer",
+					link: "https://acme.com",
+				},
+			},
+		];
+
+		it("GETs /api/interviews?after=<dttm>&limit=10 by default", async () => {
+			mockFetch.mockResolvedValue(makeResponse(MOCK_ENRICHED));
+			const result = await api.loadMoreInterviews("2026-04-15T10:00:00Z");
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/interviews?after=2026-04-15T10%3A00%3A00Z&limit=10",
+				expect.any(Object),
+			);
+			expect(result).toEqual(MOCK_ENRICHED);
+		});
+
+		it("includes the specified limit when provided", async () => {
+			mockFetch.mockResolvedValue(makeResponse(MOCK_ENRICHED));
+			await api.loadMoreInterviews("2026-04-15T10:00:00Z", 5);
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/interviews?after=2026-04-15T10%3A00%3A00Z&limit=5",
+				expect.any(Object),
+			);
+		});
+
+		it("throws when the response is not ok", async () => {
+			mockFetch.mockResolvedValue(
+				makeResponse({ error: "Unauthorized" }, false),
+			);
+			await expect(
+				api.loadMoreInterviews("2026-04-15T10:00:00Z"),
+			).rejects.toThrow("API error 400");
+		});
+	});
+
 	describe("searchInterviews", () => {
 		const MOCK_ENRICHED = [
 			{

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -58,6 +58,10 @@ export const api = {
 		request<StatsResponse>(`/stats?window=${window}`),
 
 	// Cross-job interview search
+	loadMoreInterviews: (after: string, limit = 10) => {
+		const params = new URLSearchParams({ after, limit: String(limit) });
+		return request<EnrichedInterview[]>(`/interviews?${params.toString()}`);
+	},
 	searchInterviews: (from?: string, to?: string) => {
 		const params = new URLSearchParams();
 		if (from) params.set("from", from);

--- a/frontend/src/components/InterviewsPage.spec.tsx
+++ b/frontend/src/components/InterviewsPage.spec.tsx
@@ -7,7 +7,7 @@ import { api } from "../api";
 import type { EnrichedInterview } from "../types";
 
 vi.mock("../api", () => ({
-	api: { searchInterviews: vi.fn() },
+	api: { searchInterviews: vi.fn(), loadMoreInterviews: vi.fn() },
 }));
 
 const mockNavigate = vi.fn();
@@ -18,6 +18,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 });
 
 const mockSearchInterviews = vi.mocked(api.searchInterviews);
+const mockLoadMoreInterviews = vi.mocked(api.loadMoreInterviews);
 
 // Fix "today" to Wednesday Apr 8, 2026 for deterministic date math.
 // Next Sunday = Apr 12, Sunday after that = Apr 19.
@@ -359,5 +360,201 @@ describe("InterviewsPage", () => {
 		]);
 		renderPage();
 		await waitFor(() => expect(screen.getByText("Onsite")).toBeInTheDocument());
+	});
+
+	// --- Load More ---
+
+	it("shows Load More button when initial load returns results", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview()]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+	});
+
+	it("does not show Load More button when initial load is empty", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+		);
+		expect(
+			screen.queryByRole("button", { name: /Load More/ }),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows a spinner in place of Load More while loading more", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview()]);
+		mockLoadMoreInterviews.mockReturnValue(new Promise(() => {}));
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		expect(
+			screen.queryByRole("button", { name: /Load More/ }),
+		).not.toBeInTheDocument();
+		expect(screen.getByRole("progressbar")).toBeInTheDocument();
+	});
+
+	it("appends new interviews and shows success Snackbar on load more", async () => {
+		const first = makeInterview({
+			id: 1,
+			interview_dttm: "2026-04-10T10:00:00Z",
+		});
+		const second = makeInterview({
+			id: 2,
+			interview_dttm: "2026-04-20T10:00:00Z",
+			job: {
+				id: 11,
+				company: "Beta Inc",
+				role: "Staff SWE",
+				link: "https://beta.example.com",
+			},
+		});
+		mockSearchInterviews.mockResolvedValue([first]);
+		mockLoadMoreInterviews.mockResolvedValue([second]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		await waitFor(() =>
+			expect(screen.getByText("Beta Inc · Staff SWE")).toBeInTheDocument(),
+		);
+		expect(screen.getByText("Loaded 1 new interview")).toBeInTheDocument();
+	});
+
+	it("uses plural 'interviews' in Snackbar when loading more than one", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview({ id: 1 })]);
+		mockLoadMoreInterviews.mockResolvedValue([
+			makeInterview({ id: 2, interview_dttm: "2026-05-01T10:00:00Z" }),
+			makeInterview({ id: 3, interview_dttm: "2026-05-02T10:00:00Z" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		await waitFor(() =>
+			expect(screen.getByText("Loaded 2 new interviews")).toBeInTheDocument(),
+		);
+	});
+
+	it("shows 'End of scheduled interviews' and hides Load More when response is empty", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview()]);
+		mockLoadMoreInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		await waitFor(() =>
+			expect(
+				screen.getByText("End of scheduled interviews"),
+			).toBeInTheDocument(),
+		);
+		expect(
+			screen.queryByRole("button", { name: /Load More/ }),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows 'No more interviews scheduled' Snackbar when response is empty", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview()]);
+		mockLoadMoreInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		await waitFor(() =>
+			expect(
+				screen.getByText("No more interviews scheduled"),
+			).toBeInTheDocument(),
+		);
+	});
+
+	it("sets reachedEnd when load more returns fewer results than PAGE_SIZE", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview({ id: 1 })]);
+		// 3 results < PAGE_SIZE (10) → should reach end
+		mockLoadMoreInterviews.mockResolvedValue([
+			makeInterview({ id: 2, interview_dttm: "2026-05-01T10:00:00Z" }),
+			makeInterview({ id: 3, interview_dttm: "2026-05-02T10:00:00Z" }),
+			makeInterview({ id: 4, interview_dttm: "2026-05-03T10:00:00Z" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		await waitFor(() =>
+			expect(
+				screen.getByText("End of scheduled interviews"),
+			).toBeInTheDocument(),
+		);
+	});
+
+	it("passes the last interview's dttm as the after cursor", async () => {
+		const iv = makeInterview({ interview_dttm: "2026-04-15T14:30:00Z" });
+		mockSearchInterviews.mockResolvedValue([iv]);
+		mockLoadMoreInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		await waitFor(() =>
+			expect(mockLoadMoreInterviews).toHaveBeenCalledWith(
+				"2026-04-15T14:30:00Z",
+				10,
+			),
+		);
+	});
+
+	it("re-shows Load More after date filter resets reachedEnd", async () => {
+		mockSearchInterviews.mockResolvedValue([makeInterview()]);
+		mockLoadMoreInterviews.mockResolvedValue([]);
+		renderPage();
+		// Reach end
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		await waitFor(() =>
+			expect(
+				screen.getByText("End of scheduled interviews"),
+			).toBeInTheDocument(),
+		);
+		// Change filter → resets
+		mockSearchInterviews.mockResolvedValue([makeInterview({ id: 99 })]);
+		fireEvent.change(screen.getByLabelText("From"), {
+			target: { value: "2026-01-01" },
+		});
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		expect(
+			screen.queryByText("End of scheduled interviews"),
+		).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/components/InterviewsPage.spec.tsx
+++ b/frontend/src/components/InterviewsPage.spec.tsx
@@ -118,23 +118,29 @@ describe("InterviewsPage", () => {
 		);
 	});
 
-	it("shows 'No upcoming interviews' empty state with default filters and no results", async () => {
+	it("shows empty week buckets with 'No interviews this week' when default range has no results", async () => {
 		mockSearchInterviews.mockResolvedValue([]);
 		renderPage();
 		await waitFor(() =>
-			expect(screen.getByText(/No upcoming interviews/)).toBeInTheDocument(),
+			expect(screen.getByText("Remaining this week (0):")).toBeInTheDocument(),
 		);
+		expect(screen.getByText("Next week (0):")).toBeInTheDocument();
+		expect(screen.getAllByText("No interviews this week")).toHaveLength(2);
 	});
 
-	it("shows 'No interviews found in this date range' when filters differ from defaults", async () => {
+	it("shows 'No interviews found in this date range' when range excludes current and next week", async () => {
 		mockSearchInterviews.mockResolvedValue([]);
 		renderPage();
 		await waitFor(() =>
 			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
 		);
 
+		// Set range entirely in the past (before today)
 		fireEvent.change(screen.getByLabelText("From"), {
 			target: { value: "2026-01-01" },
+		});
+		fireEvent.change(screen.getByLabelText("To"), {
+			target: { value: "2026-01-31" },
 		});
 
 		await waitFor(() =>
@@ -262,25 +268,112 @@ describe("InterviewsPage", () => {
 		expect(mockNavigate).toHaveBeenCalledWith("/jobs/10");
 	});
 
-	it("groups interviews by month", async () => {
+	// FIXED_NOW = Wed Apr 8, 2026; DEFAULT_FROM = "2026-04-08"; DEFAULT_TO = "2026-04-19"
+	// This week: Apr 6 (Mon) – Apr 12 (Sun)  → "Remaining this week (n):"
+	// Next week: Apr 13 (Mon) – Apr 19 (Sun)  → "Next week (n):"
+	// Future:    Apr 20 (Mon)+                → "Future (n):"
+	// Past:      before Apr 8 midnight        → "Past interviews (n):"
+
+	it("groups interviews into 'Remaining this week' with count", async () => {
 		mockSearchInterviews.mockResolvedValue([
-			makeInterview({ id: 1, interview_dttm: "2026-03-15T14:00:00Z" }),
-			makeInterview({
-				id: 2,
-				interview_dttm: "2026-04-02T10:00:00Z",
-				job: {
-					id: 10,
-					company: "Beta Inc",
-					role: "Staff SWE",
-					link: "https://example.com",
-				},
-			}),
+			makeInterview({ id: 1, interview_dttm: "2026-04-09T10:00:00Z" }),
 		]);
 		renderPage();
 		await waitFor(() =>
-			expect(screen.getByText(/March 2026/i)).toBeInTheDocument(),
+			expect(screen.getByText("Remaining this week (1):")).toBeInTheDocument(),
 		);
-		expect(screen.getByText(/April 2026/i)).toBeInTheDocument();
+	});
+
+	it("groups interviews into 'Next week' with count", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ id: 1, interview_dttm: "2026-04-15T10:00:00Z" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Next week (1):")).toBeInTheDocument(),
+		);
+	});
+
+	it("groups interviews into 'Future' with count", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ id: 1, interview_dttm: "2026-04-22T10:00:00Z" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Future (1):")).toBeInTheDocument(),
+		);
+	});
+
+	it("groups interviews into 'Past interviews' with count", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ id: 1, interview_dttm: "2026-04-05T10:00:00Z" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Past interviews (1):")).toBeInTheDocument(),
+		);
+	});
+
+	it("shows multiple week buckets with correct counts", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ id: 1, interview_dttm: "2026-04-05T10:00:00Z" }), // past
+			makeInterview({ id: 2, interview_dttm: "2026-04-09T10:00:00Z" }), // this week
+			makeInterview({ id: 3, interview_dttm: "2026-04-15T10:00:00Z" }), // next week
+			makeInterview({ id: 4, interview_dttm: "2026-04-22T10:00:00Z" }), // future
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Past interviews (1):")).toBeInTheDocument(),
+		);
+		expect(screen.getByText("Remaining this week (1):")).toBeInTheDocument();
+		expect(screen.getByText("Next week (1):")).toBeInTheDocument();
+		expect(screen.getByText("Future (1):")).toBeInTheDocument();
+	});
+
+	it("always shows 'Remaining this week (0)' and 'No interviews this week' when in range with no interviews", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Remaining this week (0):")).toBeInTheDocument(),
+		);
+		expect(screen.getByText("Next week (0):")).toBeInTheDocument();
+		expect(screen.getAllByText("No interviews this week")).toHaveLength(2);
+	});
+
+	it("does not show 'Remaining this week' when date range excludes current week", async () => {
+		mockSearchInterviews.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+		);
+		// Set range entirely in the future beyond next week
+		fireEvent.change(screen.getByLabelText("From"), {
+			target: { value: "2026-04-20" },
+		});
+		fireEvent.change(screen.getByLabelText("To"), {
+			target: { value: "2026-05-31" },
+		});
+		await waitFor(() =>
+			expect(screen.queryByText(/Remaining this week/)).not.toBeInTheDocument(),
+		);
+		expect(screen.queryByText(/Next week/)).not.toBeInTheDocument();
+	});
+
+	it("applies dimmed style to past interview cards and not to upcoming ones", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ id: 1, interview_dttm: "2026-04-05T10:00:00Z" }), // past
+			makeInterview({ id: 2, interview_dttm: "2026-04-09T10:00:00Z" }), // this week
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText("Past interviews (1):")).toBeInTheDocument(),
+		);
+		const cards = document.querySelectorAll<HTMLElement>(
+			'[data-testid="interview-card"]',
+		);
+		expect(cards).toHaveLength(2);
+		expect(cards[0]).toHaveAttribute("data-dimmed", "true");
+		expect(cards[1]).toHaveAttribute("data-dimmed", "false");
 	});
 
 	it("shows total count after data loads", async () => {
@@ -431,6 +524,50 @@ describe("InterviewsPage", () => {
 		expect(screen.getByText("Loaded 1 new interview")).toBeInTheDocument();
 	});
 
+	it("advances the 'To' date picker to the last loaded interview's date", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ id: 1, interview_dttm: "2026-04-10T10:00:00Z" }),
+		]);
+		mockLoadMoreInterviews.mockResolvedValue([
+			makeInterview({ id: 2, interview_dttm: "2026-04-28T09:00:00Z" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		const toInput = screen.getByLabelText("To") as HTMLInputElement;
+		expect(toInput.value).toBe(DEFAULT_TO);
+
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		await waitFor(() => expect(toInput.value).toBe("2026-04-28"));
+	});
+
+	it("does not re-fetch when 'To' is advanced by Load More", async () => {
+		mockSearchInterviews.mockResolvedValue([
+			makeInterview({ id: 1, interview_dttm: "2026-04-10T10:00:00Z" }),
+		]);
+		mockLoadMoreInterviews.mockResolvedValue([
+			makeInterview({ id: 2, interview_dttm: "2026-04-28T09:00:00Z" }),
+		]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Load More/ }),
+			).toBeInTheDocument(),
+		);
+		const callsBefore = mockSearchInterviews.mock.calls.length;
+		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
+		await waitFor(() =>
+			expect((screen.getByLabelText("To") as HTMLInputElement).value).toBe(
+				"2026-04-28",
+			),
+		);
+		// searchInterviews must not have been called again
+		expect(mockSearchInterviews.mock.calls.length).toBe(callsBefore);
+	});
+
 	it("uses plural 'interviews' in Snackbar when loading more than one", async () => {
 		mockSearchInterviews.mockResolvedValue([makeInterview({ id: 1 })]);
 		mockLoadMoreInterviews.mockResolvedValue([
@@ -449,7 +586,7 @@ describe("InterviewsPage", () => {
 		);
 	});
 
-	it("shows 'End of scheduled interviews' and hides Load More when response is empty", async () => {
+	it("shows 'No more scheduled interviews' and hides Load More when response is empty", async () => {
 		mockSearchInterviews.mockResolvedValue([makeInterview()]);
 		mockLoadMoreInterviews.mockResolvedValue([]);
 		renderPage();
@@ -461,7 +598,7 @@ describe("InterviewsPage", () => {
 		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
 		await waitFor(() =>
 			expect(
-				screen.getByText("End of scheduled interviews"),
+				screen.getByText("No more scheduled interviews"),
 			).toBeInTheDocument(),
 		);
 		expect(
@@ -503,7 +640,7 @@ describe("InterviewsPage", () => {
 		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
 		await waitFor(() =>
 			expect(
-				screen.getByText("End of scheduled interviews"),
+				screen.getByText("No more scheduled interviews"),
 			).toBeInTheDocument(),
 		);
 	});
@@ -540,7 +677,7 @@ describe("InterviewsPage", () => {
 		fireEvent.click(screen.getByRole("button", { name: /Load More/ }));
 		await waitFor(() =>
 			expect(
-				screen.getByText("End of scheduled interviews"),
+				screen.getByText("No more scheduled interviews"),
 			).toBeInTheDocument(),
 		);
 		// Change filter → resets
@@ -554,7 +691,7 @@ describe("InterviewsPage", () => {
 			).toBeInTheDocument(),
 		);
 		expect(
-			screen.queryByText("End of scheduled interviews"),
+			screen.queryByText("No more scheduled interviews"),
 		).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/components/InterviewsPage.tsx
+++ b/frontend/src/components/InterviewsPage.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
+	Alert,
 	Box,
 	Button,
 	Chip,
 	CircularProgress,
 	Link,
+	Snackbar,
 	TextField,
 	Tooltip,
 	Typography,
@@ -15,6 +17,10 @@ import PhoneIcon from "@mui/icons-material/Phone";
 import { useNavigate } from "react-router-dom";
 import { api } from "../api";
 import type { EnrichedInterview, InterviewType, InterviewVibe } from "../types";
+
+type Severity = "success" | "info" | "warning" | "error";
+
+const PAGE_SIZE = 10;
 
 const INTERVIEW_TYPE_LABELS: Record<InterviewType, string> = {
 	phone_screen: "Phone Screen",
@@ -85,13 +91,27 @@ export default function InterviewsPage() {
 	const [interviews, setInterviews] = useState<EnrichedInterview[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState(false);
+	const [loadingMore, setLoadingMore] = useState(false);
+	const [reachedEnd, setReachedEnd] = useState(false);
+	const [snack, setSnack] = useState<{
+		open: boolean;
+		message: string;
+		severity: Severity;
+	}>({ open: false, message: "", severity: "success" });
 	const defaults = getDefaultDateRange();
 	const [from, setFrom] = useState(defaults.from);
 	const [to, setTo] = useState(defaults.to);
 
+	const notify = useCallback(
+		(message: string, severity: Severity = "success") =>
+			setSnack({ open: true, message, severity }),
+		[],
+	);
+
 	useEffect(() => {
 		setLoading(true);
 		setError(false);
+		setReachedEnd(false);
 		api
 			.searchInterviews(from || undefined, to || undefined)
 			.then(setInterviews)
@@ -99,108 +119,170 @@ export default function InterviewsPage() {
 			.finally(() => setLoading(false));
 	}, [from, to]);
 
+	const handleLoadMore = useCallback(async () => {
+		const last = interviews[interviews.length - 1];
+		if (!last) return;
+		const lastDttm = last.interview_dttm;
+		setLoadingMore(true);
+		try {
+			const newItems = await api.loadMoreInterviews(lastDttm, PAGE_SIZE);
+			if (newItems.length === 0) {
+				setReachedEnd(true);
+				notify("No more interviews scheduled", "info");
+			} else {
+				setInterviews((prev) => [...prev, ...newItems]);
+				if (newItems.length < PAGE_SIZE) setReachedEnd(true);
+				notify(
+					`Loaded ${newItems.length} new interview${newItems.length !== 1 ? "s" : ""}`,
+				);
+			}
+		} catch {
+			notify("Failed to load more interviews", "error");
+		} finally {
+			setLoadingMore(false);
+		}
+	}, [interviews, notify]);
+
 	const grouped = groupByMonth(interviews);
 
 	return (
-		<Box sx={{ maxWidth: 860, mx: "auto", px: 3, py: 4 }}>
-			{/* Header */}
-			<Box
-				sx={{
-					display: "flex",
-					alignItems: "center",
-					flexWrap: "wrap",
-					gap: 2,
-					mb: 3,
-				}}
-			>
-				<Typography variant="h5" fontWeight={700} sx={{ flex: 1 }}>
-					Upcoming Interviews
-				</Typography>
-				<Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
-					<TextField
-						label="From"
-						type="date"
-						value={from}
-						onChange={(e) => setFrom(e.target.value)}
-						size="small"
-						slotProps={{ inputLabel: { shrink: true } }}
-						sx={{ width: 160 }}
-					/>
-					<TextField
-						label="To"
-						type="date"
-						value={to}
-						onChange={(e) => setTo(e.target.value)}
-						size="small"
-						slotProps={{ inputLabel: { shrink: true } }}
-						sx={{ width: 160 }}
-					/>
-					{(from !== defaults.from || to !== defaults.to) && (
-						<Button
+		<>
+			<Box sx={{ maxWidth: 860, mx: "auto", px: 3, py: 4 }}>
+				{/* Header */}
+				<Box
+					sx={{
+						display: "flex",
+						alignItems: "center",
+						flexWrap: "wrap",
+						gap: 2,
+						mb: 3,
+					}}
+				>
+					<Typography variant="h5" fontWeight={700} sx={{ flex: 1 }}>
+						Upcoming Interviews
+					</Typography>
+					<Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
+						<TextField
+							label="From"
+							type="date"
+							value={from}
+							onChange={(e) => setFrom(e.target.value)}
 							size="small"
-							variant="text"
-							onClick={() => {
-								setFrom(defaults.from);
-								setTo(defaults.to);
-							}}
-						>
-							Reset
-						</Button>
-					)}
+							slotProps={{ inputLabel: { shrink: true } }}
+							sx={{ width: 160 }}
+						/>
+						<TextField
+							label="To"
+							type="date"
+							value={to}
+							onChange={(e) => setTo(e.target.value)}
+							size="small"
+							slotProps={{ inputLabel: { shrink: true } }}
+							sx={{ width: 160 }}
+						/>
+						{(from !== defaults.from || to !== defaults.to) && (
+							<Button
+								size="small"
+								variant="text"
+								onClick={() => {
+									setFrom(defaults.from);
+									setTo(defaults.to);
+								}}
+							>
+								Reset
+							</Button>
+						)}
+					</Box>
 				</Box>
+
+				{error && (
+					<Typography color="error" sx={{ mb: 2 }}>
+						Failed to load interviews. Please try again.
+					</Typography>
+				)}
+
+				{loading ? (
+					<Box sx={{ display: "flex", justifyContent: "center", mt: 10 }}>
+						<CircularProgress />
+					</Box>
+				) : interviews.length === 0 ? (
+					<Typography
+						variant="body2"
+						color="text.disabled"
+						sx={{ textAlign: "center", mt: 10 }}
+					>
+						{from !== defaults.from || to !== defaults.to
+							? "No interviews found in this date range."
+							: "No upcoming interviews."}
+					</Typography>
+				) : (
+					grouped.map(({ month, items }) => (
+						<Box key={month} sx={{ mb: 3 }}>
+							<Typography
+								variant="overline"
+								color="text.secondary"
+								sx={{ display: "block", mb: 1 }}
+							>
+								{month}
+							</Typography>
+							{items.map((iv) => (
+								<InterviewRow
+									key={iv.id}
+									interview={iv}
+									onJobClick={() => navigate(`/jobs/${iv.job.id}`)}
+								/>
+							))}
+						</Box>
+					))
+				)}
+
+				{!loading && !error && interviews.length > 0 && (
+					<Box
+						sx={{
+							mt: 2,
+							display: "flex",
+							flexDirection: "column",
+							alignItems: "center",
+							gap: 1.5,
+						}}
+					>
+						<Typography variant="caption" color="text.disabled">
+							{interviews.length} interview{interviews.length !== 1 ? "s" : ""}
+						</Typography>
+						{reachedEnd ? (
+							<Typography variant="body2" color="text.disabled">
+								End of scheduled interviews
+							</Typography>
+						) : loadingMore ? (
+							<CircularProgress size={24} />
+						) : (
+							<Button
+								variant="outlined"
+								size="small"
+								onClick={() => void handleLoadMore()}
+							>
+								Load More
+							</Button>
+						)}
+					</Box>
+				)}
 			</Box>
 
-			{error && (
-				<Typography color="error" sx={{ mb: 2 }}>
-					Failed to load interviews. Please try again.
-				</Typography>
-			)}
-
-			{loading ? (
-				<Box sx={{ display: "flex", justifyContent: "center", mt: 10 }}>
-					<CircularProgress />
-				</Box>
-			) : interviews.length === 0 ? (
-				<Typography
-					variant="body2"
-					color="text.disabled"
-					sx={{ textAlign: "center", mt: 10 }}
+			<Snackbar
+				open={snack.open}
+				autoHideDuration={3000}
+				onClose={() => setSnack((s) => ({ ...s, open: false }))}
+				anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+			>
+				<Alert
+					severity={snack.severity}
+					variant="filled"
+					sx={{ width: "100%" }}
 				>
-					{from !== defaults.from || to !== defaults.to
-						? "No interviews found in this date range."
-						: "No upcoming interviews."}
-				</Typography>
-			) : (
-				grouped.map(({ month, items }) => (
-					<Box key={month} sx={{ mb: 3 }}>
-						<Typography
-							variant="overline"
-							color="text.secondary"
-							sx={{ display: "block", mb: 1 }}
-						>
-							{month}
-						</Typography>
-						{items.map((iv) => (
-							<InterviewRow
-								key={iv.id}
-								interview={iv}
-								onJobClick={() => navigate(`/jobs/${iv.job.id}`)}
-							/>
-						))}
-					</Box>
-				))
-			)}
-
-			{!loading && !error && interviews.length > 0 && (
-				<Typography
-					variant="caption"
-					color="text.disabled"
-					sx={{ display: "block", textAlign: "right", mt: 1 }}
-				>
-					{interviews.length} interview{interviews.length !== 1 ? "s" : ""}
-				</Typography>
-			)}
-		</Box>
+					{snack.message}
+				</Alert>
+			</Snackbar>
+		</>
 	);
 }
 

--- a/frontend/src/components/InterviewsPage.tsx
+++ b/frontend/src/components/InterviewsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
 	Alert,
 	Box,
@@ -70,20 +70,89 @@ export function getDefaultDateRange(): { from: string; to: string } {
 	return { from: fmt(today), to: fmt(sundayAfterNext) };
 }
 
-/** Group interviews by calendar month, returning entries in order. */
-function groupByMonth(
+interface WeekBucket {
+	label: string;
+	items: EnrichedInterview[];
+	isPast: boolean;
+}
+
+/**
+ * Group interviews into week buckets.
+ * "Past" and "Future" buckets are only included when non-empty.
+ * "Remaining this week" and "Next week" are always included when the
+ * [from, to] date range overlaps with those periods, even if empty.
+ */
+export function groupByWeek(
 	interviews: EnrichedInterview[],
-): { month: string; items: EnrichedInterview[] }[] {
-	const map = new Map<string, EnrichedInterview[]>();
+	from: string,
+	to: string,
+): WeekBucket[] {
+	const today = new Date();
+	today.setHours(0, 0, 0, 0);
+
+	// Next Monday = start of next week
+	const daysToNextMonday = today.getDay() === 1 ? 7 : (8 - today.getDay()) % 7;
+	const nextMonday = new Date(today);
+	nextMonday.setDate(today.getDate() + daysToNextMonday);
+
+	// Monday after next = end of next week (exclusive)
+	const mondayAfterNext = new Date(nextMonday);
+	mondayAfterNext.setDate(nextMonday.getDate() + 7);
+
+	const past: EnrichedInterview[] = [];
+	const thisWeek: EnrichedInterview[] = [];
+	const nextWeek: EnrichedInterview[] = [];
+	const future: EnrichedInterview[] = [];
+
 	for (const iv of interviews) {
 		const d = new Date(iv.interview_dttm);
-		const key = isNaN(d.getTime())
-			? "Unknown"
-			: d.toLocaleString("en-US", { month: "long", year: "numeric" });
-		if (!map.has(key)) map.set(key, []);
-		map.get(key)!.push(iv);
+		if (isNaN(d.getTime()) || d < today) past.push(iv);
+		else if (d < nextMonday) thisWeek.push(iv);
+		else if (d < mondayAfterNext) nextWeek.push(iv);
+		else future.push(iv);
 	}
-	return Array.from(map.entries()).map(([month, items]) => ({ month, items }));
+
+	const todayStr = today.toISOString().slice(0, 10);
+	const nextMondayStr = nextMonday.toISOString().slice(0, 10);
+	const mondayAfterNextStr = mondayAfterNext.toISOString().slice(0, 10);
+
+	// Show "this week" / "next week" if the selected range overlaps each period
+	const showThisWeek =
+		(from === "" || from < nextMondayStr) && (to === "" || to >= todayStr);
+	const showNextWeek =
+		(from === "" || from < mondayAfterNextStr) &&
+		(to === "" || to >= nextMondayStr);
+
+	const result: WeekBucket[] = [];
+	if (past.length > 0) {
+		result.push({
+			label: `Past interviews (${past.length}):`,
+			items: past,
+			isPast: true,
+		});
+	}
+	if (showThisWeek) {
+		result.push({
+			label: `Remaining this week (${thisWeek.length}):`,
+			items: thisWeek,
+			isPast: false,
+		});
+	}
+	if (showNextWeek) {
+		result.push({
+			label: `Next week (${nextWeek.length}):`,
+			items: nextWeek,
+			isPast: false,
+		});
+	}
+	if (future.length > 0) {
+		result.push({
+			label: `Future (${future.length}):`,
+			items: future,
+			isPast: false,
+		});
+	}
+	return result;
 }
 
 export default function InterviewsPage() {
@@ -108,7 +177,15 @@ export default function InterviewsPage() {
 		[],
 	);
 
+	// When Load More advances `to`, we suppress the re-fetch that would otherwise
+	// be triggered by the date change (the list is already up to date).
+	const suppressFetch = useRef(false);
+
 	useEffect(() => {
+		if (suppressFetch.current) {
+			suppressFetch.current = false;
+			return;
+		}
 		setLoading(true);
 		setError(false);
 		setReachedEnd(false);
@@ -135,15 +212,25 @@ export default function InterviewsPage() {
 				notify(
 					`Loaded ${newItems.length} new interview${newItems.length !== 1 ? "s" : ""}`,
 				);
+				// Advance the "To" date to cover the newly loaded interviews,
+				// suppressing the re-fetch that the state change would normally trigger.
+				const lastNew = newItems[newItems.length - 1];
+				if (lastNew) {
+					const newToDate = lastNew.interview_dttm.slice(0, 10);
+					if (newToDate > to) {
+						suppressFetch.current = true;
+						setTo(newToDate);
+					}
+				}
 			}
 		} catch {
 			notify("Failed to load more interviews", "error");
 		} finally {
 			setLoadingMore(false);
 		}
-	}, [interviews, notify]);
+	}, [interviews, notify, to]);
 
-	const grouped = groupByMonth(interviews);
+	const grouped = groupByWeek(interviews, from, to);
 
 	return (
 		<>
@@ -205,33 +292,42 @@ export default function InterviewsPage() {
 					<Box sx={{ display: "flex", justifyContent: "center", mt: 10 }}>
 						<CircularProgress />
 					</Box>
-				) : interviews.length === 0 ? (
+				) : grouped.length === 0 ? (
 					<Typography
 						variant="body2"
 						color="text.disabled"
 						sx={{ textAlign: "center", mt: 10 }}
 					>
-						{from !== defaults.from || to !== defaults.to
-							? "No interviews found in this date range."
-							: "No upcoming interviews."}
+						No interviews found in this date range.
 					</Typography>
 				) : (
-					grouped.map(({ month, items }) => (
-						<Box key={month} sx={{ mb: 3 }}>
+					grouped.map(({ label, items, isPast }) => (
+						<Box key={label} sx={{ mb: 3 }}>
 							<Typography
-								variant="overline"
+								variant="subtitle2"
 								color="text.secondary"
 								sx={{ display: "block", mb: 1 }}
 							>
-								{month}
+								{label}
 							</Typography>
-							{items.map((iv) => (
-								<InterviewRow
-									key={iv.id}
-									interview={iv}
-									onJobClick={() => navigate(`/jobs/${iv.job.id}`)}
-								/>
-							))}
+							{items.length === 0 ? (
+								<Typography
+									variant="body2"
+									color="text.disabled"
+									sx={{ textAlign: "center", py: 1.5 }}
+								>
+									No interviews this week
+								</Typography>
+							) : (
+								items.map((iv) => (
+									<InterviewRow
+										key={iv.id}
+										interview={iv}
+										onJobClick={() => navigate(`/jobs/${iv.job.id}`)}
+										dimmed={isPast}
+									/>
+								))
+							)}
 						</Box>
 					))
 				)}
@@ -251,7 +347,7 @@ export default function InterviewsPage() {
 						</Typography>
 						{reachedEnd ? (
 							<Typography variant="body2" color="text.disabled">
-								End of scheduled interviews
+								No more scheduled interviews
 							</Typography>
 						) : loadingMore ? (
 							<CircularProgress size={24} />
@@ -289,9 +385,11 @@ export default function InterviewsPage() {
 function InterviewRow({
 	interview,
 	onJobClick,
+	dimmed = false,
 }: {
 	interview: EnrichedInterview;
 	onJobClick: () => void;
+	dimmed?: boolean;
 }) {
 	const TypeIcon =
 		interview.interview_type === "phone_screen" ? PhoneIcon : BusinessIcon;
@@ -299,6 +397,8 @@ function InterviewRow({
 
 	return (
 		<Box
+			data-testid="interview-card"
+			data-dimmed={String(dimmed)}
 			sx={{
 				border: "1px solid",
 				borderColor: "divider",
@@ -308,7 +408,7 @@ function InterviewRow({
 				display: "flex",
 				gap: 1.5,
 				alignItems: "flex-start",
-				bgcolor: "background.paper",
+				bgcolor: dimmed ? "action.hover" : "background.paper",
 			}}
 		>
 			<TypeIcon


### PR DESCRIPTION
## Summary
Minor tweaks to the `Load More` button in the `Interviews` page that missed the prior commit.

## Details
Minor behavior changes. Group the contents of the `Interviews` page by week.
