### PR TITLE
feat: add interview_type field and rename interview_stage column

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -60,9 +60,10 @@ db.exec(`
   CREATE TABLE IF NOT EXISTS interviews (
     id                     INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id                 INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    interview_type         TEXT NOT NULL,
+    interview_stage        TEXT NOT NULL,
     interview_dttm         TEXT NOT NULL,
     interview_interviewers TEXT,
+    interview_type         TEXT,
     interview_vibe         TEXT,
     interview_notes        TEXT
   );

--- a/backend/db/interviews.spec.ts
+++ b/backend/db/interviews.spec.ts
@@ -35,9 +35,10 @@ const SCHEMA = `
   CREATE TABLE interviews (
     id                     INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id                 INTEGER NOT NULL,
-    interview_type         TEXT NOT NULL,
+    interview_stage         TEXT NOT NULL,
     interview_dttm         TEXT NOT NULL,
     interview_interviewers TEXT,
+    interview_type         TEXT,
     interview_vibe         TEXT,
     interview_notes        TEXT
   );
@@ -58,9 +59,10 @@ function makeDb() {
 }
 
 const BASE_INTERVIEW: Omit<InterviewCreateData, "job_id"> = {
-	interview_type: "Technical",
+	interview_stage: "Technical",
 	interview_dttm: "2025-06-01T10:00:00Z",
 	interview_interviewers: "Alice",
+	interview_type: null,
 	interview_vibe: "Good",
 	interview_notes: "Went well",
 };
@@ -116,7 +118,7 @@ describe("interviews db", () => {
 
 		it("returns all interviews for the given job", () => {
 			createInterview(db, { ...BASE_INTERVIEW, job_id: jobId });
-			createInterview(db, { ...BASE_INTERVIEW, job_id: jobId, interview_type: "HR" });
+			createInterview(db, { ...BASE_INTERVIEW, job_id: jobId, interview_stage: "HR" });
 			expect(listInterviews(db, jobId)).toHaveLength(2);
 		});
 
@@ -135,7 +137,7 @@ describe("interviews db", () => {
 			const created = createInterview(db, { ...BASE_INTERVIEW, job_id: jobId });
 			const found = findInterview(db, created.id, jobId);
 			expect(found?.id).toBe(created.id);
-			expect(found?.interview_type).toBe("Technical");
+			expect(found?.interview_stage).toBe("Technical");
 		});
 
 		it("returns undefined when job_id does not match", () => {
@@ -149,7 +151,7 @@ describe("interviews db", () => {
 			const interview = createInterview(db, { ...BASE_INTERVIEW, job_id: jobId });
 			expect(interview.id).toBeGreaterThan(0);
 			expect(interview.job_id).toBe(jobId);
-			expect(interview.interview_type).toBe("Technical");
+			expect(interview.interview_stage).toBe("Technical");
 			expect(interview.interview_dttm).toBe("2025-06-01T10:00:00Z");
 		});
 
@@ -172,9 +174,9 @@ describe("interviews db", () => {
 			const created = createInterview(db, { ...BASE_INTERVIEW, job_id: jobId });
 			const updated = updateInterview(db, created.id, jobId, {
 				...BASE_INTERVIEW,
-				interview_type: "Behavioral",
+				interview_stage: "Behavioral",
 			});
-			expect(updated?.interview_type).toBe("Behavioral");
+			expect(updated?.interview_stage).toBe("Behavioral");
 		});
 
 		it("returns null when no matching interview", () => {

--- a/backend/db/interviews.ts
+++ b/backend/db/interviews.ts
@@ -3,9 +3,10 @@ import type Database from "better-sqlite3";
 export interface InterviewRow {
 	id: number;
 	job_id: number;
-	interview_type: string;
+	interview_stage: string;
 	interview_dttm: string;
 	interview_interviewers: string | null;
+	interview_type: string | null;
 	interview_vibe: string | null;
 	interview_notes: string | null;
 }
@@ -21,9 +22,10 @@ export interface InterviewQuestionRow {
 
 export interface InterviewCreateData {
 	job_id: number;
-	interview_type: string;
+	interview_stage: string;
 	interview_dttm: string;
 	interview_interviewers: string | null;
+	interview_type: string | null;
 	interview_vibe: string | null;
 	interview_notes: string | null;
 }
@@ -65,8 +67,8 @@ export function listEnrichedInterviews(
 	}
 
 	const sql = `
-		SELECT i.id, i.job_id, i.interview_type, i.interview_dttm,
-		       i.interview_interviewers, i.interview_vibe, i.interview_notes,
+		SELECT i.id, i.job_id, i.interview_stage, i.interview_dttm,
+		       i.interview_interviewers, i.interview_type, i.interview_vibe, i.interview_notes,
 		       j.company, j.role, j.link
 		FROM interviews i
 		JOIN jobs j ON j.id = i.job_id
@@ -83,8 +85,8 @@ export function listEnrichedInterviewsAfter(
 	limit: number,
 ): EnrichedInterviewRow[] {
 	const sql = `
-		SELECT i.id, i.job_id, i.interview_type, i.interview_dttm,
-		       i.interview_interviewers, i.interview_vibe, i.interview_notes,
+		SELECT i.id, i.job_id, i.interview_stage, i.interview_dttm,
+		       i.interview_interviewers, i.interview_type, i.interview_vibe, i.interview_notes,
 		       j.company, j.role, j.link
 		FROM interviews i
 		JOIN jobs j ON j.id = i.job_id
@@ -130,15 +132,16 @@ export function createInterview(
 ): InterviewRow {
 	const result = db
 		.prepare(
-			`INSERT INTO interviews (job_id, interview_type, interview_dttm,
-        interview_interviewers, interview_vibe, interview_notes)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+			`INSERT INTO interviews (job_id, interview_stage, interview_dttm,
+        interview_interviewers, interview_type, interview_vibe, interview_notes)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		)
 		.run(
 			data.job_id,
-			data.interview_type,
+			data.interview_stage,
 			data.interview_dttm,
 			data.interview_interviewers,
+			data.interview_type,
 			data.interview_vibe,
 			data.interview_notes,
 		);
@@ -156,14 +159,15 @@ export function updateInterview(
 	const info = db
 		.prepare(
 			`UPDATE interviews SET
-        interview_type = ?, interview_dttm = ?, interview_interviewers = ?,
-        interview_vibe = ?, interview_notes = ?
+        interview_stage = ?, interview_dttm = ?, interview_interviewers = ?,
+        interview_type = ?, interview_vibe = ?, interview_notes = ?
       WHERE id = ? AND job_id = ?`,
 		)
 		.run(
-			data.interview_type,
+			data.interview_stage,
 			data.interview_dttm,
 			data.interview_interviewers,
+			data.interview_type,
 			data.interview_vibe,
 			data.interview_notes,
 			interviewId,

--- a/backend/routes/interviews.spec.ts
+++ b/backend/routes/interviews.spec.ts
@@ -4,7 +4,7 @@ import Database from "better-sqlite3";
 import request from "supertest";
 import { createApp } from "../server.js";
 import {
-	VALID_INTERVIEW_TYPES,
+	VALID_INTERVIEW_STAGES,
 	VALID_INTERVIEW_VIBES,
 	VALID_QUESTION_TYPES,
 } from "../validators.js";
@@ -48,9 +48,10 @@ const SCHEMA = `
   CREATE TABLE IF NOT EXISTS interviews (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id INTEGER NOT NULL,
-    interview_type TEXT NOT NULL,
+    interview_stage TEXT NOT NULL,
     interview_dttm TEXT NOT NULL,
     interview_interviewers TEXT,
+    interview_type TEXT,
     interview_vibe TEXT,
     interview_notes TEXT
   );
@@ -102,7 +103,7 @@ const BASE_JOB = {
 };
 
 const BASE_INTERVIEW = {
-	interview_type: "phone_screen",
+	interview_stage: "phone_screen",
 	interview_dttm: "2026-04-01T10:00",
 };
 
@@ -133,7 +134,7 @@ describe("GET /api/jobs/:jobId/interviews", () => {
 		const res = await req("get", `/api/jobs/${jobId}/interviews`);
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveLength(1);
-		expect(res.body[0].interview_type).toBe("phone_screen");
+		expect(res.body[0].interview_stage).toBe("phone_screen");
 	});
 
 	it("returns 404 when the job does not exist", async () => {
@@ -156,7 +157,7 @@ describe("POST /api/jobs/:jobId/interviews", () => {
 		expect(res.status).toBe(201);
 		expect(res.body.id).toBeTypeOf("number");
 		expect(res.body.job_id).toBe(jobId);
-		expect(res.body.interview_type).toBe("phone_screen");
+		expect(res.body.interview_stage).toBe("phone_screen");
 		expect(res.body.interview_interviewers).toBe("Alice, Bob");
 		expect(res.body.interview_vibe).toBe("casual");
 		expect(res.body.interview_notes).toBe("Went well");
@@ -171,22 +172,22 @@ describe("POST /api/jobs/:jobId/interviews", () => {
 		expect(res.body.interview_notes).toBeNull();
 	});
 
-	it("returns 422 when interview_type is missing", async () => {
+	it("returns 422 when interview_stage is missing", async () => {
 		const jobId = await createJob();
-		const { interview_type: _t, ...withoutType } = BASE_INTERVIEW;
+		const { interview_stage: _t, ...withoutType } = BASE_INTERVIEW;
 		const res = await req("post", `/api/jobs/${jobId}/interviews`).send(withoutType);
 		expect(res.status).toBe(422);
-		expect(res.body.error).toMatch(/interview_type/);
+		expect(res.body.error).toMatch(/interview_stage/);
 	});
 
-	it("returns 422 when interview_type is invalid", async () => {
+	it("returns 422 when interview_stage is invalid", async () => {
 		const jobId = await createJob();
 		const res = await req("post", `/api/jobs/${jobId}/interviews`).send({
 			...BASE_INTERVIEW,
-			interview_type: "video_call",
+			interview_stage: "video_call",
 		});
 		expect(res.status).toBe(422);
-		expect(res.body.error).toMatch(/interview_type/);
+		expect(res.body.error).toMatch(/interview_stage/);
 	});
 
 	it("returns 422 when interview_dttm is missing", async () => {
@@ -207,14 +208,14 @@ describe("POST /api/jobs/:jobId/interviews", () => {
 		expect(res.body.error).toMatch(/interview_vibe/);
 	});
 
-	it.each([...VALID_INTERVIEW_TYPES])('accepts interview_type "%s"', async (interview_type) => {
+	it.each([...VALID_INTERVIEW_STAGES])('accepts interview_stage "%s"', async (interview_stage) => {
 		const jobId = await createJob();
 		const res = await req("post", `/api/jobs/${jobId}/interviews`).send({
 			...BASE_INTERVIEW,
-			interview_type,
+			interview_stage,
 		});
 		expect(res.status).toBe(201);
-		expect(res.body.interview_type).toBe(interview_type);
+		expect(res.body.interview_stage).toBe(interview_stage);
 	});
 
 	it.each([...VALID_INTERVIEW_VIBES])('accepts interview_vibe "%s"', async (interview_vibe) => {
@@ -248,13 +249,13 @@ describe("PUT /api/jobs/:jobId/interviews/:interviewId", () => {
 		const { jobId, interviewId } = await createJobAndInterview();
 		const res = await req("put", `/api/jobs/${jobId}/interviews/${interviewId}`).send({
 			...BASE_INTERVIEW,
-			interview_type: "onsite",
+			interview_stage: "onsite",
 			interview_vibe: "intense",
 			interview_notes: "Updated notes",
 		});
 
 		expect(res.status).toBe(200);
-		expect(res.body.interview_type).toBe("onsite");
+		expect(res.body.interview_stage).toBe("onsite");
 		expect(res.body.interview_vibe).toBe("intense");
 		expect(res.body.interview_notes).toBe("Updated notes");
 	});
@@ -271,11 +272,11 @@ describe("PUT /api/jobs/:jobId/interviews/:interviewId", () => {
 		expect(res.status).toBe(404);
 	});
 
-	it("returns 422 when interview_type is invalid", async () => {
+	it("returns 422 when interview_stage is invalid", async () => {
 		const { jobId, interviewId } = await createJobAndInterview();
 		const res = await req("put", `/api/jobs/${jobId}/interviews/${interviewId}`).send({
 			...BASE_INTERVIEW,
-			interview_type: "video_call",
+			interview_stage: "video_call",
 		});
 		expect(res.status).toBe(422);
 	});
@@ -616,7 +617,7 @@ describe("GET /api/interviews", () => {
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveLength(1);
 		const interview = res.body[0];
-		expect(interview.interview_type).toBe("phone_screen");
+		expect(interview.interview_stage).toBe("phone_screen");
 		expect(interview.interview_interviewers).toBe("Alice");
 		expect(interview.interview_vibe).toBe("casual");
 		expect(interview.job).toMatchObject({
@@ -729,7 +730,7 @@ describe("GET /api/interviews", () => {
 		).id;
 		testDb
 			.prepare(
-				"INSERT INTO interviews (job_id, interview_type, interview_dttm) VALUES (?, ?, ?)",
+				"INSERT INTO interviews (job_id, interview_stage, interview_dttm) VALUES (?, ?, ?)",
 			)
 			.run(otherJobId, "phone_screen", "2026-04-02T14:00");
 
@@ -834,7 +835,7 @@ describe("GET /api/interviews — cursor pagination (?after + ?limit)", () => {
 			.run(2, "Other Corp", "PM", "https://other.example.com", "Not started");
 		const otherJobId = (testDb.prepare("SELECT last_insert_rowid() AS id").get() as { id: number }).id;
 		testDb
-			.prepare("INSERT INTO interviews (job_id, interview_type, interview_dttm) VALUES (?, ?, ?)")
+			.prepare("INSERT INTO interviews (job_id, interview_stage, interview_dttm) VALUES (?, ?, ?)")
 			.run(otherJobId, "phone_screen", "2026-04-15T10:00");
 
 		const res = await req("get", "/api/interviews?after=2026-01-01T00:00:00");

--- a/backend/routes/interviews.ts
+++ b/backend/routes/interviews.ts
@@ -119,9 +119,10 @@ export function createInterviewsRouter(db: Database.Database) {
 
 		const interview = InterviewsDb.createInterview(db, {
 			job_id: Number(jobId),
-			interview_type: f.interview_type as string,
+			interview_stage: f.interview_stage as string,
 			interview_dttm: f.interview_dttm as string,
 			interview_interviewers: (f.interview_interviewers as string | null) ?? null,
+			interview_type: (f.interview_type as string | null) ?? null,
 			interview_vibe: (f.interview_vibe as string | null) ?? null,
 			interview_notes: (f.interview_notes as string | null) ?? null,
 		});
@@ -149,9 +150,10 @@ export function createInterviewsRouter(db: Database.Database) {
 			Number(interviewId),
 			Number(jobId),
 			{
-				interview_type: f.interview_type as string,
+				interview_stage: f.interview_stage as string,
 				interview_dttm: f.interview_dttm as string,
 				interview_interviewers: (f.interview_interviewers as string | null) ?? null,
+				interview_type: (f.interview_type as string | null) ?? null,
 				interview_vibe: (f.interview_vibe as string | null) ?? null,
 				interview_notes: (f.interview_notes as string | null) ?? null,
 			},

--- a/backend/routes/jobs.spec.ts
+++ b/backend/routes/jobs.spec.ts
@@ -47,9 +47,10 @@ const SCHEMA = `
   CREATE TABLE IF NOT EXISTS interviews (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id INTEGER NOT NULL,
-    interview_type TEXT NOT NULL,
+    interview_stage TEXT NOT NULL,
     interview_dttm TEXT NOT NULL,
     interview_interviewers TEXT,
+    interview_type TEXT,
     interview_vibe TEXT,
     interview_notes TEXT
   );

--- a/backend/routes/stats.spec.ts
+++ b/backend/routes/stats.spec.ts
@@ -44,9 +44,10 @@ const SCHEMA = `
   CREATE TABLE IF NOT EXISTS interviews (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id INTEGER NOT NULL,
-    interview_type TEXT NOT NULL,
+    interview_stage TEXT NOT NULL,
     interview_dttm TEXT NOT NULL,
     interview_interviewers TEXT,
+    interview_type TEXT,
     interview_vibe TEXT,
     interview_notes TEXT
   );

--- a/backend/server.spec.ts
+++ b/backend/server.spec.ts
@@ -27,8 +27,9 @@ const SCHEMA = `
   CREATE TABLE IF NOT EXISTS interviews (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id INTEGER NOT NULL,
-    interview_type TEXT NOT NULL,
-    interview_dttm TEXT NOT NULL
+    interview_stage TEXT NOT NULL,
+    interview_dttm TEXT NOT NULL,
+    interview_type TEXT
   );
   CREATE TABLE IF NOT EXISTS interview_questions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/backend/validators.ts
+++ b/backend/validators.ts
@@ -1,5 +1,13 @@
 export const TERMINAL_STATUSES = new Set(["Rejected/Withdrawn", "Offer!"]);
-export const VALID_INTERVIEW_TYPES = new Set(["phone_screen", "onsite"]);
+export const VALID_INTERVIEW_STAGES = new Set(["phone_screen", "onsite"]);
+export const VALID_INTERVIEW_TYPES = new Set([
+	"behavioral",
+	"leadership",
+	"coding",
+	"system_design",
+	"past_experience",
+	"culture_fit",
+]);
 export const VALID_INTERVIEW_VIBES = new Set(["casual", "intense"]);
 export const VALID_QUESTION_TYPES = new Set([
 	"behavioral",
@@ -37,11 +45,11 @@ export function validateEndingSubstatus(
 export function validateInterview(
 	body: Record<string, unknown>,
 ): string | null {
-	if (!body.interview_type || typeof body.interview_type !== "string") {
-		return "interview_type is required";
+	if (!body.interview_stage || typeof body.interview_stage !== "string") {
+		return "interview_stage is required";
 	}
-	if (!VALID_INTERVIEW_TYPES.has(body.interview_type)) {
-		return `interview_type must be one of: ${[...VALID_INTERVIEW_TYPES].join(", ")}`;
+	if (!VALID_INTERVIEW_STAGES.has(body.interview_stage)) {
+		return `interview_stage must be one of: ${[...VALID_INTERVIEW_STAGES].join(", ")}`;
 	}
 	if (!body.interview_dttm || typeof body.interview_dttm !== "string") {
 		return "interview_dttm is required";
@@ -52,6 +60,13 @@ export function validateInterview(
 			!VALID_INTERVIEW_VIBES.has(body.interview_vibe))
 	) {
 		return `interview_vibe must be one of: ${[...VALID_INTERVIEW_VIBES].join(", ")}`;
+	}
+	if (
+		body.interview_type != null &&
+		(typeof body.interview_type !== "string" ||
+			!VALID_INTERVIEW_TYPES.has(body.interview_type))
+	) {
+		return `interview_type must be one of: ${[...VALID_INTERVIEW_TYPES].join(", ")}`;
 	}
 	return null;
 }

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -223,7 +223,7 @@ describe("api", () => {
 				{
 					id: 1,
 					job_id: 1,
-					interview_type: "phone_screen",
+					interview_stage: "phone_screen",
 					interview_dttm: "2024-03-12T14:00",
 					interview_interviewers: "Jane",
 					interview_vibe: "casual",
@@ -250,9 +250,10 @@ describe("api", () => {
 	describe("createInterview", () => {
 		it("POSTs to /api/jobs/:jobId/interviews with JSON body and returns the created interview", async () => {
 			const formData = {
-				interview_type: "onsite" as const,
+				interview_stage: "onsite" as const,
 				interview_dttm: "2024-03-19T10:00",
 				interview_interviewers: "Alice",
+				interview_type: null,
 				interview_vibe: "intense" as const,
 				interview_notes: null,
 			};
@@ -273,9 +274,10 @@ describe("api", () => {
 	describe("updateInterview", () => {
 		it("PUTs to /api/jobs/:jobId/interviews/:interviewId and returns the updated interview", async () => {
 			const formData = {
-				interview_type: "onsite" as const,
+				interview_stage: "onsite" as const,
 				interview_dttm: "2024-03-19T10:00",
 				interview_interviewers: "Bob",
+				interview_type: null,
 				interview_vibe: null,
 				interview_notes: "Updated notes",
 			};
@@ -406,7 +408,7 @@ describe("api", () => {
 			{
 				id: 1,
 				job_id: 10,
-				interview_type: "phone_screen",
+				interview_stage: "phone_screen",
 				interview_dttm: "2026-04-20T10:00:00Z",
 				interview_interviewers: null,
 				interview_vibe: null,
@@ -454,7 +456,7 @@ describe("api", () => {
 			{
 				id: 1,
 				job_id: 10,
-				interview_type: "phone_screen",
+				interview_stage: "phone_screen",
 				interview_dttm: "2026-03-15T14:00:00Z",
 				interview_interviewers: null,
 				interview_vibe: null,

--- a/frontend/src/components/InterviewsPage.spec.tsx
+++ b/frontend/src/components/InterviewsPage.spec.tsx
@@ -32,9 +32,10 @@ function makeInterview(
 	return {
 		id: 1,
 		job_id: 10,
-		interview_type: "phone_screen",
+		interview_stage: "phone_screen",
 		interview_dttm: "2026-03-15T14:00:00Z",
 		interview_interviewers: null,
+		interview_type: null,
 		interview_vibe: null,
 		interview_notes: null,
 		job: {
@@ -449,7 +450,7 @@ describe("InterviewsPage", () => {
 
 	it("renders onsite type label for onsite interviews", async () => {
 		mockSearchInterviews.mockResolvedValue([
-			makeInterview({ interview_type: "onsite" }),
+			makeInterview({ interview_stage: "onsite" }),
 		]);
 		renderPage();
 		await waitFor(() => expect(screen.getByText("Onsite")).toBeInTheDocument());

--- a/frontend/src/components/InterviewsPage.tsx
+++ b/frontend/src/components/InterviewsPage.tsx
@@ -16,15 +16,29 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import PhoneIcon from "@mui/icons-material/Phone";
 import { useNavigate } from "react-router-dom";
 import { api } from "../api";
-import type { EnrichedInterview, InterviewType, InterviewVibe } from "../types";
+import type {
+	EnrichedInterview,
+	InterviewStage,
+	InterviewType,
+	InterviewVibe,
+} from "../types";
 
 type Severity = "success" | "info" | "warning" | "error";
 
 const PAGE_SIZE = 10;
 
-const INTERVIEW_TYPE_LABELS: Record<InterviewType, string> = {
+const INTERVIEW_STAGE_LABELS: Record<InterviewStage, string> = {
 	phone_screen: "Phone Screen",
 	onsite: "Onsite",
+};
+
+const INTERVIEW_TYPE_LABELS: Record<InterviewType, string> = {
+	behavioral: "Behavioral",
+	leadership: "Leadership",
+	coding: "Coding",
+	system_design: "System Design",
+	past_experience: "Past Experience",
+	culture_fit: "Culture Fit",
 };
 
 const VIBE_CHIP_SX: Record<InterviewVibe, object> = {
@@ -392,8 +406,8 @@ function InterviewRow({
 	dimmed?: boolean;
 }) {
 	const TypeIcon =
-		interview.interview_type === "phone_screen" ? PhoneIcon : BusinessIcon;
-	const typeLabel = INTERVIEW_TYPE_LABELS[interview.interview_type];
+		interview.interview_stage === "phone_screen" ? PhoneIcon : BusinessIcon;
+	const typeLabel = INTERVIEW_STAGE_LABELS[interview.interview_stage];
 
 	return (
 		<Box
@@ -430,6 +444,13 @@ function InterviewRow({
 					<Typography variant="body2" color="text.secondary">
 						&middot; {formatDttm(interview.interview_dttm)}
 					</Typography>
+					{interview.interview_type && (
+						<Chip
+							label={INTERVIEW_TYPE_LABELS[interview.interview_type]}
+							size="small"
+							sx={{ bgcolor: "#f3e5f5", color: "#6a1b9a" }}
+						/>
+					)}
 					{interview.interview_vibe && (
 						<Chip
 							label={VIBE_LABELS[interview.interview_vibe]}

--- a/frontend/src/components/InterviewsTab.spec.tsx
+++ b/frontend/src/components/InterviewsTab.spec.tsx
@@ -16,9 +16,10 @@ vi.mock("../api");
 const makeInterview = (overrides: Partial<Interview> = {}): Interview => ({
 	id: 1,
 	job_id: 42,
-	interview_type: "phone_screen",
+	interview_stage: "phone_screen",
 	interview_dttm: "2024-03-12T14:00",
 	interview_interviewers: "Jane Smith",
+	interview_type: null,
 	interview_vibe: "casual",
 	interview_notes: "Great conversation",
 	...overrides,
@@ -26,7 +27,7 @@ const makeInterview = (overrides: Partial<Interview> = {}): Interview => ({
 
 const INTERVIEW_A = makeInterview({
 	id: 1,
-	interview_type: "phone_screen",
+	interview_stage: "phone_screen",
 	interview_dttm: "2024-03-12T14:00",
 	interview_interviewers: "Jane Smith",
 	interview_vibe: "casual",
@@ -35,7 +36,7 @@ const INTERVIEW_A = makeInterview({
 
 const INTERVIEW_B = makeInterview({
 	id: 2,
-	interview_type: "onsite",
+	interview_stage: "onsite",
 	interview_dttm: "2024-03-19T10:00",
 	interview_interviewers: null,
 	interview_vibe: "intense",
@@ -323,7 +324,7 @@ describe("InterviewsTab", () => {
 					42,
 					INTERVIEW_A.id,
 					expect.objectContaining({
-						interview_type: INTERVIEW_A.interview_type,
+						interview_stage: INTERVIEW_A.interview_stage,
 					}),
 				);
 			});

--- a/frontend/src/components/InterviewsTab.tsx
+++ b/frontend/src/components/InterviewsTab.tsx
@@ -20,15 +20,25 @@ import { api } from "../api";
 import type {
 	Interview,
 	InterviewFormData,
+	InterviewStage,
 	InterviewType,
 	InterviewVibe,
 } from "../types";
 import MarkdownField from "./MarkdownField";
 import QuestionSubView from "./QuestionSubView";
 
-const INTERVIEW_TYPE_LABELS: Record<InterviewType, string> = {
+const INTERVIEW_STAGE_LABELS: Record<InterviewStage, string> = {
 	phone_screen: "Phone Screen",
 	onsite: "Onsite",
+};
+
+const INTERVIEW_TYPE_LABELS: Record<InterviewType, string> = {
+	behavioral: "Behavioral",
+	leadership: "Leadership",
+	coding: "Coding",
+	system_design: "System Design",
+	past_experience: "Past Experience",
+	culture_fit: "Culture Fit",
 };
 
 const INTERVIEW_VIBE_LABELS: Record<InterviewVibe, string> = {
@@ -42,9 +52,10 @@ const VIBE_CHIP_SX: Record<InterviewVibe, object> = {
 };
 
 const EMPTY_FORM: InterviewFormData = {
-	interview_type: "phone_screen",
+	interview_stage: "phone_screen",
 	interview_dttm: "",
 	interview_interviewers: null,
+	interview_type: null,
 	interview_vibe: null,
 	interview_notes: null,
 };
@@ -159,9 +170,10 @@ export default function InterviewsTab({
 
 	function handleEditClick(interview: Interview) {
 		setForm({
-			interview_type: interview.interview_type,
+			interview_stage: interview.interview_stage,
 			interview_dttm: interview.interview_dttm.slice(0, 16),
 			interview_interviewers: interview.interview_interviewers,
+			interview_type: interview.interview_type,
 			interview_vibe: interview.interview_vibe,
 			interview_notes: interview.interview_notes,
 		});
@@ -370,8 +382,8 @@ function InterviewCard({
 	onViewQuestions: () => void;
 }) {
 	const TypeIcon =
-		interview.interview_type === "phone_screen" ? PhoneIcon : BusinessIcon;
-	const typeLabel = INTERVIEW_TYPE_LABELS[interview.interview_type];
+		interview.interview_stage === "phone_screen" ? PhoneIcon : BusinessIcon;
+	const typeLabel = INTERVIEW_STAGE_LABELS[interview.interview_stage];
 
 	return (
 		<Box
@@ -407,6 +419,13 @@ function InterviewCard({
 						<Typography variant="body2" color="text.secondary">
 							&middot; {formatDttm(interview.interview_dttm)}
 						</Typography>
+						{interview.interview_type && (
+							<Chip
+								label={INTERVIEW_TYPE_LABELS[interview.interview_type]}
+								size="small"
+								sx={{ bgcolor: "#f3e5f5", color: "#6a1b9a" }}
+							/>
+						)}
 						{interview.interview_vibe && (
 							<Chip
 								label={INTERVIEW_VIBE_LABELS[interview.interview_vibe]}
@@ -506,16 +525,16 @@ function InterviewForm({
 			<Box sx={{ display: "flex", gap: 1.5, mb: 1.5, flexWrap: "wrap" }}>
 				<TextField
 					select
-					label="Type"
-					value={data.interview_type}
+					label="Stage"
+					value={data.interview_stage}
 					onChange={(e) =>
-						onChange("interview_type", e.target.value as InterviewType)
+						onChange("interview_stage", e.target.value as InterviewStage)
 					}
 					size="small"
 					sx={{ minWidth: 140 }}
 				>
 					{(
-						Object.entries(INTERVIEW_TYPE_LABELS) as [InterviewType, string][]
+						Object.entries(INTERVIEW_STAGE_LABELS) as [InterviewStage, string][]
 					).map(([value, label]) => (
 						<MenuItem key={value} value={value}>
 							{label}
@@ -544,30 +563,56 @@ function InterviewForm({
 				placeholder="e.g. Jane Smith, Bob Lee"
 				sx={{ mb: 1.5 }}
 			/>
-			<TextField
-				select
-				label="Vibe"
-				value={data.interview_vibe ?? ""}
-				onChange={(e) =>
-					onChange(
-						"interview_vibe",
-						(e.target.value || null) as InterviewVibe | null,
-					)
-				}
-				size="small"
-				sx={{ minWidth: 140, mb: 1.5 }}
-			>
-				<MenuItem value="">
-					<em>None</em>
-				</MenuItem>
-				{(
-					Object.entries(INTERVIEW_VIBE_LABELS) as [InterviewVibe, string][]
-				).map(([value, label]) => (
-					<MenuItem key={value} value={value}>
-						{label}
+			<Box sx={{ display: "flex", gap: 1.5, mb: 1.5, flexWrap: "wrap" }}>
+				<TextField
+					select
+					label="Type"
+					value={data.interview_type ?? ""}
+					onChange={(e) =>
+						onChange(
+							"interview_type",
+							(e.target.value || null) as InterviewType | null,
+						)
+					}
+					size="small"
+					sx={{ minWidth: 160 }}
+				>
+					<MenuItem value="">
+						<em>None</em>
 					</MenuItem>
-				))}
-			</TextField>
+					{(
+						Object.entries(INTERVIEW_TYPE_LABELS) as [InterviewType, string][]
+					).map(([value, label]) => (
+						<MenuItem key={value} value={value}>
+							{label}
+						</MenuItem>
+					))}
+				</TextField>
+				<TextField
+					select
+					label="Vibe"
+					value={data.interview_vibe ?? ""}
+					onChange={(e) =>
+						onChange(
+							"interview_vibe",
+							(e.target.value || null) as InterviewVibe | null,
+						)
+					}
+					size="small"
+					sx={{ minWidth: 140 }}
+				>
+					<MenuItem value="">
+						<em>None</em>
+					</MenuItem>
+					{(
+						Object.entries(INTERVIEW_VIBE_LABELS) as [InterviewVibe, string][]
+					).map(([value, label]) => (
+						<MenuItem key={value} value={value}>
+							{label}
+						</MenuItem>
+					))}
+				</TextField>
+			</Box>
 			<Box sx={{ mb: 1.5 }}>
 				<MarkdownField
 					label="Notes"

--- a/frontend/src/components/JobDialog.spec.tsx
+++ b/frontend/src/components/JobDialog.spec.tsx
@@ -47,9 +47,10 @@ const BASE_JOB: Job = {
 const MOCK_INTERVIEW: Interview = {
 	id: 1,
 	job_id: 42,
-	interview_type: "phone_screen",
+	interview_stage: "phone_screen",
 	interview_dttm: "2024-03-12T14:00",
 	interview_interviewers: "Jane Smith",
+	interview_type: null,
 	interview_vibe: "casual",
 	interview_notes: null,
 };

--- a/frontend/src/components/QuestionSubView.spec.tsx
+++ b/frontend/src/components/QuestionSubView.spec.tsx
@@ -16,9 +16,10 @@ vi.mock("../api");
 const BASE_INTERVIEW: Interview = {
 	id: 10,
 	job_id: 42,
-	interview_type: "phone_screen",
+	interview_stage: "phone_screen",
 	interview_dttm: "2024-03-12T14:00",
 	interview_interviewers: "Jane Smith",
+	interview_type: null,
 	interview_vibe: "casual",
 	interview_notes: null,
 };
@@ -108,7 +109,7 @@ describe("QuestionSubView", () => {
 			render(
 				<QuestionSubView
 					{...DEFAULT_PROPS}
-					interview={{ ...BASE_INTERVIEW, interview_type: "onsite" }}
+					interview={{ ...BASE_INTERVIEW, interview_stage: "onsite" }}
 				/>,
 			);
 			await waitFor(() => {

--- a/frontend/src/components/QuestionSubView.tsx
+++ b/frontend/src/components/QuestionSubView.tsx
@@ -46,7 +46,7 @@ const QUESTION_TYPE_CHIP_SX: Record<
 	culture_fit: { bgcolor: "#fce4ec", color: "#c62828" },
 };
 
-const INTERVIEW_TYPE_LABELS: Record<string, string> = {
+const INTERVIEW_STAGE_LABELS: Record<string, string> = {
 	phone_screen: "Phone Screen",
 	onsite: "Onsite",
 };
@@ -177,8 +177,8 @@ export default function QuestionSubView({ jobId, interview }: Props) {
 	}
 
 	const TypeIcon =
-		interview.interview_type === "phone_screen" ? PhoneIcon : BusinessIcon;
-	const typeLabel = INTERVIEW_TYPE_LABELS[interview.interview_type];
+		interview.interview_stage === "phone_screen" ? PhoneIcon : BusinessIcon;
+	const typeLabel = INTERVIEW_STAGE_LABELS[interview.interview_stage];
 
 	const isFormMode =
 		mode === "add" || (typeof mode === "object" && "editId" in mode);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -52,15 +52,23 @@ export interface Job {
 
 export type JobFormData = Omit<Job, "id" | "created_at">;
 
-export type InterviewType = "phone_screen" | "onsite";
+export type InterviewStage = "phone_screen" | "onsite";
+export type InterviewType =
+	| "behavioral"
+	| "leadership"
+	| "coding"
+	| "system_design"
+	| "past_experience"
+	| "culture_fit";
 export type InterviewVibe = "casual" | "intense";
 
 export interface Interview {
 	id: number;
 	job_id: number;
-	interview_type: InterviewType;
+	interview_stage: InterviewStage;
 	interview_dttm: string;
 	interview_interviewers: string | null;
+	interview_type: InterviewType | null;
 	interview_vibe: InterviewVibe | null;
 	interview_notes: string | null;
 }


### PR DESCRIPTION
## Summary

Renames the `interview_type` DB column to `interview_stage` and introduces a new `interview_type` field (the kind of interview: behavioral, coding, etc.) with UI support throughout.

## Details

**Rename `interview_type` → `interview_stage`:**
- DB schema, API layer, and all frontend types/constants/labels updated
- `InterviewType` TS type → `InterviewStage`; `VALID_INTERVIEW_TYPES` → `VALID_INTERVIEW_STAGES`; `INTERVIEW_TYPE_LABELS` → `INTERVIEW_STAGE_LABELS`
- All spec fixtures and inline DDL strings updated

**New `interview_type` field:**
- Added `interview_type TEXT` column to the `interviews` table (nullable)
- Enum values: `behavioral`, `leadership`, `coding`, `system_design`, `past_experience`, `culture_fit`
- Validated in `validateInterview()`; passed through create/update routes and DB functions
- New `InterviewType` TS type added to `types.ts`; `interview_type` added to `Interview` and `InterviewFormData`

**UI:**
- "Type" dropdown added to the interview form, positioned left of the existing "Vibe" dropdown
- Interview-type badge (purple) rendered before the vibe badge on cards in both InterviewsTab and InterviewsPage

## Test plan

- [ ] Create an interview with a type set — verify it persists and appears on the card
- [ ] Edit an existing interview and change the type — verify the badge updates
- [ ] Create an interview with no type — verify no badge appears and the vibe badge still renders correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)