### PR TITLE
feat(stats): animate StatCard numbers on mount, add suffix prop

### DIFF
--- a/frontend/src/components/StatsPage.spec.tsx
+++ b/frontend/src/components/StatsPage.spec.tsx
@@ -76,10 +76,16 @@ describe("StatsPage", () => {
 	it("displays the correct values from the API response", async () => {
 		mockGetStats.mockResolvedValue(BASE_STATS);
 		render(<StatsPage />);
-		await waitFor(() => expect(screen.getByText("10")).toBeInTheDocument());
-		expect(screen.getByText("4")).toBeInTheDocument();
-		expect(screen.getByText("1")).toBeInTheDocument();
-		expect(screen.getByText("50%")).toBeInTheDocument();
+		// Wait for all animated values simultaneously — they complete at slightly different ticks
+		await waitFor(
+			() => {
+				expect(screen.getByText("10")).toBeInTheDocument();
+				expect(screen.getByText("4")).toBeInTheDocument();
+				expect(screen.getByText("1")).toBeInTheDocument();
+				expect(screen.getByText("50%")).toBeInTheDocument();
+			},
+			{ timeout: 2000 },
+		);
 	});
 
 	it("displays '—' for response rate when it is null", async () => {

--- a/frontend/src/components/StatsPage.tsx
+++ b/frontend/src/components/StatsPage.tsx
@@ -17,11 +17,6 @@ import AvgDaysChart from "./stats/AvgDaysChart";
 import PipelineOverTimeChart from "./stats/PipelineOverTimeChart";
 import TopCompaniesTable from "./stats/TopCompaniesTable";
 
-function formatPercent(rate: number | null): string {
-	if (rate === null) return "—";
-	return `${Math.round(rate * 100)}%`;
-}
-
 export default function StatsPage() {
 	const [window, setWindow] = useState<StatsWindow>("all");
 	const [data, setData] = useState<StatsResponse | null>(null);
@@ -84,7 +79,12 @@ export default function StatsPage() {
 						<StatCard label="Offers Received" value={data.offersReceived} />
 						<StatCard
 							label="Response Rate"
-							value={formatPercent(data.responseRate)}
+							value={
+								data.responseRate !== null
+									? Math.round(data.responseRate * 100)
+									: null
+							}
+							suffix="%"
 							subtitle={
 								data.responseRate !== null
 									? "Of submitted apps that got a reply"

--- a/frontend/src/components/stats/StatCard.spec.tsx
+++ b/frontend/src/components/stats/StatCard.spec.tsx
@@ -1,11 +1,16 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import StatCard from "./StatCard";
 
 describe("StatCard", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it("renders the label", () => {
@@ -13,13 +18,32 @@ describe("StatCard", () => {
 		expect(screen.getByText("Total Applications")).toBeInTheDocument();
 	});
 
-	it("renders a numeric value", () => {
-		render(<StatCard label="Active Pipeline" value={7} />);
-		expect(screen.getByText("7")).toBeInTheDocument();
+	it("starts at 0 and animates to the final value", () => {
+		render(<StatCard label="Active Pipeline" value={30} />);
+		expect(screen.getByText("0")).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(700);
+		});
+		expect(screen.getByText("30")).toBeInTheDocument();
 	});
 
-	it("renders a string value", () => {
-		render(<StatCard label="Response Rate" value="65%" />);
+	it("renders a null value as an em dash without animating", () => {
+		render(<StatCard label="Response Rate" value={null} />);
+		expect(screen.getByText("—")).toBeInTheDocument();
+	});
+
+	it("renders a zero value immediately without animating", () => {
+		render(<StatCard label="Offers Received" value={0} />);
+		expect(screen.getByText("0")).toBeInTheDocument();
+	});
+
+	it("appends the suffix after the animated value", () => {
+		render(<StatCard label="Response Rate" value={65} suffix="%" />);
+
+		act(() => {
+			vi.advanceTimersByTime(700);
+		});
 		expect(screen.getByText("65%")).toBeInTheDocument();
 	});
 

--- a/frontend/src/components/stats/StatCard.tsx
+++ b/frontend/src/components/stats/StatCard.tsx
@@ -1,13 +1,42 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, CardContent, Typography, Box } from "@mui/material";
+
+const DURATION = 600;
+const INTERVAL = 20;
 
 interface Props {
 	label: string;
-	value: string | number;
+	value: number | null;
+	suffix?: string;
 	subtitle?: string;
 }
 
-export default function StatCard({ label, value, subtitle }: Props) {
+export default function StatCard({ label, value, suffix, subtitle }: Props) {
+	const [displayed, setDisplayed] = useState(0);
+
+	useEffect(() => {
+		if (value === null || value === 0) {
+			setDisplayed(0);
+			return;
+		}
+
+		const steps = Math.ceil(DURATION / INTERVAL);
+		const increment = value / steps;
+		let current = 0;
+
+		const timer = setInterval(() => {
+			current += increment;
+			if (current >= value) {
+				setDisplayed(value);
+				clearInterval(timer);
+			} else {
+				setDisplayed(Math.round(current));
+			}
+		}, INTERVAL);
+
+		return () => clearInterval(timer);
+	}, [value]);
+
 	return (
 		<Card sx={{ flex: 1, minWidth: 160 }}>
 			<CardContent sx={{ pb: "16px !important" }}>
@@ -20,7 +49,7 @@ export default function StatCard({ label, value, subtitle }: Props) {
 				</Typography>
 				<Box sx={{ display: "flex", alignItems: "baseline", gap: 1 }}>
 					<Typography variant="h4" fontWeight={700} lineHeight={1}>
-						{value}
+						{value === null ? "—" : `${displayed}${suffix ?? ""}`}
 					</Typography>
 				</Box>
 				{subtitle && (


### PR DESCRIPTION
## Summary

Refactors `StatCard` to only accept numeric values, adds a `suffix` prop for units like `%`, and animates each card's number from 0 to its final value on mount for a polished load effect.

## Details

- `value` prop changed from `string | number` to `number | null`; null renders `"—"` (no animation)
- New optional `suffix` prop appended after the displayed number (e.g. `suffix="%"` → `"65%"`)
- On mount, displayed value increments linearly from 0 → final over ~600 ms using `setInterval` at 20 ms ticks
- `StatsPage` updated: removed `formatPercent` helper, Response Rate card now passes raw integer + `suffix="%"`
- `StatCard.spec.tsx` updated with `vi.useFakeTimers()` to cover animation, null, zero, and suffix cases
- `StatsPage.spec.tsx` updated: value assertions wrapped in a single `waitFor` that retries until all animated values are simultaneously present (cards complete animation at slightly different ticks due to rounding)

## Test plan

- [x] Stats page loads and each metric card animates up to its value
- [x] Response Rate shows e.g. `65%` after animation
- [x] When response rate data is null, card shows `—`
- [x] Unit tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)