### PR TITLE
fix(JobCard): always apply bottom margin between salary chip and tags

### DIFF
--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -244,7 +244,7 @@ const JobCard = React.memo(function JobCard({
 							flexWrap: "wrap",
 							gap: 0.5,
 							alignItems: "center",
-							mb: job.recruiter ? 0.5 : 0,
+							mb: 0.5,
 						}}
 					>
 						<Chip


### PR DESCRIPTION
## Summary

Fixes inconsistent spacing between the salary/referral chip row and the tags row on job cards. The gap appeared when a recruiter was present but disappeared when there was none.

## Details

- `mb` on the salary chip `Box` was `job.recruiter ? 0.5 : 0` — incorrectly gated on recruiter presence instead of always providing the spacing before the tags row
- Changed to unconditional `mb: 0.5`

## Test plan

- [x] Open a job card with tags but no recruiter — spacing between salary chip and tags should match a card that has a recruiter

🤖 Generated with [Claude Code](https://claude.ai/claude-code)