### PR TITLE
feat: enforce max lengths for varchar columns

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -32,22 +32,22 @@ db.exec(`
   CREATE TABLE IF NOT EXISTS jobs (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id          INTEGER REFERENCES users(id),
-    date_applied     TEXT,
-    company          TEXT NOT NULL,
-    role             TEXT NOT NULL,
-    link             TEXT NOT NULL,
-    salary           TEXT,
-    fit_score        TEXT,
-    referred_by      TEXT,
-    status           TEXT DEFAULT 'Not started',
-    recruiter        TEXT,
-    notes            TEXT,
+    date_applied     TEXT     CHECK(length(date_applied) <= 16),
+    company          TEXT NOT NULL CHECK(length(company) <= 128),
+    role             TEXT NOT NULL CHECK(length(role) <= 256),
+    link             TEXT NOT NULL CHECK(length(link) <= 4096),
+    salary           TEXT     CHECK(length(salary) <= 64),
+    fit_score        TEXT     CHECK(length(fit_score) <= 32),
+    referred_by      TEXT     CHECK(length(referred_by) <= 128),
+    status           TEXT DEFAULT 'Not started' CHECK(length(status) <= 128),
+    recruiter        TEXT     CHECK(length(recruiter) <= 128),
+    notes            TEXT     CHECK(length(notes) <= 20000),
     favorite         INTEGER DEFAULT 0,
     created_at       TEXT DEFAULT (datetime('now')),
-    job_description  TEXT,
-    ending_substatus TEXT,
-    date_phone_screen TEXT,
-    date_last_onsite TEXT,
+    job_description  TEXT     CHECK(length(job_description) <= 20000),
+    ending_substatus TEXT     CHECK(length(ending_substatus) <= 128),
+    date_phone_screen TEXT    CHECK(length(date_phone_screen) <= 16),
+    date_last_onsite TEXT     CHECK(length(date_last_onsite) <= 16),
     updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
   );
 
@@ -60,20 +60,20 @@ db.exec(`
   CREATE TABLE IF NOT EXISTS interviews (
     id                     INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id                 INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    interview_stage        TEXT NOT NULL,
-    interview_dttm         TEXT NOT NULL,
-    interview_interviewers TEXT,
-    interview_type         TEXT,
-    interview_vibe         TEXT,
-    interview_notes        TEXT
+    interview_stage        TEXT NOT NULL CHECK(length(interview_stage) <= 128),
+    interview_dttm         TEXT NOT NULL CHECK(length(interview_dttm) <= 16),
+    interview_interviewers TEXT     CHECK(length(interview_interviewers) <= 128),
+    interview_type         TEXT     CHECK(length(interview_type) <= 128),
+    interview_vibe         TEXT     CHECK(length(interview_vibe) <= 64),
+    interview_notes        TEXT     CHECK(length(interview_notes) <= 4096)
   );
 
   CREATE TABLE IF NOT EXISTS interview_questions (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
     interview_id   INTEGER NOT NULL REFERENCES interviews(id) ON DELETE CASCADE,
-    question_type  TEXT NOT NULL,
-    question_text  TEXT NOT NULL,
-    question_notes TEXT,
+    question_type  TEXT NOT NULL CHECK(length(question_type) <= 128),
+    question_text  TEXT NOT NULL CHECK(length(question_text) <= 4096),
+    question_notes TEXT     CHECK(length(question_notes) <= 4096),
     difficulty     INTEGER NOT NULL
   );
 
@@ -92,7 +92,7 @@ db.exec(`
 
   CREATE TABLE IF NOT EXISTS job_tags (
     job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
+    tag    TEXT NOT NULL CHECK(length(tag) <= 64),
     PRIMARY KEY (job_id, tag)
   );
 

--- a/backend/routes/interviews.spec.ts
+++ b/backend/routes/interviews.spec.ts
@@ -4,6 +4,8 @@ import Database from "better-sqlite3";
 import request from "supertest";
 import { createApp } from "../server.js";
 import {
+	INTERVIEW_MAX_LENGTHS,
+	QUESTION_MAX_LENGTHS,
 	VALID_INTERVIEW_STAGES,
 	VALID_INTERVIEW_VIBES,
 	VALID_QUESTION_TYPES,
@@ -129,6 +131,15 @@ async function createJobAndInterview() {
 	const jobId = await createJob();
 	const interviewRes = await req("post", `/api/jobs/${jobId}/interviews`).send(BASE_INTERVIEW);
 	return { jobId, interviewId: interviewRes.body.id as number };
+}
+
+async function createJobInterviewAndQuestion() {
+	const { jobId, interviewId } = await createJobAndInterview();
+	const questionRes = await req(
+		"post",
+		`/api/jobs/${jobId}/interviews/${interviewId}/questions`,
+	).send(BASE_QUESTION);
+	return { jobId, interviewId, questionId: questionRes.body.id as number };
 }
 
 // --- Interview routes ---
@@ -859,4 +870,107 @@ describe("GET /api/interviews — cursor pagination (?after + ?limit)", () => {
 		expect(res.status).toBe(200);
 		expect(res.body[0].job).toMatchObject({ id: jobId, company: BASE_JOB.company });
 	});
+});
+
+describe("interview field length validation", () => {
+	const LENGTH_CASES = Object.entries(INTERVIEW_MAX_LENGTHS) as [
+		keyof typeof INTERVIEW_MAX_LENGTHS,
+		number,
+	][];
+
+	it.each(LENGTH_CASES)(
+		"POST returns 422 when %s exceeds %d characters",
+		async (field, max) => {
+			const jobId = await createJob();
+			const res = await req("post", `/api/jobs/${jobId}/interviews`).send({
+				...BASE_INTERVIEW,
+				[field]: "a".repeat(max + 1),
+			});
+			expect(res.status).toBe(422);
+			expect(res.body.error).toMatch(new RegExp(field));
+		},
+	);
+
+	it.each(LENGTH_CASES)(
+		"POST accepts %s at exactly %d characters",
+		async (field, max) => {
+			const jobId = await createJob();
+			const res = await req("post", `/api/jobs/${jobId}/interviews`).send({
+				...BASE_INTERVIEW,
+				[field]: "a".repeat(max),
+			});
+			expect(res.status).toBe(201);
+		},
+	);
+
+	it.each(LENGTH_CASES)(
+		"PUT returns 422 when %s exceeds %d characters",
+		async (field, max) => {
+			const { jobId, interviewId } = await createJobAndInterview();
+			const res = await req(
+				"put",
+				`/api/jobs/${jobId}/interviews/${interviewId}`,
+			).send({
+				...BASE_INTERVIEW,
+				[field]: "a".repeat(max + 1),
+			});
+			expect(res.status).toBe(422);
+			expect(res.body.error).toMatch(new RegExp(field));
+		},
+	);
+});
+
+describe("question field length validation", () => {
+	const LENGTH_CASES = Object.entries(QUESTION_MAX_LENGTHS) as [
+		keyof typeof QUESTION_MAX_LENGTHS,
+		number,
+	][];
+
+	it.each(LENGTH_CASES)(
+		"POST returns 422 when %s exceeds %d characters",
+		async (field, max) => {
+			const { jobId, interviewId } = await createJobAndInterview();
+			const res = await req(
+				"post",
+				`/api/jobs/${jobId}/interviews/${interviewId}/questions`,
+			).send({
+				...BASE_QUESTION,
+				[field]: "a".repeat(max + 1),
+			});
+			expect(res.status).toBe(422);
+			expect(res.body.error).toMatch(new RegExp(field));
+		},
+	);
+
+	it.each(LENGTH_CASES)(
+		"POST accepts %s at exactly %d characters",
+		async (field, max) => {
+			const { jobId, interviewId } = await createJobAndInterview();
+			const res = await req(
+				"post",
+				`/api/jobs/${jobId}/interviews/${interviewId}/questions`,
+			).send({
+				...BASE_QUESTION,
+				[field]: "a".repeat(max),
+			});
+			expect(res.status).toBe(201);
+		},
+	);
+
+	it.each(LENGTH_CASES)(
+		"PUT returns 422 when %s exceeds %d characters",
+		async (field, max) => {
+			const { jobId, interviewId, questionId } =
+				await createJobInterviewAndQuestion();
+			const res = await req(
+				"put",
+				`/api/jobs/${jobId}/interviews/${interviewId}/questions/${questionId}`,
+			).send({
+				...BASE_QUESTION,
+				[field]: "a".repeat(max + 1),
+			});
+			expect(res.status).toBe(422);
+			expect(res.body.error).toMatch(new RegExp(field));
+		},
+	);
 });

--- a/backend/routes/jobs.spec.ts
+++ b/backend/routes/jobs.spec.ts
@@ -4,6 +4,7 @@ import Database from "better-sqlite3";
 import request from "supertest";
 import { createApp } from "../server.js";
 import {
+	JOB_MAX_LENGTHS,
 	TERMINAL_STATUSES,
 	VALID_ENDING_SUBSTATUSES,
 } from "../validators.js";
@@ -400,5 +401,54 @@ describe("date_phone_screen and date_last_onsite fields", () => {
 		expect(res.status).toBe(200);
 		expect(res.body.date_phone_screen).toBeNull();
 		expect(res.body.date_last_onsite).toBeNull();
+	});
+});
+
+describe("field length validation", () => {
+	const LENGTH_CASES = Object.entries(JOB_MAX_LENGTHS) as [
+		keyof typeof JOB_MAX_LENGTHS,
+		number,
+	][];
+
+	describe("POST /api/jobs", () => {
+		it.each(LENGTH_CASES)(
+			"returns 422 when %s exceeds %d characters",
+			async (field, max) => {
+				const res = await req("post", "/api/jobs").send({
+					...BASE_JOB,
+					[field]: "a".repeat(max + 1),
+				});
+				expect(res.status).toBe(422);
+				expect(res.body.error).toMatch(new RegExp(field));
+			},
+		);
+
+		it.each(LENGTH_CASES)(
+			"accepts %s at exactly %d characters",
+			async (field, max) => {
+				const res = await req("post", "/api/jobs").send({
+					...BASE_JOB,
+					[field]: "a".repeat(max),
+				});
+				expect(res.status).toBe(201);
+			},
+		);
+	});
+
+	describe("PUT /api/jobs/:id", () => {
+		it.each(LENGTH_CASES)(
+			"returns 422 when %s exceeds %d characters",
+			async (field, max) => {
+				const createRes = await req("post", "/api/jobs").send(BASE_JOB);
+				const id: number = createRes.body.id;
+
+				const res = await req("put", `/api/jobs/${id}`).send({
+					...BASE_JOB,
+					[field]: "a".repeat(max + 1),
+				});
+				expect(res.status).toBe(422);
+				expect(res.body.error).toMatch(new RegExp(field));
+			},
+		);
 	});
 });

--- a/backend/routes/jobs.ts
+++ b/backend/routes/jobs.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import express from "express";
 import * as JobsDb from "../db/jobs.js";
-import { validateEndingSubstatus } from "../validators.js";
+import { validateEndingSubstatus, validateJobFields } from "../validators.js";
 
 export function createJobsRouter(db: Database.Database) {
 	const router = express.Router();
@@ -19,6 +19,9 @@ export function createJobsRouter(db: Database.Database) {
 	router.post("/", (req, res) => {
 		const f = req.body;
 		const userId = req.session.userId!;
+
+		const lengthError = validateJobFields(f);
+		if (lengthError) return res.status(422).json({ error: lengthError });
 
 		const substatusError = validateEndingSubstatus(
 			f.status ?? "Not started",
@@ -54,6 +57,10 @@ export function createJobsRouter(db: Database.Database) {
 
 	router.put("/:id", (req, res) => {
 		const f = req.body;
+
+		const lengthError = validateJobFields(f);
+		if (lengthError) return res.status(422).json({ error: lengthError });
+
 		const substatusError = validateEndingSubstatus(
 			f.status,
 			f.ending_substatus ?? null,

--- a/backend/validators.ts
+++ b/backend/validators.ts
@@ -1,4 +1,48 @@
 export const TERMINAL_STATUSES = new Set(["Rejected/Withdrawn", "Offer!"]);
+
+// ── Max-length constants ───────────────────────────────────────────────────────
+export const JOB_MAX_LENGTHS = {
+	company: 128,
+	role: 256,
+	link: 4096,
+	salary: 64,
+	recruiter: 128,
+	referred_by: 128,
+	notes: 20_000,
+	job_description: 20_000,
+} as const;
+
+export const INTERVIEW_MAX_LENGTHS = {
+	interview_interviewers: 128,
+	interview_notes: 4_096,
+} as const;
+
+export const QUESTION_MAX_LENGTHS = {
+	question_text: 4_096,
+	question_notes: 4_096,
+} as const;
+
+function checkLength(
+	value: unknown,
+	field: string,
+	max: number,
+): string | null {
+	if (typeof value === "string" && value.length > max) {
+		return `${field} must be at most ${max.toLocaleString()} characters`;
+	}
+	return null;
+}
+
+export function validateJobFields(
+	body: Record<string, unknown>,
+): string | null {
+	for (const [field, max] of Object.entries(JOB_MAX_LENGTHS)) {
+		const err = checkLength(body[field], field, max);
+		if (err) return err;
+	}
+	return null;
+}
+
 export const VALID_INTERVIEW_STAGES = new Set(["phone_screen", "onsite"]);
 export const VALID_INTERVIEW_TYPES = new Set([
 	"behavioral",
@@ -68,6 +112,10 @@ export function validateInterview(
 	) {
 		return `interview_type must be one of: ${[...VALID_INTERVIEW_TYPES].join(", ")}`;
 	}
+	for (const [field, max] of Object.entries(INTERVIEW_MAX_LENGTHS)) {
+		const err = checkLength(body[field], field, max);
+		if (err) return err;
+	}
 	return null;
 }
 
@@ -89,6 +137,10 @@ export function validateInterviewQuestion(
 	const difficulty = Number(body.difficulty);
 	if (!Number.isInteger(difficulty) || difficulty < 1 || difficulty > 5) {
 		return "difficulty must be an integer between 1 and 5";
+	}
+	for (const [field, max] of Object.entries(QUESTION_MAX_LENGTHS)) {
+		const err = checkLength(body[field], field, max);
+		if (err) return err;
 	}
 	return null;
 }

--- a/frontend/src/components/InterviewsTab.spec.tsx
+++ b/frontend/src/components/InterviewsTab.spec.tsx
@@ -381,4 +381,54 @@ describe("InterviewsTab", () => {
 			});
 		});
 	});
+
+	describe("field length validation", () => {
+		beforeEach(() => {
+			vi.mocked(api.getInterviews).mockResolvedValue([]);
+		});
+
+		async function openAddForm() {
+			render(<InterviewsTab {...DEFAULT_PROPS} />);
+			await waitFor(() =>
+				screen.getByRole("button", { name: "Add Interview" }),
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Add Interview" }));
+			// Set a required date value
+			fireEvent.change(screen.getByLabelText(/Date & Time/i), {
+				target: { value: "2026-04-01T10:00" },
+			});
+		}
+
+		it("shows an error when interviewers exceeds 128 characters", async () => {
+			await openAddForm();
+			fireEvent.change(screen.getByLabelText(/Interviewers/i), {
+				target: { value: "a".repeat(129) },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Save Interview" }));
+			await waitFor(() => {
+				expect(
+					screen.getByText("Interviewers must be 128 characters or fewer"),
+				).toBeInTheDocument();
+			});
+			expect(api.createInterview).not.toHaveBeenCalled();
+		});
+
+		it("does not show an error when interviewers is within 128 characters", async () => {
+			vi.mocked(api.createInterview).mockResolvedValue(
+				makeInterview({ id: 99 }),
+			);
+			vi.mocked(api.getInterviews)
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([makeInterview({ id: 99 })]);
+			vi.mocked(api.getQuestions).mockResolvedValue([]);
+			await openAddForm();
+			fireEvent.change(screen.getByLabelText(/Interviewers/i), {
+				target: { value: "a".repeat(128) },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Save Interview" }));
+			await waitFor(() => {
+				expect(api.createInterview).toHaveBeenCalled();
+			});
+		});
+	});
 });

--- a/frontend/src/components/InterviewsTab.tsx
+++ b/frontend/src/components/InterviewsTab.tsx
@@ -17,6 +17,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import PhoneIcon from "@mui/icons-material/Phone";
 import QuizOutlinedIcon from "@mui/icons-material/QuizOutlined";
 import { api } from "../api";
+import { INTERVIEW_MAX_LENGTHS } from "../constants";
 import type {
 	Interview,
 	InterviewFormData,
@@ -189,6 +190,25 @@ export default function InterviewsTab({
 	async function handleSave() {
 		if (!form.interview_dttm) {
 			setFormError("Date and time are required");
+			return;
+		}
+		if (
+			form.interview_interviewers &&
+			form.interview_interviewers.length >
+				INTERVIEW_MAX_LENGTHS.interview_interviewers
+		) {
+			setFormError(
+				`Interviewers must be ${INTERVIEW_MAX_LENGTHS.interview_interviewers.toLocaleString()} characters or fewer`,
+			);
+			return;
+		}
+		if (
+			form.interview_notes &&
+			form.interview_notes.length > INTERVIEW_MAX_LENGTHS.interview_notes
+		) {
+			setFormError(
+				`Notes must be ${INTERVIEW_MAX_LENGTHS.interview_notes.toLocaleString()} characters or fewer`,
+			);
 			return;
 		}
 		setSaving(true);
@@ -562,6 +582,11 @@ function InterviewForm({
 				fullWidth
 				placeholder="e.g. Jane Smith, Bob Lee"
 				sx={{ mb: 1.5 }}
+				slotProps={{
+					htmlInput: {
+						maxLength: INTERVIEW_MAX_LENGTHS.interview_interviewers,
+					},
+				}}
 			/>
 			<Box sx={{ display: "flex", gap: 1.5, mb: 1.5, flexWrap: "wrap" }}>
 				<TextField

--- a/frontend/src/components/JobDialog.spec.tsx
+++ b/frontend/src/components/JobDialog.spec.tsx
@@ -740,4 +740,107 @@ describe("JobDialog", () => {
 			});
 		});
 	});
+
+	describe("field length validation", () => {
+		function fillRequiredFields() {
+			fireEvent.change(screen.getByLabelText(/Company \*/i), {
+				target: { value: "Acme" },
+			});
+			fireEvent.change(screen.getByLabelText(/Role \*/i), {
+				target: { value: "Engineer" },
+			});
+			fireEvent.change(screen.getByPlaceholderText("https://..."), {
+				target: { value: "https://example.com" },
+			});
+		}
+
+		function clickSave() {
+			fireEvent.click(screen.getByRole("button", { name: "Add Job" }));
+		}
+
+		it("shows an error when company exceeds 128 characters", () => {
+			render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+			fillRequiredFields();
+			fireEvent.change(screen.getByLabelText(/Company \*/i), {
+				target: { value: "a".repeat(129) },
+			});
+			clickSave();
+			expect(
+				screen.getByText("Must be 128 characters or fewer"),
+			).toBeInTheDocument();
+			expect(DEFAULT_PROPS.onSave).not.toHaveBeenCalled();
+		});
+
+		it("shows an error when role exceeds 256 characters", () => {
+			render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+			fillRequiredFields();
+			fireEvent.change(screen.getByLabelText(/Role \*/i), {
+				target: { value: "a".repeat(257) },
+			});
+			clickSave();
+			expect(
+				screen.getByText("Must be 256 characters or fewer"),
+			).toBeInTheDocument();
+			expect(DEFAULT_PROPS.onSave).not.toHaveBeenCalled();
+		});
+
+		it("shows an error when link exceeds 4096 characters", () => {
+			render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+			fillRequiredFields();
+			fireEvent.change(screen.getByPlaceholderText("https://..."), {
+				target: { value: "a".repeat(4097) },
+			});
+			clickSave();
+			expect(
+				screen.getByText("Must be 4,096 characters or fewer"),
+			).toBeInTheDocument();
+			expect(DEFAULT_PROPS.onSave).not.toHaveBeenCalled();
+		});
+
+		it("shows an error when salary exceeds 64 characters", () => {
+			render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+			fillRequiredFields();
+			fireEvent.change(screen.getByLabelText(/Salary/i), {
+				target: { value: "a".repeat(65) },
+			});
+			clickSave();
+			expect(
+				screen.getByText("Must be 64 characters or fewer"),
+			).toBeInTheDocument();
+			expect(DEFAULT_PROPS.onSave).not.toHaveBeenCalled();
+		});
+
+		it("shows an error when recruiter exceeds 128 characters", () => {
+			render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+			fillRequiredFields();
+			fireEvent.change(screen.getByLabelText(/Recruiter/i), {
+				target: { value: "a".repeat(129) },
+			});
+			clickSave();
+			expect(
+				screen.getByText("Must be 128 characters or fewer"),
+			).toBeInTheDocument();
+			expect(DEFAULT_PROPS.onSave).not.toHaveBeenCalled();
+		});
+
+		it("shows an error when referred_by exceeds 128 characters", () => {
+			render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+			fillRequiredFields();
+			fireEvent.change(screen.getByLabelText(/Referred By/i), {
+				target: { value: "a".repeat(129) },
+			});
+			clickSave();
+			expect(
+				screen.getByText("Must be 128 characters or fewer"),
+			).toBeInTheDocument();
+			expect(DEFAULT_PROPS.onSave).not.toHaveBeenCalled();
+		});
+
+		it("calls onSave when all fields are within limits", () => {
+			render(<JobDialog {...DEFAULT_PROPS} initialValues={null} />);
+			fillRequiredFields();
+			clickSave();
+			expect(DEFAULT_PROPS.onSave).toHaveBeenCalled();
+		});
+	});
 });

--- a/frontend/src/components/JobDialog.tsx
+++ b/frontend/src/components/JobDialog.tsx
@@ -26,6 +26,7 @@ import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import {
+	JOB_MAX_LENGTHS,
 	STATUSES,
 	FIT_SCORES,
 	ENDING_SUBSTATUSES,
@@ -115,8 +116,34 @@ export default function JobDialog({
 	function validate() {
 		const e: typeof errors = {};
 		if (!form.company?.trim()) e.company = "Required";
+		else if (form.company.length > JOB_MAX_LENGTHS.company)
+			e.company = `Must be ${JOB_MAX_LENGTHS.company.toLocaleString()} characters or fewer`;
+
 		if (!form.role?.trim()) e.role = "Required";
+		else if (form.role.length > JOB_MAX_LENGTHS.role)
+			e.role = `Must be ${JOB_MAX_LENGTHS.role.toLocaleString()} characters or fewer`;
+
 		if (!form.link?.trim()) e.link = "Required";
+		else if (form.link.length > JOB_MAX_LENGTHS.link)
+			e.link = `Must be ${JOB_MAX_LENGTHS.link.toLocaleString()} characters or fewer`;
+
+		if (form.salary && form.salary.length > JOB_MAX_LENGTHS.salary)
+			e.salary = `Must be ${JOB_MAX_LENGTHS.salary.toLocaleString()} characters or fewer`;
+		if (form.recruiter && form.recruiter.length > JOB_MAX_LENGTHS.recruiter)
+			e.recruiter = `Must be ${JOB_MAX_LENGTHS.recruiter.toLocaleString()} characters or fewer`;
+		if (
+			form.referred_by &&
+			form.referred_by.length > JOB_MAX_LENGTHS.referred_by
+		)
+			e.referred_by = `Must be ${JOB_MAX_LENGTHS.referred_by.toLocaleString()} characters or fewer`;
+		if (form.notes && form.notes.length > JOB_MAX_LENGTHS.notes)
+			e.notes = `Must be ${JOB_MAX_LENGTHS.notes.toLocaleString()} characters or fewer`;
+		if (
+			form.job_description &&
+			form.job_description.length > JOB_MAX_LENGTHS.job_description
+		)
+			e.job_description = `Must be ${JOB_MAX_LENGTHS.job_description.toLocaleString()} characters or fewer`;
+
 		if (TERMINAL_STATUSES.has(form.status) && !form.ending_substatus)
 			e.ending_substatus = "Required for this status";
 		setErrors(e);
@@ -253,6 +280,9 @@ export default function JobDialog({
 									helperText={errors.company}
 									fullWidth
 									size="small"
+									slotProps={{
+										htmlInput: { maxLength: JOB_MAX_LENGTHS.company },
+									}}
 								/>
 							</Grid>
 							<Grid size={{ xs: 12, sm: 6 }}>
@@ -264,6 +294,7 @@ export default function JobDialog({
 									helperText={errors.role}
 									fullWidth
 									size="small"
+									slotProps={{ htmlInput: { maxLength: JOB_MAX_LENGTHS.role } }}
 								/>
 							</Grid>
 							<Grid size={12}>
@@ -296,6 +327,9 @@ export default function JobDialog({
 										fullWidth
 										size="small"
 										placeholder="https://..."
+										slotProps={{
+											htmlInput: { maxLength: JOB_MAX_LENGTHS.link },
+										}}
 									/>
 								)}
 							</Grid>
@@ -426,9 +460,14 @@ export default function JobDialog({
 									label="Salary"
 									value={form.salary ?? ""}
 									onChange={(e) => set("salary", e.target.value || null)}
+									error={!!errors.salary}
+									helperText={errors.salary}
 									fullWidth
 									size="small"
 									placeholder="e.g. $120k–$150k"
+									slotProps={{
+										htmlInput: { maxLength: JOB_MAX_LENGTHS.salary },
+									}}
 								/>
 							</Grid>
 
@@ -437,8 +476,13 @@ export default function JobDialog({
 									label="Recruiter"
 									value={form.recruiter ?? ""}
 									onChange={(e) => set("recruiter", e.target.value || null)}
+									error={!!errors.recruiter}
+									helperText={errors.recruiter}
 									fullWidth
 									size="small"
+									slotProps={{
+										htmlInput: { maxLength: JOB_MAX_LENGTHS.recruiter },
+									}}
 								/>
 							</Grid>
 
@@ -473,6 +517,15 @@ export default function JobDialog({
 									onChange={(v) => set("job_description", v)}
 									placeholder="Paste the job description here in case the posting gets removed..."
 								/>
+								{errors.job_description && (
+									<Typography
+										variant="caption"
+										color="error"
+										sx={{ display: "block", mt: 0.5, mx: "14px" }}
+									>
+										{errors.job_description}
+									</Typography>
+								)}
 							</Grid>
 
 							<Grid size={12}>
@@ -481,6 +534,15 @@ export default function JobDialog({
 									value={form.notes}
 									onChange={(v) => set("notes", v)}
 								/>
+								{errors.notes && (
+									<Typography
+										variant="caption"
+										color="error"
+										sx={{ display: "block", mt: 0.5, mx: "14px" }}
+									>
+										{errors.notes}
+									</Typography>
+								)}
 							</Grid>
 
 							<Grid size={{ xs: 12, sm: 6 }}>
@@ -488,9 +550,14 @@ export default function JobDialog({
 									label="Referred By"
 									value={form.referred_by ?? ""}
 									onChange={(e) => set("referred_by", e.target.value || null)}
+									error={!!errors.referred_by}
+									helperText={errors.referred_by}
 									fullWidth
 									size="small"
 									placeholder="Name of referrer"
+									slotProps={{
+										htmlInput: { maxLength: JOB_MAX_LENGTHS.referred_by },
+									}}
 								/>
 							</Grid>
 						</Grid>

--- a/frontend/src/components/QuestionSubView.spec.tsx
+++ b/frontend/src/components/QuestionSubView.spec.tsx
@@ -423,4 +423,45 @@ describe("QuestionSubView", () => {
 			});
 		});
 	});
+
+	describe("field length validation", () => {
+		beforeEach(() => {
+			vi.mocked(api.getQuestions).mockResolvedValue([]);
+		});
+
+		async function openAddForm() {
+			render(<QuestionSubView {...DEFAULT_PROPS} />);
+			await waitFor(() => screen.getByText(/No questions recorded yet/i));
+			fireEvent.click(screen.getByText("Add one."));
+		}
+
+		it("shows an error when question text exceeds 4096 characters", async () => {
+			await openAddForm();
+			fireEvent.change(screen.getByLabelText(/Question/i), {
+				target: { value: "a".repeat(4097) },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Save Question" }));
+			await waitFor(() => {
+				expect(
+					screen.getByText("Question text must be 4,096 characters or fewer"),
+				).toBeInTheDocument();
+			});
+			expect(api.createQuestion).not.toHaveBeenCalled();
+		});
+
+		it("does not show an error when question text is within 4096 characters", async () => {
+			vi.mocked(api.createQuestion).mockResolvedValue(makeQuestion({ id: 99 }));
+			vi.mocked(api.getQuestions)
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([makeQuestion({ id: 99 })]);
+			await openAddForm();
+			fireEvent.change(screen.getByLabelText(/Question/i), {
+				target: { value: "a".repeat(4096) },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Save Question" }));
+			await waitFor(() => {
+				expect(api.createQuestion).toHaveBeenCalled();
+			});
+		});
+	});
 });

--- a/frontend/src/components/QuestionSubView.tsx
+++ b/frontend/src/components/QuestionSubView.tsx
@@ -18,6 +18,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import PhoneIcon from "@mui/icons-material/Phone";
 import { api } from "../api";
+import { QUESTION_MAX_LENGTHS } from "../constants";
 import type {
 	Interview,
 	InterviewQuestion,
@@ -147,6 +148,21 @@ export default function QuestionSubView({ jobId, interview }: Props) {
 	async function handleSave() {
 		if (!form.question_text.trim()) {
 			setFormError("Question text is required");
+			return;
+		}
+		if (form.question_text.length > QUESTION_MAX_LENGTHS.question_text) {
+			setFormError(
+				`Question text must be ${QUESTION_MAX_LENGTHS.question_text.toLocaleString()} characters or fewer`,
+			);
+			return;
+		}
+		if (
+			form.question_notes &&
+			form.question_notes.length > QUESTION_MAX_LENGTHS.question_notes
+		) {
+			setFormError(
+				`Notes must be ${QUESTION_MAX_LENGTHS.question_notes.toLocaleString()} characters or fewer`,
+			);
 			return;
 		}
 		setSaving(true);
@@ -519,6 +535,9 @@ function QuestionForm({
 				minRows={2}
 				placeholder="What was the question?"
 				sx={{ mb: 1.5 }}
+				slotProps={{
+					htmlInput: { maxLength: QUESTION_MAX_LENGTHS.question_text },
+				}}
 			/>
 			<Box sx={{ mb: 1.5 }}>
 				<MarkdownField

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -112,6 +112,27 @@ export function tagChipProps(
 	return { color: "default", sx: { color: c, borderColor: c } };
 }
 
+export const JOB_MAX_LENGTHS = {
+	company: 128,
+	role: 256,
+	link: 4096,
+	salary: 64,
+	recruiter: 128,
+	referred_by: 128,
+	notes: 20_000,
+	job_description: 20_000,
+} as const;
+
+export const INTERVIEW_MAX_LENGTHS = {
+	interview_interviewers: 128,
+	interview_notes: 4_096,
+} as const;
+
+export const QUESTION_MAX_LENGTHS = {
+	question_text: 4_096,
+	question_notes: 4_096,
+} as const;
+
 export const FIT_SCORE_COLORS = {
 	"Not sure": "default",
 	"Very Low": "error",


### PR DESCRIPTION
## Summary

Closes #67. Adds three-layer length enforcement across the stack for all user-editable text fields to prevent payload bombs.

## Details

- **SQLite (`backend/jobman.db`)**: Rebuilt `jobs`, `interviews`, `interview_questions`, and `job_tags` in-place using the standard table-recreation migration. All existing data was verified clean (zero violations) before migrating. Matching `CHECK(length(col) <= n)` constraints added to the `CREATE TABLE IF NOT EXISTS` blocks in `db.ts` for fresh installs.
- **Backend validators (`backend/validators.ts`)**: Exported `JOB_MAX_LENGTHS`, `INTERVIEW_MAX_LENGTHS`, and `QUESTION_MAX_LENGTHS` constants. Added `validateJobFields()` for jobs; extended `validateInterview()` and `validateInterviewQuestion()` with per-field length loops.
- **Backend routes (`backend/routes/jobs.ts`)**: Both `POST /api/jobs` and `PUT /api/jobs/:id` call `validateJobFields()` before any DB write, returning `422` with a clear `"{field} must be at most {n} characters"` message.
- **Frontend constants (`frontend/src/constants.ts`)**: Added `JOB_MAX_LENGTHS`, `INTERVIEW_MAX_LENGTHS`, and `QUESTION_MAX_LENGTHS` — the single source of truth for all FE length limits.
- **Frontend components**: `validate()` in `JobDialog` and `handleSave()` in `InterviewsTab` / `QuestionSubView` reference the constants; short text inputs also get `htmlInput.maxLength` as a secondary guard. `MarkdownField`-backed fields show a `<Typography color="error">` below the field on violation.
- **Tests**: Parameterised backend tests cover every constrained field on POST + PUT for both jobs and interviews/questions. Frontend tests assert error messages appear and `onSave`/API calls are not invoked on violations.

## Test plan

- [x] Start the dev server (`npm run dev`) and open the Add Job dialog — verify you cannot type more than 128 characters in Company, 256 in Role, etc.
- [x] Attempt to save a job with a very long notes/job description — verify a validation error appears below the field
- [x] Via curl/Postman, `POST /api/jobs` with `company: "a".repeat(129)` — verify `422` with `"company must be at most 128 characters"`
- [x] Add an interview with a very long interviewers string — verify error shown before API call
- [x] All tests pass: `npm test`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)