### PR TITLE
feat(jobs): add view query param to GET /jobs to reduce Kanban payload

### DIFF
--- a/backend/db/jobs.ts
+++ b/backend/db/jobs.ts
@@ -24,10 +24,16 @@ interface JobDbRow {
 }
 
 // SQLite stores booleans as 0/1 — convert for the client
-export type Job = Omit<JobDbRow, "favorite" | "tags_csv"> & {
+export type Job = Omit<JobDbRow, "favorite" | "tags_csv" | "notes" | "job_description"> & {
 	favorite: boolean;
 	tags: string[];
+	/** Absent in summary view; present in full view. */
+	notes?: string | null;
+	/** Absent in summary view; present in full view. */
+	job_description?: string | null;
 };
+
+export type JobView = "full" | "summary";
 
 function toClient(row: unknown): Job {
 	const r = row as JobDbRow;
@@ -55,7 +61,15 @@ export interface JobCreateData {
 	tags: string[];
 }
 
-export type JobUpdateData = Omit<JobCreateData, "user_id">;
+/**
+ * notes and job_description are optional here — if absent the existing DB
+ * values are preserved (useful for status/favorite-only updates where the
+ * caller doesn't have those fields loaded).
+ */
+export type JobUpdateData = Omit<JobCreateData, "user_id" | "notes" | "job_description"> & {
+	notes?: string | null;
+	job_description?: string | null;
+};
 
 const JOBS_WITH_TAGS_SQL = `
   SELECT j.*, GROUP_CONCAT(jt.tag) AS tags_csv
@@ -71,11 +85,15 @@ function setTags(db: Database.Database, jobId: number | bigint, tags: string[]):
 	}
 }
 
-export function listJobs(db: Database.Database, userId: number): Job[] {
-	return db
+export function listJobs(db: Database.Database, userId: number, view: JobView = "summary"): Job[] {
+	const rows = db
 		.prepare(`${JOBS_WITH_TAGS_SQL} WHERE j.user_id = ? GROUP BY j.id ORDER BY j.created_at DESC`)
 		.all(userId)
 		.map(toClient);
+	if (view === "summary") {
+		return rows.map(({ notes: _n, job_description: _jd, ...rest }) => rest);
+	}
+	return rows;
 }
 
 export function findJob(
@@ -156,12 +174,19 @@ export function updateJob(
 			.get(jobId, userId) as { status: string } | undefined;
 		if (!current) return null;
 
+		// notes/job_description are optional — only update them when explicitly
+		// provided; otherwise keep the existing DB value.
+		const notesProvided = "notes" in data;
+		const jdProvided = "job_description" in data;
+
 		const info = db
 			.prepare(
 				`UPDATE jobs SET
           date_applied = ?, company = ?, role = ?, link = ?, salary = ?,
-          fit_score = ?, referred_by = ?, status = ?, recruiter = ?, notes = ?,
-          job_description = ?, ending_substatus = ?, date_phone_screen = ?,
+          fit_score = ?, referred_by = ?, status = ?, recruiter = ?,
+          notes = CASE WHEN ? THEN ? ELSE notes END,
+          job_description = CASE WHEN ? THEN ? ELSE job_description END,
+          ending_substatus = ?, date_phone_screen = ?,
           date_last_onsite = ?, favorite = ?
         WHERE id = ? AND user_id = ?`,
 			)
@@ -175,8 +200,8 @@ export function updateJob(
 				data.referred_by,
 				data.status,
 				data.recruiter,
-				data.notes,
-				data.job_description,
+				notesProvided ? 1 : 0, data.notes ?? null,
+				jdProvided ? 1 : 0, data.job_description ?? null,
 				data.ending_substatus,
 				data.date_phone_screen,
 				data.date_last_onsite,

--- a/backend/routes/jobs.spec.ts
+++ b/backend/routes/jobs.spec.ts
@@ -121,6 +121,54 @@ describe("GET /api/jobs", () => {
 		expect(res.body).toHaveLength(1);
 		expect(res.body[0].company).toBe("Acme Corp");
 	});
+
+	describe("view param", () => {
+		it("omits notes and job_description when view=summary", async () => {
+			await req("post", "/api/jobs").send({
+				...BASE_JOB,
+				notes: "some notes",
+				job_description: "job description text",
+			});
+			const res = await req("get", "/api/jobs?view=summary");
+			expect(res.status).toBe(200);
+			expect(res.body[0]).not.toHaveProperty("notes");
+			expect(res.body[0]).not.toHaveProperty("job_description");
+		});
+
+		it("defaults to summary when view param is omitted", async () => {
+			await req("post", "/api/jobs").send({
+				...BASE_JOB,
+				notes: "some notes",
+				job_description: "job description text",
+			});
+			const res = await req("get", "/api/jobs");
+			expect(res.status).toBe(200);
+			expect(res.body[0]).not.toHaveProperty("notes");
+			expect(res.body[0]).not.toHaveProperty("job_description");
+		});
+
+		it("includes notes and job_description when view=full", async () => {
+			await req("post", "/api/jobs").send({
+				...BASE_JOB,
+				notes: "some notes",
+				job_description: "job description text",
+			});
+			const res = await req("get", "/api/jobs?view=full");
+			expect(res.status).toBe(200);
+			expect(res.body[0].notes).toBe("some notes");
+			expect(res.body[0].job_description).toBe("job description text");
+		});
+
+		it("falls back to summary for an unknown view value", async () => {
+			await req("post", "/api/jobs").send({
+				...BASE_JOB,
+				notes: "some notes",
+			});
+			const res = await req("get", "/api/jobs?view=unknown");
+			expect(res.status).toBe(200);
+			expect(res.body[0]).not.toHaveProperty("notes");
+		});
+	});
 });
 
 describe("GET /api/jobs/:jobId", () => {
@@ -213,6 +261,41 @@ describe("PUT /api/jobs/:id", () => {
 		expect(res.body.company).toBe("Updated Corp");
 		expect(res.body.status).toBe("Resume submitted");
 		expect(res.body.referred_by).toBe("Jane Doe");
+	});
+
+	it("preserves notes and job_description when they are absent from the request body", async () => {
+		const createRes = await req("post", "/api/jobs").send({
+			...BASE_JOB,
+			notes: "keep me",
+			job_description: "keep me too",
+		});
+		const id: number = createRes.body.id;
+
+		// Update only status — notes/job_description intentionally omitted from body
+		// (mirrors a summary-state client that never loaded those fields)
+		const { notes: _n, ...withoutDetailFields } = BASE_JOB;
+		const res = await req("put", `/api/jobs/${id}`).send({
+			...withoutDetailFields,
+			status: "Phone screen",
+		});
+		expect(res.status).toBe(200);
+		expect(res.body.notes).toBe("keep me");
+		expect(res.body.job_description).toBe("keep me too");
+	});
+
+	it("clears notes when null is explicitly sent", async () => {
+		const createRes = await req("post", "/api/jobs").send({
+			...BASE_JOB,
+			notes: "clear me",
+		});
+		const id: number = createRes.body.id;
+
+		const res = await req("put", `/api/jobs/${id}`).send({
+			...BASE_JOB,
+			notes: null,
+		});
+		expect(res.status).toBe(200);
+		expect(res.body.notes).toBeNull();
 	});
 
 	it("returns 404 when job does not exist", async () => {

--- a/backend/routes/jobs.ts
+++ b/backend/routes/jobs.ts
@@ -1,13 +1,15 @@
 import type Database from "better-sqlite3";
 import express from "express";
 import * as JobsDb from "../db/jobs.js";
+import type { JobView } from "../db/jobs.js";
 import { validateEndingSubstatus, validateJobFields } from "../validators.js";
 
 export function createJobsRouter(db: Database.Database) {
 	const router = express.Router();
 
 	router.get("/", (req, res) => {
-		res.json(JobsDb.listJobs(db, req.session.userId!));
+		const view: JobView = req.query.view === "full" ? "full" : "summary";
+		res.json(JobsDb.listJobs(db, req.session.userId!, view));
 	});
 
 	router.get("/:jobId", (req, res) => {
@@ -81,8 +83,10 @@ export function createJobsRouter(db: Database.Database) {
 				referred_by: f.referred_by ?? null,
 				status: f.status,
 				recruiter: f.recruiter ?? null,
-				notes: f.notes ?? null,
-				job_description: f.job_description ?? null,
+				// Only update notes/job_description when explicitly present in the
+				// request body — omitting them preserves the existing DB value.
+				...("notes" in f && { notes: f.notes ?? null }),
+				...("job_description" in f && { job_description: f.job_description ?? null }),
 				ending_substatus: f.ending_substatus ?? null,
 				date_phone_screen: f.date_phone_screen ?? null,
 				date_last_onsite: f.date_last_onsite ?? null,

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -132,11 +132,11 @@ describe("api", () => {
 	});
 
 	describe("getJobs", () => {
-		it("fetches GET /api/jobs and returns the parsed JSON", async () => {
+		it("fetches GET /api/jobs?view=summary and returns the parsed JSON", async () => {
 			mockFetch.mockResolvedValue(makeResponse([MOCK_JOB]));
 			const result = await api.getJobs();
 			expect(mockFetch).toHaveBeenCalledWith(
-				"/api/jobs",
+				"/api/jobs?view=summary",
 				expect.objectContaining({
 					headers: { "Content-Type": "application/json" },
 				}),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -45,7 +45,7 @@ export const api = {
 		request<{ success: boolean }>("/auth/logout", { method: "POST" }),
 
 	// Jobs
-	getJobs: () => request<Job[]>("/jobs"),
+	getJobs: () => request<Job[]>("/jobs?view=summary"),
 	getJob: (id: number) => request<Job>(`/jobs/${id}`),
 	createJob: (data: JobFormData) =>
 		request<Job>("/jobs", { method: "POST", body: JSON.stringify(data) }),

--- a/frontend/src/components/JobDialog.tsx
+++ b/frontend/src/components/JobDialog.tsx
@@ -584,7 +584,7 @@ export default function JobDialog({
 								<Grid size={12}>
 									<MarkdownField
 										label="Job Description"
-										value={form.job_description}
+										value={form.job_description ?? null}
 										onChange={(v) => set("job_description", v)}
 										placeholder="Paste the job description here in case the posting gets removed..."
 									/>
@@ -602,7 +602,7 @@ export default function JobDialog({
 								<Grid size={12}>
 									<MarkdownField
 										label="Notes"
-										value={form.notes}
+										value={form.notes ?? null}
 										onChange={(v) => set("notes", v)}
 									/>
 									{errors.notes && (

--- a/frontend/src/components/JobManagementPage.spec.tsx
+++ b/frontend/src/components/JobManagementPage.spec.tsx
@@ -546,4 +546,52 @@ describe("JobManagementPage", () => {
 			expect(mockOnLogout).toHaveBeenCalledOnce();
 		});
 	});
+
+	describe("summary view state management", () => {
+		it("calls getJobs on mount to load jobs", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			renderPage();
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+			expect(mockGetJobs).toHaveBeenCalledOnce();
+		});
+
+		it("strips notes and job_description from state after a status change", async () => {
+			const job = makeJob({ id: 1, company: "Acme" });
+			mockGetJobs.mockResolvedValue([job]);
+			// API returns a full job (with notes) after the status change PUT
+			vi.mocked(api.updateJob).mockResolvedValue(
+				makeJob({
+					id: 1,
+					company: "Acme",
+					notes: "secret",
+					job_description: "secret jd",
+				}),
+			);
+
+			let boardJobs: Job[] = [];
+			MockKanbanBoard.mockImplementation(({ jobs, onStatusChange }) => {
+				boardJobs = jobs;
+				return (
+					<button onClick={() => onStatusChange(jobs[0]!, "Phone screen")}>
+						change status
+					</button>
+				);
+			});
+
+			renderPage();
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+
+			fireEvent.click(screen.getByRole("button", { name: "change status" }));
+
+			await waitFor(() => expect(vi.mocked(api.updateJob)).toHaveBeenCalled());
+
+			// State should not carry notes/job_description — board only needs summary fields
+			expect(boardJobs[0]).not.toHaveProperty("notes");
+			expect(boardJobs[0]).not.toHaveProperty("job_description");
+		});
+	});
 });

--- a/frontend/src/components/JobManagementPage.tsx
+++ b/frontend/src/components/JobManagementPage.tsx
@@ -55,6 +55,12 @@ import EndingStatusDialog from "./EndingStatusDialog";
 
 type Severity = "success" | "error" | "info" | "warning";
 
+/** Strip heavy fields not needed by the Kanban board to keep state lean. */
+function toSummaryJob(job: Job): Job {
+	const { notes: _n, job_description: _jd, ...rest } = job;
+	return rest;
+}
+
 // Minimum fit score filter: show jobs at or above this threshold
 // "Not sure" is excluded when any threshold is set
 const MIN_FIT_SCORE_OPTIONS: { label: string; value: FitScore | null }[] = [
@@ -172,12 +178,12 @@ export default function JobManagementPage() {
 				if (dialogJob) {
 					const updated = await api.updateJob(dialogJob.id, formData);
 					setJobs((prev) =>
-						prev.map((j) => (j.id === updated.id ? updated : j)),
+						prev.map((j) => (j.id === updated.id ? toSummaryJob(updated) : j)),
 					);
 					notify("Job updated");
 				} else {
 					const created = await api.createJob(formData);
-					setJobs((prev) => [created, ...prev]);
+					setJobs((prev) => [toSummaryJob(created), ...prev]);
 					notify("Job added");
 				}
 				closeDialog();
@@ -212,7 +218,9 @@ export default function JobManagementPage() {
 					status: newStatus,
 					...extraUpdates,
 				});
-				setJobs((prev) => prev.map((j) => (j.id === updated.id ? updated : j)));
+				setJobs((prev) =>
+					prev.map((j) => (j.id === updated.id ? toSummaryJob(updated) : j)),
+				);
 				notify("Job status updated successfully");
 			} catch {
 				setJobs((prev) => prev.map((j) => (j.id === job.id ? job : j)));

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -49,8 +49,10 @@ export interface Job {
 	referred_by: string | null;
 	status: JobStatus;
 	recruiter: string | null;
-	notes: string | null;
-	job_description: string | null;
+	/** Absent when loaded via the summary view; present via the full view or individual job fetch. */
+	notes?: string | null;
+	/** Absent when loaded via the summary view; present via the full view or individual job fetch. */
+	job_description?: string | null;
 	ending_substatus: EndingSubstatus | null;
 	date_phone_screen: string | null;
 	date_last_onsite: string | null;


### PR DESCRIPTION
Closes #69

## Summary

- Adds `?view=summary|full` to `GET /api/jobs`. The default is `summary`, which omits `notes` and `job_description` from the list response, reducing the Kanban page's initial payload.
- `GET /api/jobs/:id` always returns the full job (including `notes` and `job_description`), so `JobDialog` continues to load and persist both fields without any change.
- `frontend/src/api.ts`: `getJobs()` now calls `/jobs?view=summary`.
- `JobManagementPage` strips `notes` and `job_description` from API responses before storing them in state (via a `toSummaryJob` helper), keeping state lean and consistent with the summary view.
- `notes` and `job_description` are now optional (`?`) in the frontend `Job` type and the backend `Job` type, since summary jobs won't carry those fields.

## Bonus fix: no more accidental note-wiping on status/favorite updates

The existing `PUT /jobs/:id` handler previously always wrote `notes = f.notes ?? null`, which would wipe a job's notes if the client didn't include that field in the request body. Now that Kanban state is summary-only, a drag-and-drop status change or favorite toggle would spread a job without `notes`, inadvertently clearing it.

The fix: `PUT` now uses `CASE WHEN notesProvided THEN newValue ELSE notes END` in the SQL, so fields absent from the request body are preserved. Explicit `null` values still clear the field as expected.

## Test plan

- [x] `GET /api/jobs` (default) and `?view=summary` both omit `notes`/`job_description`
- [x] `GET /api/jobs?view=full` includes `notes`/`job_description`
- [x] Unknown `view` values fall back to `summary`
- [x] `PUT /api/jobs/:id` preserves `notes`/`job_description` when absent from the body
- [x] `PUT /api/jobs/:id` clears `notes` when `null` is explicitly sent
- [x] After a status-change drag-and-drop, Kanban state has no `notes`/`job_description`
- [x] All 260 backend tests and 421 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)