### PR TITLE
fix(deploy): preserve backups/ folder during S3 frontend sync

### DIFF
--- a/frontend/scripts/deploy-frontend.sh
+++ b/frontend/scripts/deploy-frontend.sh
@@ -19,7 +19,7 @@ echo "Building frontend..."
 npm run build --prefix "${SCRIPT_ROOT}/.."
 
 echo "Syncing to S3..."
-aws s3 sync "${SCRIPT_ROOT}/../dist/" "s3://${S3_BUCKET}" --delete
+aws s3 sync "${SCRIPT_ROOT}/../dist/" "s3://${S3_BUCKET}" --delete --exclude "backups/*"
 
 echo "Invalidating CloudFront cache..."
 aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_ID}" --paths "/*"


### PR DESCRIPTION
## Summary

The `deploy:frontend` script was passing `--delete` to `aws s3 sync`, which removes any S3 objects not present in the local `dist/` folder. This would wipe out the `backups/` prefix where the daily DB backup cron job stores its files.

## Details

- Added `--exclude "backups/*"` to the `aws s3 sync` call in `frontend/scripts/deploy-frontend.sh` so the `backups/` prefix is skipped during both the upload sync and the `--delete` cleanup pass.

## Test plan

- [x] Run `deploy:frontend` and verify the `backups/` prefix in S3 is untouched after the deploy.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)