### PR TITLE
fix(JobDialog): disable backdrop click closing the modal

### DIFF
--- a/frontend/src/components/JobDialog.spec.tsx
+++ b/frontend/src/components/JobDialog.spec.tsx
@@ -172,6 +172,17 @@ describe("JobDialog", () => {
 			expect(DEFAULT_PROPS.onClose).toHaveBeenCalledTimes(1);
 		});
 
+		it("does not call onClose when backdrop is clicked", () => {
+			const { baseElement } = render(
+				<JobDialog {...DEFAULT_PROPS} jobId={null} />,
+			);
+			const backdrop = baseElement.querySelector(
+				".MuiBackdrop-root",
+			) as HTMLElement;
+			fireEvent.click(backdrop);
+			expect(DEFAULT_PROPS.onClose).not.toHaveBeenCalled();
+		});
+
 		it("does not call api.getJob in add mode", () => {
 			render(<JobDialog {...DEFAULT_PROPS} jobId={null} />);
 			expect(vi.mocked(api.getJob)).not.toHaveBeenCalled();

--- a/frontend/src/components/JobDialog.tsx
+++ b/frontend/src/components/JobDialog.tsx
@@ -141,7 +141,8 @@ export default function JobDialog({
 		};
 	}, [open, jobId]);
 
-	function handleClose() {
+	function handleClose(_: unknown, reason?: string) {
+		if (reason === "backdropClick") return;
 		abortRef.current?.abort();
 		onClose();
 	}


### PR DESCRIPTION
## Summary

- Modifies `handleClose` to check MUI's `reason` parameter and return early when `reason === "backdropClick"`
- Escape key and the X button continue to close the dialog as before

## Test plan
- [x] New unit test: clicking `.MuiBackdrop-root` does **not** call `onClose`
- [x] All 82 existing `JobDialog` tests still pass

Closes #74