### PR TITLE
feat(lint): expand oxlint with additional plugins and stricter categories

### DIFF
--- a/backend/routes/interviews.spec.ts
+++ b/backend/routes/interviews.spec.ts
@@ -790,6 +790,7 @@ describe("GET /api/interviews — cursor pagination (?after + ?limit)", () => {
 	it("returns at most ?limit interviews", async () => {
 		const jobId = await createJob();
 		for (let i = 1; i <= 5; i++) {
+			// eslint-disable-next-line no-await-in-loop
 			await req("post", `/api/jobs/${jobId}/interviews`).send({
 				...BASE_INTERVIEW,
 				interview_dttm: `2026-04-0${i}T10:00`,
@@ -805,6 +806,7 @@ describe("GET /api/interviews — cursor pagination (?after + ?limit)", () => {
 		const jobId = await createJob();
 		for (let i = 1; i <= 15; i++) {
 			const day = String(i).padStart(2, "0");
+			// eslint-disable-next-line no-await-in-loop
 			await req("post", `/api/jobs/${jobId}/interviews`).send({
 				...BASE_INTERVIEW,
 				interview_dttm: `2026-04-${day}T10:00`,

--- a/frontend/src/components/InterviewsPage.tsx
+++ b/frontend/src/components/InterviewsPage.tsx
@@ -52,6 +52,8 @@ const VIBE_LABELS: Record<InterviewVibe, string> = {
 	intense: "Intense",
 };
 
+const fmt = (d: Date) => d.toISOString().slice(0, 10);
+
 /**
  * Returns {from, to} strings (YYYY-MM-DD) covering today through the Sunday
  * after next Sunday — i.e. "this week and next week".
@@ -68,7 +70,6 @@ export function getDefaultDateRange(): { from: string; to: string } {
 	const sundayAfterNext = new Date(nextSunday);
 	sundayAfterNext.setDate(nextSunday.getDate() + 7);
 
-	const fmt = (d: Date) => d.toISOString().slice(0, 10);
 	return { from: fmt(today), to: fmt(sundayAfterNext) };
 }
 

--- a/frontend/src/components/InterviewsTab.tsx
+++ b/frontend/src/components/InterviewsTab.tsx
@@ -95,7 +95,7 @@ export default function InterviewsTab({
 		setLoading(true);
 		try {
 			const data = await api.getInterviews(jobId);
-			const sorted = [...data].sort((a, b) =>
+			const sorted = data.toSorted((a, b) =>
 				b.interview_dttm.localeCompare(a.interview_dttm),
 			);
 			setInterviews(sorted);
@@ -240,9 +240,9 @@ export default function InterviewsTab({
 
 	// ---- Date bucketing ----
 	const now = new Date();
-	const upcomingInterviews = [...interviews]
+	const upcomingInterviews = interviews
 		.filter((iv) => new Date(iv.interview_dttm) >= now)
-		.sort((a, b) => a.interview_dttm.localeCompare(b.interview_dttm));
+		.toSorted((a, b) => a.interview_dttm.localeCompare(b.interview_dttm));
 	// interviews is already sorted descending from load()
 	const priorInterviews = interviews.filter(
 		(iv) => new Date(iv.interview_dttm) < now,

--- a/frontend/src/components/JobManagementPage.tsx
+++ b/frontend/src/components/JobManagementPage.tsx
@@ -578,6 +578,7 @@ export default function JobManagementPage() {
 					{snack.message.includes("\n")
 						? snack.message
 								.split("\n")
+								// eslint-disable-next-line react/no-array-index-key
 								.map((line, i) => <div key={i}>{line}</div>)
 						: snack.message}
 				</Alert>

--- a/frontend/src/components/MarkdownField.tsx
+++ b/frontend/src/components/MarkdownField.tsx
@@ -70,7 +70,8 @@ export default function MarkdownField({
 				multiline
 				minRows={6}
 				placeholder={placeholder}
-				autoFocus={editing}
+				// eslint-disable-next-line jsx-a11y/no-autofocus -- user-initiated focus, not a surprise steal
+				autoFocus
 				slotProps={{
 					htmlInput: { style: { resize: "vertical" } },
 				}}

--- a/oxlint.json
+++ b/oxlint.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "vitest"],
+  "plugins": ["react", "typescript", "vitest", "import", "jsx-a11y", "unicorn"],
   "options": {
     "maxWarnings": 0
   },
@@ -11,7 +11,14 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "no-console": "warn",
-    "vitest/require-mock-type-parameters": "off"
+    "vitest/require-mock-type-parameters": "off",
+    "import/no-unassigned-import": ["error", { "allow": ["@testing-library/jest-dom"] }]
+  },
+  "categories": {
+    "correctness": "error",
+    "perf": "error",
+    //"restriction": "error", -- todo: Enable me
+    "suspicious": "error"
   },
   "overrides": [
     {


### PR DESCRIPTION
## Summary

Significantly expands the oxlint configuration beyond the initial import plugin, adding three more plugins and enabling stricter rule categories across the board.

## Details

**New plugins added to `oxlint.json`**
- `jsx-a11y` — accessibility rules for JSX
- `unicorn` — opinionated best-practice rules
- `import` — import/export correctness (already in prior PR, carried forward)

**Stricter categories**
- `correctness: error` and `suspicious: error` — broad correctness enforcement
- `perf: error` — performance anti-patterns

**Violation fixes**
- `import/no-unassigned-import`: allowlist `@testing-library/jest-dom` (intentional side-effect import)
- `jsx-a11y/no-autofocus`: suppress inline in `MarkdownField` — `autoFocus` is user-initiated here, not a surprise focus steal
- `unicorn/no-array-sort`: replace `[...arr].sort()` with `arr.toSorted()` in `InterviewsTab` (×2)
- `unicorn/consistent-function-scoping`: hoist `fmt` helper to module scope in `InterviewsPage`
- `perf/no-await-in-loop`: suppress in two pagination test loops — sequential insertion is intentional for ordering assertions
- `react/no-array-index-key`: suppress for newline-split display rendering in `JobManagementPage` — no meaningful key exists for display-only fragments

**`restriction` category investigated but not enabled** — flagged 1,200+ violations across 9+ rules that are a poor fit (e.g. `jsx-filename-extension` wanting `.jsx` instead of `.tsx`, `require-test-timeout` on every unit test, `no-relative-parent-imports` banning `../../`).

## Test plan

- [ ] `npm run lint` passes with 0 warnings and 0 errors
- [ ] `npm run tsc` passes with no type errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)