### PR TITLE
feat(interviews): render markdown in interview notes snippets

### DIFF
--- a/frontend/src/components/InterviewsPage.tsx
+++ b/frontend/src/components/InterviewsPage.tsx
@@ -17,6 +17,7 @@ import PhoneIcon from "@mui/icons-material/Phone";
 import { useNavigate } from "react-router-dom";
 import { api } from "../api";
 import { formatTime } from "../jobUtils";
+import MarkdownSnippet from "./MarkdownSnippet";
 import type {
 	EnrichedInterview,
 	InterviewStage,
@@ -591,7 +592,7 @@ function InterviewRow({
 							whiteSpace: "nowrap",
 						}}
 					>
-						{interview.interview_notes.split("\n")[0]}
+						<MarkdownSnippet text={interview.interview_notes} />
 					</Typography>
 				)}
 			</Box>

--- a/frontend/src/components/InterviewsTab.tsx
+++ b/frontend/src/components/InterviewsTab.tsx
@@ -30,6 +30,7 @@ import type {
 	InterviewVibe,
 } from "../types";
 import MarkdownField from "./MarkdownField";
+import MarkdownSnippet from "./MarkdownSnippet";
 import QuestionSubView from "./QuestionSubView";
 import { formatTime } from "../jobUtils";
 
@@ -701,7 +702,7 @@ function InterviewCard({
 								whiteSpace: "nowrap",
 							}}
 						>
-							{interview.interview_notes.split("\n")[0]}
+							<MarkdownSnippet text={interview.interview_notes} />
 						</Typography>
 					)}
 					<Button

--- a/frontend/src/components/MarkdownSnippet.tsx
+++ b/frontend/src/components/MarkdownSnippet.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+const INLINE_COMPONENTS = {
+	p: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+};
+
+/** Renders the first non-empty line of markdown text as inline content (no block wrappers). */
+export default function MarkdownSnippet({ text }: { text: string }) {
+	const firstLine = text.split("\n").find((l) => l.trim()) ?? "";
+	return (
+		<ReactMarkdown remarkPlugins={[remarkGfm]} components={INLINE_COMPONENTS}>
+			{firstLine}
+		</ReactMarkdown>
+	);
+}


### PR DESCRIPTION
## Summary

The one-line notes preview shown on interview cards (both in the job detail Interviews tab and the global Interviews page) was displaying raw markdown syntax instead of rendered output.

## Details

- Added a shared `MarkdownSnippet` component that renders the first non-empty line of a markdown string as inline content (using `react-markdown` + `remark-gfm`, already in the project)
- The `p` element is mapped to a React fragment to prevent block-level margins from breaking the single-line `text-overflow: ellipsis` truncation
- Used in `InterviewCard` (`InterviewsTab.tsx`) and `InterviewRow` (`InterviewsPage.tsx`)

## Test plan

- [ ] Open a job with interview notes containing markdown (e.g. `**bold**`, `_italic_`, `` `code` ``) — verify the snippet in the card renders styled text, not raw syntax
- [ ] Verify long notes are still truncated with an ellipsis at the card boundary
- [ ] Check the global Interviews page renders the same way in `InterviewRow`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)