### PR TITLE
refactor: rename /interviews route and nav label to /calendar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -79,7 +79,7 @@ export default function App() {
 						<Route path="/" element={<Navigate to="/jobs" replace />} />
 						<Route path="/jobs" element={<JobManagementPage />} />
 						<Route path="/jobs/:jobId" element={<JobManagementPage />} />
-						<Route path="/interviews" element={<InterviewsPage />} />
+						<Route path="/calendar" element={<InterviewsPage />} />
 						<Route path="/stats" element={<StatsPage />} />
 						<Route path="*" element={<Navigate to="/jobs" replace />} />
 					</Route>

--- a/frontend/src/components/AppShell.spec.tsx
+++ b/frontend/src/components/AppShell.spec.tsx
@@ -49,10 +49,10 @@ describe(AppShell, () => {
 		expect(screen.getByRole("button", { name: "Board" })).toBeInTheDocument();
 	});
 
-	it("renders the Interviews nav button", () => {
+	it("renders the Calendar nav button", () => {
 		renderAppShell();
 		expect(
-			screen.getByRole("button", { name: "Interviews" }),
+			screen.getByRole("button", { name: "Calendar" }),
 		).toBeInTheDocument();
 	});
 
@@ -72,10 +72,10 @@ describe(AppShell, () => {
 		expect(mockNavigate).toHaveBeenCalledWith("/jobs");
 	});
 
-	it("navigates to /interviews when Interviews is clicked", () => {
+	it("navigates to /calendar when Calendar is clicked", () => {
 		renderAppShell();
-		fireEvent.click(screen.getByRole("button", { name: "Interviews" }));
-		expect(mockNavigate).toHaveBeenCalledWith("/interviews");
+		fireEvent.click(screen.getByRole("button", { name: "Calendar" }));
+		expect(mockNavigate).toHaveBeenCalledWith("/calendar");
 	});
 
 	it("navigates to /stats when Stats is clicked", () => {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -25,8 +25,8 @@ const NAV_ITEMS = [
 	{ icon: <ViewKanbanOutlinedIcon />, label: "Board", path: "/jobs" },
 	{
 		icon: <CalendarMonthOutlinedIcon />,
-		label: "Interviews",
-		path: "/interviews",
+		label: "Calendar",
+		path: "/calendar",
 	},
 	{ icon: <InsightsIcon />, label: "Stats", path: "/stats" },
 ] as const;


### PR DESCRIPTION
## Summary

Renames the `/interviews` frontend route to `/calendar` and updates the navigation label from "Interviews" to "Calendar".

## Details

- `AppShell.tsx`: Updated `NAV_ITEMS` entry — path `/interviews` → `/calendar`, label `"Interviews"` → `"Calendar"`
- `App.tsx`: Updated route definition from `/interviews` to `/calendar`
- `AppShell.spec.tsx`: Updated two tests to match the new label and path

## Test plan

- [x] Nav rail shows "Calendar" tooltip (was "Interviews")
- [x] Clicking Calendar nav icon navigates to `/calendar`
- [x] `AppShell` unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)