### PR TITLE
feat: show company logos in interview cards and question bank table

### DIFF
--- a/frontend/src/components/InterviewsPage.tsx
+++ b/frontend/src/components/InterviewsPage.tsx
@@ -17,6 +17,7 @@ import PhoneIcon from "@mui/icons-material/Phone";
 import { useNavigate } from "react-router-dom";
 import { api } from "../api";
 import { formatTime } from "../jobUtils";
+import { fetchLogo, getCachedLogo } from "../logoCache";
 import MarkdownSnippet from "./MarkdownSnippet";
 import type {
 	EnrichedInterview,
@@ -484,6 +485,33 @@ export default function InterviewsPage() {
 	);
 }
 
+function CompanyLogo({ company }: { company: string }) {
+	const [entry, setEntry] = useState(() => getCachedLogo(company));
+
+	useEffect(() => {
+		void fetchLogo(company).then(setEntry);
+	}, [company]);
+
+	if (!entry || entry.status !== "resolved") {
+		return null;
+	}
+
+	return (
+		<Box
+			component="img"
+			src={entry.src}
+			alt={company}
+			sx={{
+				borderRadius: 0.5,
+				flexShrink: 0,
+				height: 24,
+				objectFit: "contain",
+				width: 24,
+			}}
+		/>
+	);
+}
+
 function InterviewRow({
 	interview,
 	onJobClick,
@@ -597,6 +625,7 @@ function InterviewRow({
 					</Typography>
 				)}
 			</Box>
+			<CompanyLogo company={interview.job.company} />
 		</Box>
 	);
 }

--- a/frontend/src/components/insights/QuestionBankTable.tsx
+++ b/frontend/src/components/insights/QuestionBankTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
 	Box,
 	Chip,
@@ -14,6 +14,7 @@ import {
 	Tooltip,
 	Typography,
 } from "@mui/material";
+import { fetchLogo, getCachedLogo } from "../../logoCache";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
 import RemoveIcon from "@mui/icons-material/Remove";
@@ -33,6 +34,33 @@ const TYPE_LABELS: Record<string, string> = {
 	system_design: "System Design",
 	technical: "Technical",
 };
+
+function CompanyLogo({ company }: { company: string }) {
+	const [entry, setEntry] = useState(() => getCachedLogo(company));
+
+	useEffect(() => {
+		void fetchLogo(company).then(setEntry);
+	}, [company]);
+
+	if (!entry || entry.status !== "resolved") {
+		return null;
+	}
+
+	return (
+		<Box
+			component="img"
+			src={entry.src}
+			alt={company}
+			sx={{
+				borderRadius: 0.5,
+				flexShrink: 0,
+				height: 20,
+				objectFit: "contain",
+				width: 20,
+			}}
+		/>
+	);
+}
 
 function DifficultyStars({ difficulty }: { difficulty: number }) {
 	return (
@@ -190,9 +218,14 @@ export default function QuestionBankTable({ recentQuestions }: Props) {
 									</Tooltip>
 								</TableCell>
 								<TableCell>
-									<Typography variant="body2" noWrap>
-										{q.company}
-									</Typography>
+									<Box
+										sx={{ alignItems: "center", display: "flex", gap: 0.75 }}
+									>
+										<CompanyLogo company={q.company} />
+										<Typography variant="body2" noWrap>
+											{q.company}
+										</Typography>
+									</Box>
 									<Typography variant="caption" color="text.secondary" noWrap>
 										{q.role}
 									</Typography>


### PR DESCRIPTION
## Summary

Add company logo display to two views that show interview data, using the existing `logoCache.ts` module.

## Details

- **Upcoming Interviews (`InterviewsPage`)** — logo appears in the top-right corner of each interview card, keeping clear of the left-aligned content
- **Question Bank table (`QuestionBankTable`)** — logo appears inline to the left of the company name in the Company column
- Both views use a shared `CompanyLogo` component pattern: synchronous cache lookup on first render via `getCachedLogo`, then a `useEffect` call to `fetchLogo` (which short-circuits if already cached); renders `null` until resolved so rows/cards without a matching logo are visually unaffected

## Test plan

- [ ] Open Upcoming Interviews — verify logos appear in the top-right of cards for companies that have logos
- [ ] Open Interview Insights → Question Bank — verify logos appear beside company names in the table
- [ ] Confirm cards/rows with no matching logo render normally with no broken image

🤖 Generated with [Claude Code](https://claude.ai/claude-code)