### PR TITLE
feat: Add Interview modal defaults for Stage and Type

### DIFF
--- a/frontend/src/components/InterviewsTab.spec.tsx
+++ b/frontend/src/components/InterviewsTab.spec.tsx
@@ -46,6 +46,7 @@ const INTERVIEW_B = makeInterview({
 
 const DEFAULT_PROPS = {
 	jobId: 42,
+	jobStatus: "Not started" as const,
 	onCountChange: vi.fn(),
 	onViewingQuestionsChange: vi.fn(),
 	viewingQuestionsFor: null,
@@ -273,6 +274,76 @@ describe(InterviewsTab, () => {
 					screen.getByText("Failed to save. Please try again."),
 				).toBeInTheDocument();
 			});
+		});
+	});
+
+	describe("smart defaults based on job status", () => {
+		async function openAddFormWithStatus(jobStatus: string) {
+			vi.mocked(api.createInterview).mockResolvedValue(
+				makeInterview({ id: 99 }),
+			);
+			vi.mocked(api.getInterviews)
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			render(
+				<InterviewsTab
+					{...DEFAULT_PROPS}
+					jobStatus={jobStatus as "Not started"}
+				/>,
+			);
+			await waitFor(() =>
+				screen.getByRole("button", { name: /Add Interview/i }),
+			);
+			fireEvent.click(screen.getByRole("button", { name: /Add Interview/i }));
+			fireEvent.change(screen.getByLabelText(/Date & Time/i), {
+				target: { value: "2026-04-01T10:00" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Save Interview" }));
+			await waitFor(() => expect(api.createInterview).toHaveBeenCalled());
+		}
+
+		it("defaults stage to phone_screen and type to recruiter_call for Not started", async () => {
+			await openAddFormWithStatus("Not started");
+			expect(api.createInterview).toHaveBeenCalledWith(
+				42,
+				expect.objectContaining({
+					interview_stage: "phone_screen",
+					interview_type: "recruiter_call",
+				}),
+			);
+		});
+
+		it("defaults stage to phone_screen and type to recruiter_call for Applied", async () => {
+			await openAddFormWithStatus("Applied");
+			expect(api.createInterview).toHaveBeenCalledWith(
+				42,
+				expect.objectContaining({
+					interview_stage: "phone_screen",
+					interview_type: "recruiter_call",
+				}),
+			);
+		});
+
+		it("defaults stage to onsite and type to null for Phone screen", async () => {
+			await openAddFormWithStatus("Phone screen");
+			expect(api.createInterview).toHaveBeenCalledWith(
+				42,
+				expect.objectContaining({
+					interview_stage: "onsite",
+					interview_type: null,
+				}),
+			);
+		});
+
+		it("defaults stage to onsite and type to null for Interviewing", async () => {
+			await openAddFormWithStatus("Interviewing");
+			expect(api.createInterview).toHaveBeenCalledWith(
+				42,
+				expect.objectContaining({
+					interview_stage: "onsite",
+					interview_type: null,
+				}),
+			);
 		});
 	});
 

--- a/frontend/src/components/InterviewsTab.tsx
+++ b/frontend/src/components/InterviewsTab.tsx
@@ -28,6 +28,7 @@ import type {
 	InterviewStage,
 	InterviewType,
 	InterviewVibe,
+	JobStatus,
 } from "../types";
 import MarkdownField from "./MarkdownField";
 import MarkdownSnippet from "./MarkdownSnippet";
@@ -144,21 +145,25 @@ const FEELING_OPTIONS: {
 	},
 ];
 
-const EMPTY_FORM: InterviewFormData = {
-	interview_dttm: "",
-	interview_interviewers: null,
-	interview_notes: null,
-	interview_stage: "phone_screen",
-	interview_type: null,
-	interview_vibe: null,
-	interview_result: null,
-	interview_feeling: null,
-};
+function makeEmptyForm(jobStatus: JobStatus): InterviewFormData {
+	const isEarly = jobStatus === "Not started" || jobStatus === "Applied";
+	return {
+		interview_dttm: "",
+		interview_interviewers: null,
+		interview_notes: null,
+		interview_stage: isEarly ? "phone_screen" : "onsite",
+		interview_type: isEarly ? "recruiter_call" : null,
+		interview_vibe: null,
+		interview_result: null,
+		interview_feeling: null,
+	};
+}
 
 type Mode = "list" | "add" | { editId: number } | { confirmDeleteId: number };
 
 interface Props {
 	jobId: number;
+	jobStatus: JobStatus;
 	onCountChange: (count: number) => void;
 	viewingQuestionsFor: Interview | null;
 	onViewingQuestionsChange: (interview: Interview | null) => void;
@@ -166,6 +171,7 @@ interface Props {
 
 export default function InterviewsTab({
 	jobId,
+	jobStatus,
 	onCountChange,
 	viewingQuestionsFor,
 	onViewingQuestionsChange,
@@ -173,7 +179,9 @@ export default function InterviewsTab({
 	const [interviews, setInterviews] = useState<Interview[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [mode, setMode] = useState<Mode>("list");
-	const [form, setForm] = useState<InterviewFormData>(EMPTY_FORM);
+	const [form, setForm] = useState<InterviewFormData>(() =>
+		makeEmptyForm(jobStatus),
+	);
 	const [formError, setFormError] = useState<string | null>(null);
 	const [saving, setSaving] = useState(false);
 	const [questionCounts, setQuestionCounts] = useState<Record<number, number>>(
@@ -251,7 +259,7 @@ export default function InterviewsTab({
 	}
 
 	function handleAddClick() {
-		setForm(EMPTY_FORM);
+		setForm(makeEmptyForm(jobStatus));
 		setFormError(null);
 		setMode("add");
 	}

--- a/frontend/src/components/JobDialog.tsx
+++ b/frontend/src/components/JobDialog.tsx
@@ -663,6 +663,7 @@ export default function JobDialog({
 						{isEdit && activeTab === 1 && (
 							<InterviewsTab
 								jobId={jobId!}
+								jobStatus={form.status}
 								onCountChange={setInterviewCount}
 								viewingQuestionsFor={viewingQuestionsFor}
 								onViewingQuestionsChange={setViewingQuestionsFor}


### PR DESCRIPTION
## Summary
The "Add Interview" modal should default a couple of fields for new interviews when the job is in certain statuses:

1. When in `Not Started` and `Applied`, it should default to stage = `Phone Screen`, type = `Recruiter Call`.
2. When in any other status, it should default to stage = `Onsite` but still with an unspecified type.

## Details
Like it says on the tin.
