### PR TITLE
feat: flag possibly-ghosted jobs with a red accent on Kanban cards

### DIFF
--- a/frontend/src/components/JobCard.spec.tsx
+++ b/frontend/src/components/JobCard.spec.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { fireEvent, render, screen } from "@testing-library/react";
 import JobCard from "./JobCard";
 import type { Job } from "../types";
@@ -226,6 +227,140 @@ describe(JobCard, () => {
 				/>,
 			);
 			expect(screen.queryByText("Remote")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("possibly ghosted chip", () => {
+		// Pin time so dates relative to "now" are deterministic
+		const NOW = new Date("2026-01-31T00:00:00.000Z").getTime();
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(NOW);
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("shows 'Possibly ghosted' chip when Applied with old date_applied", () => {
+			render(
+				<JobCard
+					job={{ ...BASE_JOB, status: "Applied", date_applied: "2024-12-31" }}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.getByText("👻 Possibly ghosted")).toBeInTheDocument();
+		});
+
+		it("shows 'Possibly ghosted' chip for Phone screen with old date_phone_screen", () => {
+			render(
+				<JobCard
+					job={{
+						...BASE_JOB,
+						status: "Phone screen",
+						date_phone_screen: "2024-12-31",
+					}}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.getByText("👻 Possibly ghosted")).toBeInTheDocument();
+		});
+
+		it("shows 'Possibly ghosted' chip for Interviewing with old date_last_onsite", () => {
+			render(
+				<JobCard
+					job={{
+						...BASE_JOB,
+						status: "Interviewing",
+						date_last_onsite: "2024-12-31",
+					}}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.getByText("👻 Possibly ghosted")).toBeInTheDocument();
+		});
+
+		it("does not show chip when date is within 30 days", () => {
+			render(
+				<JobCard
+					job={{ ...BASE_JOB, status: "Applied", date_applied: "2026-01-20" }}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.queryByText("👻 Possibly ghosted")).not.toBeInTheDocument();
+		});
+
+		it("does not show chip for 'Not started' even with old dates", () => {
+			render(
+				<JobCard
+					job={{
+						...BASE_JOB,
+						status: "Not started",
+						date_applied: "2024-12-31",
+					}}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.queryByText("👻 Possibly ghosted")).not.toBeInTheDocument();
+		});
+
+		it("does not show chip for 'Offer!' even with old dates", () => {
+			render(
+				<JobCard
+					job={{ ...BASE_JOB, status: "Offer!", date_applied: "2024-12-31" }}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.queryByText("👻 Possibly ghosted")).not.toBeInTheDocument();
+		});
+
+		it("does not show chip for 'Rejected/Withdrawn' even with old dates", () => {
+			render(
+				<JobCard
+					job={{
+						...BASE_JOB,
+						status: "Rejected/Withdrawn",
+						date_applied: "2024-12-31",
+					}}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.queryByText("👻 Possibly ghosted")).not.toBeInTheDocument();
+		});
+
+		it("does not show chip when all dates are null", () => {
+			render(
+				<JobCard
+					job={{ ...BASE_JOB, status: "Applied" }}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.queryByText("👻 Possibly ghosted")).not.toBeInTheDocument();
+		});
+
+		it("does not show chip when most recent date is within 30 days even if others are old", () => {
+			render(
+				<JobCard
+					job={{
+						...BASE_JOB,
+						status: "Phone screen",
+						date_applied: "2024-12-31",
+						date_phone_screen: "2026-01-20",
+					}}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.queryByText("👻 Possibly ghosted")).not.toBeInTheDocument();
 		});
 	});
 

--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -19,6 +19,7 @@ import PeopleIcon from "@mui/icons-material/People";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import type { FitScore, Job, JobStatus } from "../types";
 import { STATUS_COLORS, TAG_LABELS, tagChipProps } from "../constants";
+import { isPossiblyGhosted } from "../jobUtils";
 
 function formatDate(dateStr: string | null): string | null {
 	if (!dateStr) {
@@ -128,6 +129,8 @@ const JobCard = React.memo(function JobCard({
 			id: String(job.id),
 		});
 
+	const isGhosted = isPossiblyGhosted(job);
+
 	const style = {
 		opacity: isDragging ? 0.4 : 1,
 		transform: CSS.Translate.toString(transform),
@@ -140,8 +143,11 @@ const JobCard = React.memo(function JobCard({
 			elevation={0}
 			sx={{
 				"&:hover": {
-					boxShadow: `0 0 0 1px rgba(99,102,241,0.3), 0 4px 12px rgba(0,0,0,0.1)`,
+					boxShadow: isGhosted
+						? `inset 3px 0 0 #ef5350, 0 0 0 1px rgba(239,83,80,0.5), 0 4px 12px rgba(239,83,80,0.2)`
+						: `0 0 0 1px rgba(99,102,241,0.3), 0 4px 12px rgba(0,0,0,0.1)`,
 				},
+				boxShadow: isGhosted ? "inset 3px 0 0 #ef5350" : undefined,
 				mb: 1.5,
 				transition: "box-shadow 0.15s",
 			}}
@@ -269,6 +275,16 @@ const JobCard = React.memo(function JobCard({
 								variant="outlined"
 								sx={{ maxWidth: 120 }}
 							/>
+						)}
+						{isGhosted && (
+							<Tooltip title="No company response in 30+ days">
+								<Chip
+									label="👻 Possibly ghosted"
+									size="small"
+									variant="outlined"
+									sx={{ borderColor: "#ef5350", color: "#ef5350" }}
+								/>
+							</Tooltip>
 						)}
 					</Box>
 

--- a/frontend/src/jobUtils.spec.ts
+++ b/frontend/src/jobUtils.spec.ts
@@ -1,4 +1,140 @@
-import { formatTime } from "./jobUtils";
+import { formatTime, isPossiblyGhosted } from "./jobUtils";
+import type { Job } from "./types";
+
+// 2026-01-31 — all "old" dates in these tests are Jan 1 (30 days prior, not ghosted)
+// Or Dec 31 (31 days prior, ghosted). Recent dates use Feb 1 (future = 0 days ago).
+const NOW = new Date("2026-01-31T00:00:00.000Z").getTime();
+
+const BASE_JOB: Job = {
+	id: 1,
+	company: "Acme",
+	role: "Engineer",
+	link: "https://example.com",
+	status: "Applied",
+	fit_score: null,
+	salary: null,
+	date_applied: null,
+	date_phone_screen: null,
+	date_last_onsite: null,
+	referred_by: null,
+	recruiter: null,
+	notes: null,
+	job_description: null,
+	ending_substatus: null,
+	favorite: false,
+	tags: [],
+	created_at: "2025-01-01T00:00:00.000Z",
+	updated_at: "2025-01-01T00:00:00.000Z",
+};
+
+describe(isPossiblyGhosted, () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns false for 'Not started' regardless of dates", () => {
+		expect(
+			isPossiblyGhosted({
+				...BASE_JOB,
+				status: "Not started",
+				date_applied: "2024-12-31",
+			}),
+		).toBeFalsy();
+	});
+
+	it("returns false for 'Offer!' regardless of dates", () => {
+		expect(
+			isPossiblyGhosted({
+				...BASE_JOB,
+				status: "Offer!",
+				date_applied: "2024-12-31",
+			}),
+		).toBeFalsy();
+	});
+
+	it("returns false for 'Rejected/Withdrawn' regardless of dates", () => {
+		expect(
+			isPossiblyGhosted({
+				...BASE_JOB,
+				status: "Rejected/Withdrawn",
+				date_applied: "2024-12-31",
+			}),
+		).toBeFalsy();
+	});
+
+	it("returns false when all dates are null (no data)", () => {
+		expect(isPossiblyGhosted({ ...BASE_JOB, status: "Applied" })).toBeFalsy();
+	});
+
+	it("returns true for Applied when date_applied is 31 days ago", () => {
+		expect(
+			isPossiblyGhosted({
+				...BASE_JOB,
+				status: "Applied",
+				date_applied: "2024-12-31",
+			}),
+		).toBeTruthy();
+	});
+
+	it("returns false for Applied when date_applied is exactly 30 days ago", () => {
+		expect(
+			isPossiblyGhosted({
+				...BASE_JOB,
+				status: "Applied",
+				date_applied: "2026-01-01",
+			}),
+		).toBeFalsy();
+	});
+
+	it("returns true for 'Phone screen' when date_phone_screen is 31 days ago", () => {
+		expect(
+			isPossiblyGhosted({
+				...BASE_JOB,
+				status: "Phone screen",
+				date_phone_screen: "2024-12-31",
+			}),
+		).toBeTruthy();
+	});
+
+	it("returns true for Interviewing when date_last_onsite is 31 days ago", () => {
+		expect(
+			isPossiblyGhosted({
+				...BASE_JOB,
+				status: "Interviewing",
+				date_last_onsite: "2024-12-31",
+			}),
+		).toBeTruthy();
+	});
+
+	it("uses the most recent date when multiple dates are set", () => {
+		// Date_applied is old but date_phone_screen is recent — not ghosted
+		expect(
+			isPossiblyGhosted({
+				...BASE_JOB,
+				status: "Phone screen",
+				date_applied: "2024-12-31",
+				date_phone_screen: "2026-01-20",
+			}),
+		).toBeFalsy();
+	});
+
+	it("returns true when all dates are old, using the most recent one", () => {
+		expect(
+			isPossiblyGhosted({
+				...BASE_JOB,
+				status: "Interviewing",
+				date_applied: "2024-11-01",
+				date_phone_screen: "2024-11-15",
+				date_last_onsite: "2024-12-31",
+			}),
+		).toBeTruthy();
+	});
+});
 
 describe(formatTime, () => {
 	beforeEach(() => {

--- a/frontend/src/jobUtils.ts
+++ b/frontend/src/jobUtils.ts
@@ -1,5 +1,34 @@
 import type { Job, JobStatus } from "./types";
 
+const GHOSTABLE_STATUSES = new Set<JobStatus>([
+	"Applied",
+	"Phone screen",
+	"Interviewing",
+]);
+const GHOSTED_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Returns true if a job is in an active status but hasn't had any company
+ * communication (date_applied, date_phone_screen, date_last_onsite) in > 30 days.
+ */
+export function isPossiblyGhosted(job: Job): boolean {
+	if (!GHOSTABLE_STATUSES.has(job.status)) {
+		return false;
+	}
+	const timestamps = [
+		job.date_applied,
+		job.date_phone_screen,
+		job.date_last_onsite,
+	]
+		.filter((d): d is string => d !== null)
+		.map((d) => new Date(d).getTime())
+		.filter((t) => !isNaN(t));
+	if (timestamps.length === 0) {
+		return false;
+	}
+	return Date.now() - Math.max(...timestamps) > GHOSTED_THRESHOLD_MS;
+}
+
 export function formatTime(dttm: string): string {
 	const d = new Date(dttm);
 	if (isNaN(d.getTime())) {


### PR DESCRIPTION
## Summary

Adds a visual "possibly ghosted" indicator to Kanban job cards for jobs that are in an active status (Applied, Phone screen, or Interviewing) but have had no company-side communication in more than 30 days.

## Details

- **`jobUtils.ts`** — new `isPossiblyGhosted(job)` utility that computes `Math.max()` of `date_applied`, `date_phone_screen`, and `date_last_onsite` and returns `true` if that date is > 30 days in the past. Returns `false` for terminal/non-started statuses and when all three dates are null.
- **`JobCard.tsx`** — when a card is possibly ghosted:
  - A `👻 Possibly ghosted` chip (red outlined, tooltip: "No company response in 30+ days") appears in the chips row
  - The card gets a 3px red left-stripe via inset `box-shadow`
  - On hover, the glow shifts to a red tint instead of the default indigo

## Test plan

- [x] Open the Kanban board with a job in Applied/Phone screen/Interviewing whose most recent communication date is > 30 days ago — confirm the chip and red stripe appear
- [x] Confirm jobs in Not started, Offer!, and Rejected/Withdrawn never show the indicator regardless of dates
- [x] Confirm a recently-updated job in an active status shows no indicator
- [x] Confirm that when multiple dates are set, only the most recent one is used for the 30-day check

🤖 Generated with [Claude Code](https://claude.ai/claude-code)