### PR TITLE
feat: add FAANG Radar page with reapplication cooldown tracking

### DIFF
--- a/backend/bin/company.ts
+++ b/backend/bin/company.ts
@@ -1,0 +1,165 @@
+// CLI for managing the target_companies table.
+//
+// Usage:
+//   tsx backend/bin/company.ts <subcommand> [args]
+//
+// Subcommands:
+//   list [--tier <tier>]               List all companies with cooldown columns.
+//                                      --tier filters by tier: faang | faang_adjacent | custom
+//   show <name>                        Print all fields for a single company.
+//   set  <name> <column> <value>       Update one column for a company.
+//                                      Pass "null" as value to clear the field.
+//   help                               Print this usage text.
+//
+// Writable columns for `set`:
+//   application_cooldown_days     phone_screen_cooldown_days    onsite_cooldown_days
+//   max_apps_per_period           apps_period_days              policy_summary
+//   policy_url                    policy_confidence             policy_updated_at
+//   user_notes                    hidden                        tier
+//
+// Examples:
+//   tsx backend/bin/company.ts list
+//   tsx backend/bin/company.ts list --tier faang
+//   tsx backend/bin/company.ts show "Google"
+//   tsx backend/bin/company.ts set "Google" application_cooldown_days 365
+//   tsx backend/bin/company.ts set "Google" user_notes "null"
+
+import Database from "better-sqlite3";
+import { join } from "node:path";
+
+const USAGE = `Usage: tsx backend/bin/company.ts <subcommand> [args]
+
+Subcommands:
+  list [--tier <tier>]               List all companies with cooldown columns.
+                                     --tier filters by tier: faang | faang_adjacent | custom
+  show <name>                        Print all fields for a single company.
+  set  <name> <column> <value>       Update one column for a company.
+                                     Pass "null" as value to clear the field.
+  help                               Print this usage text.
+
+Writable columns for \`set\`:
+  application_cooldown_days     phone_screen_cooldown_days    onsite_cooldown_days
+  max_apps_per_period           apps_period_days              policy_summary
+  policy_url                    policy_confidence             policy_updated_at
+  user_notes                    hidden                        tier
+
+Examples:
+  tsx backend/bin/company.ts list
+  tsx backend/bin/company.ts list --tier faang
+  tsx backend/bin/company.ts show "Google"
+  tsx backend/bin/company.ts set "Google" application_cooldown_days 365
+  tsx backend/bin/company.ts set "Google" user_notes null`;
+
+const WRITABLE_COLUMNS = new Set([
+  "application_cooldown_days",
+  "phone_screen_cooldown_days",
+  "onsite_cooldown_days",
+  "max_apps_per_period",
+  "apps_period_days",
+  "policy_summary",
+  "policy_url",
+  "policy_confidence",
+  "policy_updated_at",
+  "user_notes",
+  "hidden",
+  "tier",
+]);
+
+const db = new Database(join(import.meta.dirname, "../jobman.db"), {
+  readonly: false,
+});
+
+const [, , subcommand, ...rest] = process.argv;
+
+function die(msg: string): never {
+  console.error(`Error: ${msg}`);
+  process.exit(1);
+}
+
+function cmdList(args: string[]) {
+  let tier: string | null = null;
+  if (args[0] === "--tier") {
+    if (!args[1]) die("--tier requires a value");
+    tier = args[1];
+  }
+
+  const rows = tier
+    ? db
+        .prepare(
+          "SELECT name, tier, application_cooldown_days, phone_screen_cooldown_days, onsite_cooldown_days, user_notes FROM target_companies WHERE tier = ? ORDER BY name"
+        )
+        .all(tier)
+    : db
+        .prepare(
+          "SELECT name, tier, application_cooldown_days, phone_screen_cooldown_days, onsite_cooldown_days, user_notes FROM target_companies ORDER BY tier, name"
+        )
+        .all();
+
+  if (rows.length === 0) {
+    console.log(tier ? `No companies found with tier "${tier}".` : "No companies found.");
+    return;
+  }
+
+  console.table(rows);
+}
+
+function cmdShow(args: string[]) {
+  const [name] = args;
+  if (!name) die('show requires a company name, e.g.: show "Google"');
+
+  const row = db
+    .prepare("SELECT * FROM target_companies WHERE name = ?")
+    .get(name);
+
+  if (!row) die(`No company found with name "${name}"`);
+
+  console.log(row);
+}
+
+function cmdSet(args: string[]) {
+  const [name, column, rawValue] = args;
+  if (!name || !column || rawValue === undefined) {
+    die('set requires: <name> <column> <value>, e.g.: set "Google" application_cooldown_days 365');
+  }
+
+  if (!WRITABLE_COLUMNS.has(column)) {
+    die(
+      `"${column}" is not a writable column.\n\nWritable columns:\n  ${[...WRITABLE_COLUMNS].join(", ")}`
+    );
+  }
+
+  const existing = db
+    .prepare("SELECT id FROM target_companies WHERE name = ?")
+    .get(name);
+  if (!existing) die(`No company found with name "${name}"`);
+
+  const value = rawValue === "null" ? null : rawValue;
+
+  db.prepare(`UPDATE target_companies SET ${column} = ? WHERE name = ?`).run(
+    value,
+    name
+  );
+
+  console.log(`Updated "${name}" — ${column} = ${value === null ? "NULL" : JSON.stringify(value)}`);
+}
+
+switch (subcommand) {
+  case "list":
+    cmdList(rest);
+    break;
+  case "show":
+    cmdShow(rest);
+    break;
+  case "set":
+    cmdSet(rest);
+    break;
+  case "help":
+  case "--help":
+  case "-h":
+    console.log(USAGE);
+    break;
+  default:
+    console.error(subcommand ? `Unknown subcommand: "${subcommand}"\n` : "");
+    console.error(USAGE);
+    process.exit(1);
+}

--- a/backend/db.ts
+++ b/backend/db.ts
@@ -99,6 +99,25 @@ db.exec(`
   );
 
   CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
+
+  CREATE TABLE IF NOT EXISTS target_companies (
+    id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+    name                       TEXT    NOT NULL UNIQUE,
+    tier                       TEXT    NOT NULL DEFAULT 'faang_adjacent'
+                                       CHECK(tier IN ('faang', 'faang_adjacent', 'custom')),
+    application_cooldown_days  INTEGER,
+    phone_screen_cooldown_days INTEGER,
+    onsite_cooldown_days       INTEGER,
+    max_apps_per_period        INTEGER,
+    apps_period_days           INTEGER,
+    policy_summary             TEXT,
+    policy_url                 TEXT,
+    policy_confidence          TEXT
+                               CHECK(policy_confidence IN ('official', 'community', 'estimate')),
+    policy_updated_at          TEXT,
+    user_notes                 TEXT,
+    hidden                     INTEGER NOT NULL DEFAULT 0
+  );
 `);
 
 // One-time backfill: synthesise history rows from existing date columns for
@@ -175,6 +194,60 @@ db.exec(`
     AND job_id IN (
       SELECT id FROM jobs WHERE status = 'Not started'
     );
+`);
+
+// Seed target companies (INSERT OR IGNORE — safe to re-run)
+db.exec(`
+  INSERT OR IGNORE INTO target_companies
+    (name, tier, application_cooldown_days, phone_screen_cooldown_days, onsite_cooldown_days, policy_summary, policy_confidence)
+  VALUES
+    ('Google',     'faang',          90,   180,  365, '90-day reapplication window; 6 months after phone screen; 12 months after onsite', 'community'),
+    ('Meta',       'faang',          NULL, 180,  365, '6 months after phone screen rejection; 12 months after onsite rejection',          'community'),
+    ('Apple',      'faang',          180,  180,  180, '6 months across all rejection stages',                                             'community'),
+    ('Amazon',     'faang',          180,  180,  180, '6 months after any rejection',                                                     'community'),
+    ('Netflix',    'faang',          NULL, NULL, 180, 'No formal policy; ~6 months informal cooling period after rejection',              'estimate'),
+    ('Microsoft',  'faang',          90,   90,   180, '3 months after application or phone screen; 6 months after onsite',               'estimate'),
+    ('Uber',       'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Lyft',       'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Snap',       'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Twitter/X',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Salesforce', 'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Adobe',      'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Stripe',     'faang_adjacent', NULL, 180,  180, '6 months after rejection',                                                        'community'),
+    ('Airbnb',     'faang_adjacent', NULL, 180,  365, '6 months after phone screen; 12 months after onsite rejection',                   'community'),
+    ('DoorDash',   'faang_adjacent', NULL, NULL, 180, '~6 months after rejection',                                                       'estimate'),
+    ('Instacart',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Databricks', 'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('OpenAI',     'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Anthropic',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Nvidia',     'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Palantir',   'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('LinkedIn',   'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Spotify',    'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Block',      'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Coinbase',   'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Robinhood',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Pinterest',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Reddit',     'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Twilio',     'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Okta',       'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Datadog',    'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('MongoDB',    'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Confluent',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Snowflake',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('ServiceNow', 'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Workday',    'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Atlassian',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Cloudflare', 'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Twitch',     'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('GitHub',     'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('GitLab',     'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('HashiCorp',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Figma',      'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Notion',     'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Airtable',   'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Rippling',   'faang_adjacent', NULL, NULL, NULL, NULL, NULL),
+    ('Scale AI',   'faang_adjacent', NULL, NULL, NULL, NULL, NULL);
 `);
 
 export default db;

--- a/backend/db/radar.ts
+++ b/backend/db/radar.ts
@@ -1,0 +1,372 @@
+import type Database from "better-sqlite3";
+
+interface TargetCompanyRow {
+	id: number;
+	name: string;
+	tier: string;
+	application_cooldown_days: number | null;
+	phone_screen_cooldown_days: number | null;
+	onsite_cooldown_days: number | null;
+	max_apps_per_period: number | null;
+	apps_period_days: number | null;
+	policy_summary: string | null;
+	policy_url: string | null;
+	policy_confidence: string | null;
+	policy_updated_at: string | null;
+	user_notes: string | null;
+	hidden: number;
+}
+
+interface JobRow {
+	id: number;
+	company_key: string;
+	role: string;
+	status: string;
+	date_applied: string | null;
+}
+
+interface RejectedJobRow {
+	company_key: string;
+	rejection_date: string;
+	rejection_stage: string;
+}
+
+interface LastInterviewRow {
+	company_key: string;
+	last_dttm: string;
+}
+
+interface LastAppRow {
+	company_key: string;
+	date_applied: string | null;
+}
+
+export interface RadarJobSummary {
+	id: number;
+	role: string;
+	status: string;
+	date_applied: string | null;
+}
+
+export interface RadarPolicy {
+	application_cooldown_days: number | null;
+	phone_screen_cooldown_days: number | null;
+	onsite_cooldown_days: number | null;
+	max_apps_per_period: number | null;
+	apps_period_days: number | null;
+	summary: string | null;
+	url: string | null;
+	confidence: "official" | "community" | "estimate" | null;
+	updated_at: string | null;
+}
+
+export interface RadarEntry {
+	id: number;
+	name: string;
+	tier: "faang" | "faang_adjacent" | "custom";
+	eligibility: "active" | "cooling_down" | "clear" | "no_history" | "limit_reached";
+	unlock_date: string | null;
+	days_until_unlock: number | null;
+	last_application_date: string | null;
+	last_interview_date: string | null;
+	latest_active_status: string | null;
+	active_job_id: number | null;
+	jobs: RadarJobSummary[];
+	policy: RadarPolicy;
+	user_notes: string | null;
+	hidden: boolean;
+}
+
+export interface RadarResponse {
+	entries: RadarEntry[];
+	generated_at: string;
+}
+
+export type RadarPatch = Partial<{
+	hidden: number;
+	user_notes: string | null;
+	application_cooldown_days: number | null;
+	phone_screen_cooldown_days: number | null;
+	onsite_cooldown_days: number | null;
+	max_apps_per_period: number | null;
+	apps_period_days: number | null;
+	policy_summary: string | null;
+	policy_url: string | null;
+	policy_confidence: string | null;
+	policy_updated_at: string | null;
+}>;
+
+const PATCH_ALLOWLIST = new Set([
+	"hidden",
+	"user_notes",
+	"application_cooldown_days",
+	"phone_screen_cooldown_days",
+	"onsite_cooldown_days",
+	"max_apps_per_period",
+	"apps_period_days",
+	"policy_summary",
+	"policy_url",
+	"policy_confidence",
+	"policy_updated_at",
+]);
+
+function addUnlock(
+	candidates: Date[],
+	dateStr: string | null | undefined,
+	days: number | null | undefined,
+): void {
+	if (!dateStr || !days) {return;}
+	const d = new Date(dateStr.slice(0, 10));
+	if (isNaN(d.getTime())) {return;}
+	d.setDate(d.getDate() + days);
+	candidates.push(d);
+}
+
+export function getRadar(
+	db: Database.Database,
+	userId: number,
+	includeHidden = false,
+): RadarResponse {
+	const companies = db
+		.prepare(
+			`SELECT * FROM target_companies ${includeHidden ? "" : "WHERE hidden = 0"}
+       ORDER BY (CASE tier WHEN 'faang' THEN 0 ELSE 1 END), name ASC`,
+		)
+		.all() as TargetCompanyRow[];
+
+	// All user jobs — exclude Rejected/Withdrawn entries that aren't the
+	// Applicant's fault (job closed) or aren't meaningful rejections (not a good fit)
+	const allJobs = db
+		.prepare(
+			`SELECT id, lower(company) as company_key, role, status, date_applied
+       FROM jobs WHERE user_id = ?
+         AND NOT (status = 'Rejected/Withdrawn'
+           AND ending_substatus IN ('Job closed', 'Not a good fit'))
+       ORDER BY date_applied DESC, created_at DESC`,
+		)
+		.all(userId) as JobRow[];
+
+	// Most recent application date per company (including rejected jobs)
+	const lastAppRows = db
+		.prepare(
+			`SELECT lower(company) as company_key, MAX(date_applied) as date_applied
+       FROM jobs WHERE user_id = ? AND date_applied IS NOT NULL
+       GROUP BY lower(company)`,
+		)
+		.all(userId) as LastAppRow[];
+
+	// Rejected jobs with the stage they reached — exclude user-initiated exits
+	const rejectedJobs = db
+		.prepare(
+			`SELECT
+         lower(j.company) as company_key,
+         h_rej.entered_at as rejection_date,
+         CASE
+           WHEN EXISTS(
+             SELECT 1 FROM job_status_history h
+             WHERE h.job_id = j.id AND h.status IN ('Interviewing', 'Offer!')
+           ) THEN 'onsite'
+           WHEN EXISTS(
+             SELECT 1 FROM job_status_history h
+             WHERE h.job_id = j.id AND h.status = 'Phone screen'
+           ) THEN 'phone_screen'
+           ELSE 'applied'
+         END as rejection_stage
+       FROM jobs j
+       JOIN job_status_history h_rej ON h_rej.job_id = j.id
+         AND h_rej.status = 'Rejected/Withdrawn'
+       WHERE j.user_id = ?
+         AND (j.ending_substatus IS NULL
+           OR j.ending_substatus NOT IN ('Withdrawn', 'Offer declined', 'Offer accepted',
+             'Job closed', 'Not a good fit'))
+       ORDER BY h_rej.entered_at DESC`,
+		)
+		.all(userId) as RejectedJobRow[];
+
+	// Most recent interview date per company
+	const lastInterviewRows = db
+		.prepare(
+			`SELECT lower(j.company) as company_key, MAX(i.interview_dttm) as last_dttm
+       FROM interviews i
+       JOIN jobs j ON j.id = i.job_id
+       WHERE j.user_id = ?
+       GROUP BY lower(j.company)`,
+		)
+		.all(userId) as LastInterviewRow[];
+
+	// Build lookup maps
+	const jobsByCompany = new Map<string, JobRow[]>();
+	for (const job of allJobs) {
+		const list = jobsByCompany.get(job.company_key) ?? [];
+		list.push(job);
+		jobsByCompany.set(job.company_key, list);
+	}
+
+	const lastAppByCompany = new Map<string, string>();
+	for (const row of lastAppRows) {
+		if (row.date_applied) {lastAppByCompany.set(row.company_key, row.date_applied);}
+	}
+
+	// Most recent rejection date per company per stage
+	const rejByCompany = new Map<
+		string,
+		{ onsite?: string; phone_screen?: string; applied?: string }
+	>();
+	for (const rej of rejectedJobs) {
+		const map = rejByCompany.get(rej.company_key) ?? {};
+		const stage = rej.rejection_stage as "onsite" | "phone_screen" | "applied";
+		if (!map[stage] || rej.rejection_date > map[stage]!) {
+			map[stage] = rej.rejection_date;
+		}
+		rejByCompany.set(rej.company_key, map);
+	}
+
+	const lastInterviewByCompany = new Map<string, string>();
+	for (const row of lastInterviewRows) {
+		lastInterviewByCompany.set(row.company_key, row.last_dttm);
+	}
+
+	const STATUS_RANK: Record<string, number> = {
+		"Interviewing": 4,
+		"Phone screen": 3,
+		"Applied": 2,
+		"Not started": 1,
+	};
+	const RANK_TO_STATUS: Record<number, string> = {
+		4: "Interviewing",
+		3: "Phone screen",
+		2: "Applied",
+		1: "Not started",
+	};
+
+	const today = new Date();
+	today.setHours(0, 0, 0, 0);
+
+	const entries: RadarEntry[] = companies.map((tc) => {
+		const key = tc.name.toLowerCase();
+		const companyJobs = jobsByCompany.get(key) ?? [];
+		const lastApplication = lastAppByCompany.get(key) ?? null;
+		const lastInterview = lastInterviewByCompany.get(key) ?? null;
+		const rejections = rejByCompany.get(key);
+		const hasHistory =
+			lastApplication !== null || lastInterview !== null || companyJobs.length > 0;
+
+		const bestRank = companyJobs
+			.filter((j) => j.status !== "Offer!" && j.status !== "Rejected/Withdrawn")
+			.reduce((best, j) => Math.max(best, STATUS_RANK[j.status] ?? 0), 0);
+		const latestActiveStatus = bestRank > 0 ? (RANK_TO_STATUS[bestRank] ?? null) : null;
+
+		const activeJob =
+			companyJobs.find((j) => j.status !== "Rejected/Withdrawn") ?? null;
+
+		// Compute the earliest date each cooldown expires
+		const unlockCandidates: Date[] = [];
+		addUnlock(unlockCandidates, lastApplication, tc.application_cooldown_days);
+		addUnlock(unlockCandidates, rejections?.phone_screen, tc.phone_screen_cooldown_days);
+		addUnlock(unlockCandidates, rejections?.onsite, tc.onsite_cooldown_days);
+
+		const unlockDate =
+			unlockCandidates.length > 0
+				? new Date(Math.max(...unlockCandidates.map((d) => d.getTime())))
+				: null;
+
+		let eligibility: RadarEntry["eligibility"];
+		let finalUnlockDate: Date | null = null;
+
+		if (activeJob) {
+			eligibility = "active";
+		} else if (unlockDate !== null && unlockDate > today) {
+			eligibility = "cooling_down";
+			finalUnlockDate = unlockDate;
+		} else if (!hasHistory) {
+			eligibility = "no_history";
+		} else {
+			eligibility = "clear";
+		}
+
+		// Per-period application limit — overrides all other eligibility states
+		if (tc.max_apps_per_period && tc.apps_period_days) {
+			const cutoff = new Date(today);
+			cutoff.setDate(today.getDate() - tc.apps_period_days);
+			const cutoffStr = cutoff.toISOString().slice(0, 10);
+			const recentJobs = companyJobs.filter(
+				(j) => j.date_applied && j.date_applied >= cutoffStr,
+			);
+			if (recentJobs.length >= tc.max_apps_per_period) {
+				// Oldest app in the window + period = when a slot opens up
+				const [ oldest ] = recentJobs
+					.map((j) => j.date_applied!)
+					.toSorted();
+				if (oldest) {
+					const slotOpens = new Date(oldest);
+					slotOpens.setDate(slotOpens.getDate() + tc.apps_period_days);
+					finalUnlockDate = slotOpens > today ? slotOpens : null;
+				}
+				eligibility = "limit_reached";
+			}
+		}
+
+		const daysUntilUnlock =
+			finalUnlockDate && finalUnlockDate > today
+				? Math.ceil((finalUnlockDate.getTime() - today.getTime()) / 86_400_000)
+				: null;
+
+		return {
+			id: tc.id,
+			name: tc.name,
+			tier: tc.tier as RadarEntry["tier"],
+			eligibility,
+			unlock_date:
+				finalUnlockDate && finalUnlockDate > today
+					? finalUnlockDate.toISOString().slice(0, 10)
+					: null,
+			days_until_unlock: daysUntilUnlock,
+			last_application_date: lastApplication,
+			last_interview_date: lastInterview,
+			latest_active_status: latestActiveStatus,
+			active_job_id: activeJob?.id ?? null,
+			jobs: companyJobs.map((j) => ({
+				id: j.id,
+				role: j.role,
+				status: j.status,
+				date_applied: j.date_applied,
+			})),
+			policy: {
+				application_cooldown_days: tc.application_cooldown_days,
+				phone_screen_cooldown_days: tc.phone_screen_cooldown_days,
+				onsite_cooldown_days: tc.onsite_cooldown_days,
+				max_apps_per_period: tc.max_apps_per_period,
+				apps_period_days: tc.apps_period_days,
+				summary: tc.policy_summary,
+				url: tc.policy_url,
+				confidence: tc.policy_confidence as RadarEntry["policy"]["confidence"],
+				updated_at: tc.policy_updated_at,
+			},
+			user_notes: tc.user_notes,
+			hidden: tc.hidden === 1,
+		};
+	});
+
+	return {
+		entries: entries.filter((e) => e.jobs.length > 0),
+		generated_at: new Date().toISOString(),
+	};
+}
+
+export function patchRadarEntry(
+	db: Database.Database,
+	id: number,
+	patch: RadarPatch,
+): boolean {
+	const entries = Object.entries(patch).filter(([k]) => PATCH_ALLOWLIST.has(k));
+	if (entries.length === 0) {return false;}
+
+	const sets = entries.map(([k]) => `${k} = ?`).join(", ");
+	const values = entries.map(([, v]) => v);
+
+	const result = db
+		.prepare(`UPDATE target_companies SET ${sets} WHERE id = ?`)
+		.run([...values, id]);
+
+	return result.changes > 0;
+}

--- a/backend/routes/radar.ts
+++ b/backend/routes/radar.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import type Database from "better-sqlite3";
+import { getRadar, patchRadarEntry } from "../db/radar.js";
+
+export function createRadarRouter(db: Database.Database) {
+	const router = Router();
+
+	router.get("/", (req, res) => {
+		const userId = req.session.userId as number;
+		const includeHidden = req.query["includeHidden"] === "true";
+		res.json(getRadar(db, userId, includeHidden));
+	});
+
+	router.patch("/:id", (req, res) => {
+		const id = Number(req.params.id);
+		if (isNaN(id)) {
+			return res.status(400).json({ error: "Invalid id" });
+		}
+
+		const updated = patchRadarEntry(db, id, req.body);
+		if (!updated) {
+			return res.status(404).json({ error: "Not found" });
+		}
+
+		return res.json({ success: true });
+	});
+
+	return router;
+}

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -11,6 +11,7 @@ import {
 	createInterviewsRouter,
 } from "./routes/interviews.js";
 import { createJobsRouter } from "./routes/jobs.js";
+import { createRadarRouter } from "./routes/radar.js";
 import { createStatsRouter } from "./routes/stats.js";
 
 // Augment express-session to include our custom fields
@@ -70,6 +71,7 @@ export function createApp(db: Database.Database) {
 		requireAuth,
 		createInterviewsRouter(db),
 	);
+	app.use("/api/radar", requireAuth, createRadarRouter(db));
 	app.use("/api/stats", requireAuth, createStatsRouter(db));
 	app.use(
 		"/api/interview-insights",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import AppShell from "./components/AppShell";
 import InsightsPage from "./components/InsightsPage";
 import JobManagementPage from "./components/JobManagementPage";
 import InterviewsPage from "./components/InterviewsPage";
+import RadarPage from "./components/RadarPage";
 import StatsPage from "./components/StatsPage";
 
 export default function App() {
@@ -83,6 +84,7 @@ export default function App() {
 						<Route path="/calendar" element={<InterviewsPage />} />
 						<Route path="/stats" element={<StatsPage />} />
 						<Route path="/insights" element={<InsightsPage />} />
+						<Route path="/radar" element={<RadarPage />} />
 						<Route path="*" element={<Navigate to="/jobs" replace />} />
 					</Route>
 				</Routes>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,6 +7,8 @@ import type {
 	InterviewQuestionFormData,
 	Job,
 	JobFormData,
+	RadarPatch,
+	RadarResponse,
 	StatsResponse,
 	StatsWindow,
 	User,
@@ -60,6 +62,17 @@ export const api = {
 		request<Job>(`/jobs/${id}`, { body: JSON.stringify(data), method: "PUT" }),
 	deleteJob: (id: number) =>
 		request<{ success: boolean }>(`/jobs/${id}`, { method: "DELETE" }),
+
+	// Radar
+	getRadar: (includeHidden = false) =>
+		request<RadarResponse>(
+			`/radar${includeHidden ? "?includeHidden=true" : ""}`,
+		),
+	patchRadarEntry: (id: number, patch: RadarPatch) =>
+		request<{ success: boolean }>(`/radar/${id}`, {
+			body: JSON.stringify(patch),
+			method: "PATCH",
+		}),
 
 	// Stats
 	getStats: (window: StatsWindow) =>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -17,6 +17,7 @@ import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
 import CalendarMonthOutlinedIcon from "@mui/icons-material/CalendarMonthOutlined";
 import InsightsIcon from "@mui/icons-material/Insights";
 import PsychologyOutlinedIcon from "@mui/icons-material/PsychologyOutlined";
+import RadarIcon from "@mui/icons-material/Radar";
 import ViewKanbanOutlinedIcon from "@mui/icons-material/ViewKanbanOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
@@ -35,6 +36,7 @@ const NAV_ITEMS = [
 		label: "Insights",
 		path: "/insights",
 	},
+	{ icon: <RadarIcon />, label: "Radar", path: "/radar" },
 ] as const;
 
 interface Props {

--- a/frontend/src/components/RadarPage.tsx
+++ b/frontend/src/components/RadarPage.tsx
@@ -1,0 +1,810 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+	Box,
+	Button,
+	Chip,
+	CircularProgress,
+	Collapse,
+	FormControlLabel,
+	Link,
+	Switch,
+	Tab,
+	Tabs,
+	TextField,
+	Tooltip,
+	Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import { useNavigate } from "react-router-dom";
+import { api } from "../api";
+import { fetchLogo, getCachedLogo } from "../logoCache";
+import type { RadarEntry, RadarPatch, RadarResponse } from "../types";
+
+type TabValue = "all" | "eligible" | "active" | "cooling_down";
+
+const TIER_CHIP_SX = {
+	faang: {
+		bgcolor: "#fce4ec",
+		color: "#c62828",
+		fontSize: "0.6rem",
+		height: 16,
+	},
+	faang_adjacent: {
+		bgcolor: "#e8eaf6",
+		color: "#283593",
+		fontSize: "0.6rem",
+		height: 16,
+	},
+	custom: {
+		bgcolor: "#f3e5f5",
+		color: "#6a1b9a",
+		fontSize: "0.6rem",
+		height: 16,
+	},
+};
+
+const TIER_LABELS: Record<string, string> = {
+	faang: "FAANG",
+	faang_adjacent: "Adjacent",
+	custom: "Custom",
+};
+
+const CONFIDENCE_LABELS: Record<string, string> = {
+	official: "official source",
+	community: "community reports",
+	estimate: "estimate",
+};
+
+const CONFIDENCE_COLORS: Record<string, string> = {
+	official: "#2e7d32",
+	community: "#1565c0",
+	estimate: "#e65100",
+};
+
+function formatDays(days: number): string {
+	if (days >= 365 && days % 365 === 0) {
+		return `${days / 365} yr`;
+	}
+	if (days >= 30) {
+		return `${Math.round(days / 30)} mo`;
+	}
+	return `${days}d`;
+}
+
+function lastActivityDate(entry: RadarEntry): string | null {
+	const candidates = [
+		entry.last_application_date,
+		entry.last_interview_date?.slice(0, 10) ?? null,
+	].filter(Boolean) as string[];
+	if (candidates.length === 0) {
+		return null;
+	}
+	return candidates.reduce((a, b) => (a > b ? a : b));
+}
+
+function formatActivityDate(iso: string): string {
+	return new Date(iso).toLocaleDateString("en-US", {
+		month: "short",
+		year: "numeric",
+	});
+}
+
+// ── Eligibility chip ──────────────────────────────────────────────────────────
+
+function EligibilityChip({ entry }: { entry: RadarEntry }) {
+	if (entry.eligibility === "limit_reached") {
+		return (
+			<Tooltip
+				title={
+					entry.unlock_date
+						? `A slot opens on ${entry.unlock_date}`
+						: "Per-period application limit reached"
+				}
+			>
+				<Chip
+					label={
+						entry.days_until_unlock
+							? `App Limit · slot in ${entry.days_until_unlock}d`
+							: "App Limit Reached"
+					}
+					size="small"
+					sx={{ bgcolor: "#f3e5f5", color: "#6a1b9a", fontWeight: 600 }}
+				/>
+			</Tooltip>
+		);
+	}
+	if (entry.eligibility === "active") {
+		return (
+			<Chip
+				label="Active Pipeline"
+				size="small"
+				color="primary"
+				sx={{ fontWeight: 600 }}
+			/>
+		);
+	}
+	if (entry.eligibility === "cooling_down") {
+		const long = (entry.days_until_unlock ?? 0) > 180;
+		return (
+			<Tooltip title={`Unlocks ${entry.unlock_date ?? ""}`}>
+				<Chip
+					label={`Unlock in ${entry.days_until_unlock}d`}
+					size="small"
+					sx={{
+						bgcolor: long ? "#ffebee" : "#fff3e0",
+						color: long ? "#c62828" : "#e65100",
+						fontWeight: 600,
+					}}
+				/>
+			</Tooltip>
+		);
+	}
+	if (entry.eligibility === "clear") {
+		return (
+			<Chip
+				label="Clear to Apply"
+				size="small"
+				sx={{ bgcolor: "#e8f5e9", color: "#2e7d32", fontWeight: 600 }}
+			/>
+		);
+	}
+	return (
+		<Chip
+			label="No History"
+			size="small"
+			sx={{ bgcolor: "#f5f5f5", color: "#9e9e9e" }}
+		/>
+	);
+}
+
+// ── Company logo ──────────────────────────────────────────────────────────────
+
+function CompanyLogo({ company }: { company: string }) {
+	const [entry, setEntry] = useState(() => getCachedLogo(company));
+	useEffect(() => {
+		void fetchLogo(company).then(setEntry);
+	}, [company]);
+
+	if (!entry || entry.status !== "resolved") {
+		return <Box sx={{ width: 20, height: 20, flexShrink: 0 }} />;
+	}
+	return (
+		<Box
+			component="img"
+			src={entry.src}
+			alt={company}
+			sx={{
+				borderRadius: 0.5,
+				flexShrink: 0,
+				height: 20,
+				objectFit: "contain",
+				width: 20,
+			}}
+		/>
+	);
+}
+
+// ── Radar row ─────────────────────────────────────────────────────────────────
+
+function RadarRow({
+	entry,
+	expanded,
+	onToggle,
+	onUpdate,
+}: {
+	entry: RadarEntry;
+	expanded: boolean;
+	onToggle: () => void;
+	onUpdate: (patch: RadarPatch) => void;
+}) {
+	const navigate = useNavigate();
+	const [notes, setNotes] = useState(entry.user_notes ?? "");
+
+	// Keep notes in sync if parent re-renders the entry (e.g. after patch)
+	useEffect(() => {
+		setNotes(entry.user_notes ?? "");
+	}, [entry.user_notes]);
+
+	const activity = lastActivityDate(entry);
+	const { policy } = entry;
+	const hasCooldownData =
+		policy.application_cooldown_days !== null ||
+		policy.phone_screen_cooldown_days !== null ||
+		policy.onsite_cooldown_days !== null;
+
+	return (
+		<Box sx={{ mb: expanded ? 0 : 0.75 }}>
+			{/* Summary row */}
+			<Box
+				onClick={onToggle}
+				sx={{
+					alignItems: "center",
+					bgcolor: "background.paper",
+					border: "1px solid",
+					borderBottom: expanded ? "none" : undefined,
+					borderColor: expanded ? "primary.light" : "divider",
+					borderRadius: expanded ? "8px 8px 0 0" : 1,
+					cursor: "pointer",
+					display: "flex",
+					gap: 1.5,
+					px: 1.5,
+					py: 1,
+					"&:hover": { bgcolor: "action.hover" },
+				}}
+			>
+				<CompanyLogo company={entry.name} />
+
+				{/* Name + tier */}
+				<Box
+					sx={{
+						alignItems: "center",
+						display: "flex",
+						gap: 0.75,
+						width: 180,
+						flexShrink: 0,
+					}}
+				>
+					<Typography variant="body2" fontWeight={600} noWrap>
+						{entry.name}
+					</Typography>
+					<Chip
+						label={TIER_LABELS[entry.tier] ?? entry.tier}
+						size="small"
+						sx={TIER_CHIP_SX[entry.tier] ?? TIER_CHIP_SX.custom}
+					/>
+				</Box>
+
+				{/* Farthest stage */}
+				<Typography
+					variant="caption"
+					color="text.secondary"
+					sx={{ flex: 1, minWidth: 0 }}
+					noWrap
+				>
+					{entry.latest_active_status ?? "—"}
+				</Typography>
+
+				{/* Last activity */}
+				<Typography
+					variant="caption"
+					color="text.disabled"
+					sx={{ flexShrink: 0, width: 72, textAlign: "right" }}
+				>
+					{activity ? formatActivityDate(activity) : "—"}
+				</Typography>
+
+				{/* Eligibility chip */}
+				<Box
+					sx={{
+						flexShrink: 0,
+						width: 148,
+						display: "flex",
+						justifyContent: "flex-end",
+					}}
+				>
+					<EligibilityChip entry={entry} />
+				</Box>
+
+				<ExpandMoreIcon
+					sx={{
+						color: "text.disabled",
+						flexShrink: 0,
+						fontSize: 18,
+						transform: expanded ? "rotate(180deg)" : "none",
+						transition: "transform 0.2s",
+					}}
+				/>
+			</Box>
+
+			{/* Expansion panel */}
+			<Collapse in={expanded}>
+				<Box
+					sx={{
+						bgcolor: "background.paper",
+						border: "1px solid",
+						borderColor: "primary.light",
+						borderRadius: "0 0 8px 8px",
+						borderTop: "none",
+						mb: 0.75,
+						px: 2,
+						py: 1.5,
+					}}
+				>
+					{/* Policy details */}
+					<Typography variant="caption" fontWeight={600} color="text.secondary">
+						Cooldown Policy
+					</Typography>
+					{hasCooldownData ? (
+						<Box
+							sx={{
+								display: "flex",
+								flexWrap: "wrap",
+								gap: 2,
+								mt: 0.5,
+								mb: 0.5,
+							}}
+						>
+							{policy.application_cooldown_days !== null && (
+								<Box>
+									<Typography
+										variant="caption"
+										color="text.disabled"
+										display="block"
+									>
+										After application
+									</Typography>
+									<Typography variant="body2" fontWeight={500}>
+										{formatDays(policy.application_cooldown_days)}
+									</Typography>
+								</Box>
+							)}
+							{policy.phone_screen_cooldown_days !== null && (
+								<Box>
+									<Typography
+										variant="caption"
+										color="text.disabled"
+										display="block"
+									>
+										After phone screen rejection
+									</Typography>
+									<Typography variant="body2" fontWeight={500}>
+										{formatDays(policy.phone_screen_cooldown_days)}
+									</Typography>
+								</Box>
+							)}
+							{policy.onsite_cooldown_days !== null && (
+								<Box>
+									<Typography
+										variant="caption"
+										color="text.disabled"
+										display="block"
+									>
+										After onsite rejection
+									</Typography>
+									<Typography variant="body2" fontWeight={500}>
+										{formatDays(policy.onsite_cooldown_days)}
+									</Typography>
+								</Box>
+							)}
+							{policy.max_apps_per_period !== null &&
+								policy.apps_period_days !== null && (
+									<Box>
+										<Typography
+											variant="caption"
+											color="text.disabled"
+											display="block"
+										>
+											Application limit
+										</Typography>
+										<Typography variant="body2" fontWeight={500}>
+											{policy.max_apps_per_period} per{" "}
+											{formatDays(policy.apps_period_days)}
+										</Typography>
+									</Box>
+								)}
+						</Box>
+					) : (
+						<Typography
+							variant="body2"
+							color="text.disabled"
+							sx={{ mt: 0.5, mb: 0.5 }}
+						>
+							No policy data — run the populate-radar-policies skill to fetch.
+						</Typography>
+					)}
+
+					{/* Source + confidence + updated date */}
+					<Box
+						sx={{
+							alignItems: "center",
+							display: "flex",
+							flexWrap: "wrap",
+							gap: 1,
+							mt: 0.5,
+						}}
+					>
+						{policy.confidence && (
+							<Typography
+								variant="caption"
+								sx={{ color: CONFIDENCE_COLORS[policy.confidence] }}
+							>
+								{CONFIDENCE_LABELS[policy.confidence]}
+							</Typography>
+						)}
+						{policy.url && (
+							<Link
+								href={policy.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								variant="caption"
+								sx={{ display: "flex", alignItems: "center", gap: 0.25 }}
+							>
+								source <OpenInNewIcon sx={{ fontSize: 10 }} />
+							</Link>
+						)}
+						{policy.updated_at && (
+							<Typography variant="caption" color="text.disabled">
+								· Data updated:{" "}
+								{new Date(policy.updated_at).toLocaleDateString("en-US", {
+									month: "long",
+									day: "numeric",
+									year: "numeric",
+								})}
+							</Typography>
+						)}
+					</Box>
+
+					{/* Job history */}
+					{entry.jobs.length > 0 && (
+						<Box sx={{ mt: 1.5 }}>
+							<Typography
+								variant="caption"
+								fontWeight={600}
+								color="text.secondary"
+							>
+								Application History
+							</Typography>
+							<Box
+								sx={{
+									mt: 0.5,
+									display: "flex",
+									flexDirection: "column",
+									gap: 0.25,
+								}}
+							>
+								{entry.jobs.map((job) => (
+									<Box
+										key={job.id}
+										sx={{ alignItems: "center", display: "flex", gap: 1 }}
+									>
+										<Link
+											component="button"
+											variant="caption"
+											underline="hover"
+											onClick={() => navigate(`/jobs/${job.id}`)}
+											sx={{ fontWeight: 500 }}
+										>
+											{job.role}
+										</Link>
+										<Typography variant="caption" color="text.disabled">
+											· {job.status}
+											{job.date_applied
+												? ` · ${job.date_applied.slice(0, 10)}`
+												: ""}
+										</Typography>
+									</Box>
+								))}
+							</Box>
+						</Box>
+					)}
+
+					{/* Notes */}
+					<TextField
+						label="Notes"
+						value={notes}
+						onChange={(e) => setNotes(e.target.value)}
+						onBlur={() => {
+							const next = notes.trim() || null;
+							if (next !== (entry.user_notes ?? null)) {
+								onUpdate({ user_notes: next });
+							}
+						}}
+						size="small"
+						fullWidth
+						multiline
+						minRows={2}
+						placeholder="Personal notes about this company…"
+						sx={{ mt: 1.5 }}
+					/>
+
+					{/* Hide toggle */}
+					{entry.hidden ? (
+						<Button
+							size="small"
+							variant="outlined"
+							sx={{ mt: 1 }}
+							onClick={() => onUpdate({ hidden: 0 })}
+						>
+							Restore to radar
+						</Button>
+					) : (
+						<FormControlLabel
+							control={
+								<Switch
+									size="small"
+									checked={false}
+									onChange={() => onUpdate({ hidden: 1 })}
+								/>
+							}
+							label={
+								<Typography variant="caption" color="text.secondary">
+									Hide from radar
+								</Typography>
+							}
+							sx={{ mt: 0.5, ml: 0 }}
+						/>
+					)}
+				</Box>
+			</Collapse>
+		</Box>
+	);
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function RadarPage() {
+	const [data, setData] = useState<RadarResponse | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(false);
+	const [tab, setTab] = useState<TabValue>("all");
+	const [expandedId, setExpandedId] = useState<number | null>(null);
+	const [showHidden, setShowHidden] = useState(false);
+
+	useEffect(() => {
+		setLoading(true);
+		setError(false);
+		api
+			.getRadar(showHidden)
+			.then(setData)
+			.catch(() => setError(true))
+			.finally(() => setLoading(false));
+	}, [showHidden]);
+
+	const counts = useMemo(
+		() => ({
+			active:
+				data?.entries.filter((e) => e.eligibility === "active").length ?? 0,
+			limit_reached:
+				data?.entries.filter((e) => e.eligibility === "limit_reached").length ??
+				0,
+			cooling_down:
+				data?.entries.filter((e) => e.eligibility === "cooling_down").length ??
+				0,
+			clear: data?.entries.filter((e) => e.eligibility === "clear").length ?? 0,
+			no_history:
+				data?.entries.filter((e) => e.eligibility === "no_history").length ?? 0,
+		}),
+		[data],
+	);
+
+	const filtered = useMemo(() => {
+		if (!data) {
+			return [];
+		}
+		if (tab === "eligible") {
+			return data.entries.filter(
+				(e) => e.eligibility === "clear" || e.eligibility === "no_history",
+			);
+		}
+		if (tab === "active") {
+			return data.entries.filter(
+				(e) => e.eligibility === "active" || e.eligibility === "limit_reached",
+			);
+		}
+		if (tab === "cooling_down") {
+			return data.entries.filter((e) => e.eligibility === "cooling_down");
+		}
+		return data.entries;
+	}, [data, tab]);
+
+	const handleUpdate = useCallback(
+		(id: number, patch: RadarPatch) => {
+			void api.patchRadarEntry(id, patch).then(() => {
+				if ("hidden" in patch) {
+					// Re-fetch so eligibility is recomputed and list membership is correct
+					setLoading(true);
+					void api
+						.getRadar(showHidden)
+						.then(setData)
+						.finally(() => setLoading(false));
+				} else {
+					setData((prev) => {
+						if (!prev) {
+							return prev;
+						}
+						return {
+							...prev,
+							entries: prev.entries.map((e) =>
+								e.id === id
+									? { ...e, user_notes: patch.user_notes ?? e.user_notes }
+									: e,
+							),
+						};
+					});
+				}
+			});
+		},
+		[showHidden],
+	);
+
+	const handleToggle = useCallback(
+		(id: number) => setExpandedId((prev) => (prev === id ? null : id)),
+		[],
+	);
+
+	return (
+		<Box sx={{ maxWidth: 1100, mx: "auto", px: 3, py: 4 }}>
+			{/* Header */}
+			<Box
+				sx={{
+					alignItems: "flex-start",
+					display: "flex",
+					justifyContent: "space-between",
+					mb: 1,
+				}}
+			>
+				<Typography variant="h5" fontWeight={700}>
+					FAANG Radar
+				</Typography>
+				<FormControlLabel
+					control={
+						<Switch
+							size="small"
+							checked={showHidden}
+							onChange={(e) => setShowHidden(e.target.checked)}
+						/>
+					}
+					label={
+						<Typography variant="caption" color="text.secondary">
+							Show hidden
+						</Typography>
+					}
+					sx={{ mr: 0 }}
+				/>
+			</Box>
+			<Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+				Track reapplication cooldowns across target companies
+			</Typography>
+
+			{error && (
+				<Typography color="error" sx={{ mb: 2 }}>
+					Failed to load radar data. Please try again.
+				</Typography>
+			)}
+
+			{loading ? (
+				<Box sx={{ display: "flex", justifyContent: "center", mt: 10 }}>
+					<CircularProgress />
+				</Box>
+			) : null}
+
+			{!loading && data && (
+				<>
+					{/* Summary chips */}
+					<Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 2 }}>
+						<Chip
+							label={`Active: ${counts.active}`}
+							size="small"
+							color="primary"
+							variant="outlined"
+						/>
+						<Chip
+							label={`App Limit: ${counts.limit_reached}`}
+							size="small"
+							sx={{ borderColor: "#6a1b9a", color: "#6a1b9a" }}
+							variant="outlined"
+						/>
+						<Chip
+							label={`Cooling Down: ${counts.cooling_down}`}
+							size="small"
+							sx={{ borderColor: "#e65100", color: "#e65100" }}
+							variant="outlined"
+						/>
+						<Chip
+							label={`Clear: ${counts.clear}`}
+							size="small"
+							sx={{ borderColor: "#2e7d32", color: "#2e7d32" }}
+							variant="outlined"
+						/>
+						<Chip
+							label={`No History: ${counts.no_history}`}
+							size="small"
+							variant="outlined"
+						/>
+					</Box>
+
+					{/* Filter tabs */}
+					<Tabs
+						value={tab}
+						onChange={(_, v: TabValue) => {
+							setTab(v);
+							setExpandedId(null);
+						}}
+						sx={{ mb: 2, borderBottom: 1, borderColor: "divider" }}
+					>
+						<Tab label={`All (${data.entries.length})`} value="all" />
+						<Tab
+							label={`Eligible Now (${counts.clear + counts.no_history})`}
+							value="eligible"
+						/>
+						<Tab
+							label={`Active (${counts.active + counts.limit_reached})`}
+							value="active"
+						/>
+						<Tab
+							label={`On Cooldown (${counts.cooling_down})`}
+							value="cooling_down"
+						/>
+					</Tabs>
+
+					{/* Column header */}
+					<Box
+						sx={{
+							color: "text.disabled",
+							display: "flex",
+							fontSize: "0.7rem",
+							fontWeight: 600,
+							gap: 1.5,
+							mb: 0.5,
+							px: 1.5,
+							textTransform: "uppercase",
+						}}
+					>
+						<Box sx={{ width: 20, flexShrink: 0 }} />
+						<Box sx={{ width: 180, flexShrink: 0 }}>Company</Box>
+						<Box sx={{ flex: 1 }}>Latest Active Status</Box>
+						<Box sx={{ width: 72, textAlign: "right", flexShrink: 0 }}>
+							Last Activity
+						</Box>
+						<Box sx={{ width: 148, textAlign: "right", flexShrink: 0 }}>
+							Eligibility
+						</Box>
+						<Box sx={{ width: 18, flexShrink: 0 }} />
+					</Box>
+
+					{/* Rows */}
+					{filtered.length === 0 ? (
+						<Typography
+							variant="body2"
+							color="text.disabled"
+							sx={{ textAlign: "center", mt: 8 }}
+						>
+							No companies match this filter.
+						</Typography>
+					) : (
+						filtered.map((entry) => (
+							<RadarRow
+								key={entry.id}
+								entry={entry}
+								expanded={expandedId === entry.id}
+								onToggle={() => handleToggle(entry.id)}
+								onUpdate={(patch) => handleUpdate(entry.id, patch)}
+							/>
+						))
+					)}
+
+					{/* Hidden companies */}
+					{showHidden &&
+						(() => {
+							const hiddenEntries = data.entries.filter((e) => e.hidden);
+							if (hiddenEntries.length === 0) {
+								return null;
+							}
+							return (
+								<Box sx={{ mt: 4 }}>
+									<Typography
+										variant="caption"
+										color="text.disabled"
+										fontWeight={600}
+										sx={{ display: "block", mb: 1, textTransform: "uppercase" }}
+									>
+										Hidden ({hiddenEntries.length})
+									</Typography>
+									{hiddenEntries.map((entry) => (
+										<RadarRow
+											key={entry.id}
+											entry={entry}
+											expanded={expandedId === entry.id}
+											onToggle={() => handleToggle(entry.id)}
+											onUpdate={(patch) => handleUpdate(entry.id, patch)}
+										/>
+									))}
+								</Box>
+							);
+						})()}
+				</>
+			)}
+		</Box>
+	);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -131,6 +131,70 @@ export type InterviewQuestionFormData = Omit<
 
 export type StatsWindow = "all" | "90" | "30";
 
+export type RadarEligibility =
+	| "active"
+	| "cooling_down"
+	| "clear"
+	| "no_history"
+	| "limit_reached";
+export type RadarTier = "faang" | "faang_adjacent" | "custom";
+export type RadarPolicyConfidence = "official" | "community" | "estimate";
+
+export interface RadarPolicy {
+	application_cooldown_days: number | null;
+	phone_screen_cooldown_days: number | null;
+	onsite_cooldown_days: number | null;
+	max_apps_per_period: number | null;
+	apps_period_days: number | null;
+	summary: string | null;
+	url: string | null;
+	confidence: RadarPolicyConfidence | null;
+	updated_at: string | null;
+}
+
+export interface RadarJobSummary {
+	id: number;
+	role: string;
+	status: string;
+	date_applied: string | null;
+}
+
+export interface RadarEntry {
+	id: number;
+	name: string;
+	tier: RadarTier;
+	eligibility: RadarEligibility;
+	unlock_date: string | null;
+	days_until_unlock: number | null;
+	last_application_date: string | null;
+	last_interview_date: string | null;
+	latest_active_status: string | null;
+	active_job_id: number | null;
+	jobs: RadarJobSummary[];
+	policy: RadarPolicy;
+	user_notes: string | null;
+	hidden: boolean;
+}
+
+export interface RadarResponse {
+	entries: RadarEntry[];
+	generated_at: string;
+}
+
+export type RadarPatch = Partial<{
+	hidden: number;
+	user_notes: string | null;
+	application_cooldown_days: number | null;
+	phone_screen_cooldown_days: number | null;
+	onsite_cooldown_days: number | null;
+	max_apps_per_period: number | null;
+	apps_period_days: number | null;
+	policy_summary: string | null;
+	policy_url: string | null;
+	policy_confidence: string | null;
+	policy_updated_at: string | null;
+}>;
+
 export interface InterviewInsightsResponse {
 	totalInterviews: number;
 	passRate: number | null;

--- a/oxlint.json
+++ b/oxlint.json
@@ -4,7 +4,7 @@
   "options": {
     "maxWarnings": 0
   },
-  "ignorePatterns": ["**/node_modules/**", "**/dist/**"],
+  "ignorePatterns": ["**/node_modules/**", "**/dist/**", "backend/bin/**"],
   "env": {
     "es2022": true
   },


### PR DESCRIPTION
## Summary

Adds a FAANG Radar page that tracks reapplication cooldown windows across target companies (FAANG, adjacent, and custom tiers).

## Details

- **Cooldown engine** — computes eligibility per company from application date, phone-screen rejection date, and onsite rejection date; also enforces per-period application limits
- **Latest Active Status** — shows the deepest currently in-progress stage (Phone screen, Interviewing, etc.) for each company; excludes Offer! and Rejected/Withdrawn so only actionable pipeline state is surfaced (replaces the old all-time "Farthest Stage")
- **Show hidden toggle** — hidden companies are excluded by default; toggling reveals them in a separate section with a "Restore to radar" action
- **Company admin CLI** (`backend/bin/company.ts`) — `tsx backend/bin/company.ts list/show/set` for managing `target_companies` cooldown config outside the app UI
- **oxlint** — `backend/bin/**` excluded from linting

## Test plan

- [x] Radar page loads and displays companies grouped by eligibility
- [x] Cooldown countdown is correct for a company with a recent rejection
- [x] "Latest Active Status" shows the deepest active stage, blank for companies with only closed/rejected apps
- [x] "App Limit" chip appears when per-period limit is reached
- [x] Hiding a company removes it from the main list; toggling "Show hidden" reveals it
- [x] "Restore to radar" un-hides a company
- [x] `tsx backend/bin/company.ts help` prints usage; `set`/`list`/`show` work correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)