### PR TITLE
refactor!: split EndingSubstatus into OfferSubstatus and RejectedSubstatus

### DIFF
--- a/backend/routes/jobs.spec.ts
+++ b/backend/routes/jobs.spec.ts
@@ -5,7 +5,8 @@ import { createApp } from "../server.js";
 import {
 	JOB_MAX_LENGTHS,
 	TERMINAL_STATUSES,
-	VALID_ENDING_SUBSTATUSES,
+	VALID_OFFER_SUBSTATUSES,
+	VALID_REJECTED_SUBSTATUSES,
 } from "../validators.js";
 
 const SCHEMA = `
@@ -328,7 +329,6 @@ describe("ending_substatus validation", () => {
 		"Phone screen",
 		"Interviewing",
 	] as const;
-	const VALID_SUBSTATUSES = [...VALID_ENDING_SUBSTATUSES];
 
 	describe("POST /api/jobs", () => {
 		it.each([...TERMINAL_STATUSES])(
@@ -352,8 +352,8 @@ describe("ending_substatus validation", () => {
 			},
 		);
 
-		it.each(VALID_SUBSTATUSES)(
-			'accepts ending_substatus "%s" with terminal status',
+		it.each([...VALID_OFFER_SUBSTATUSES])(
+			'accepts ending_substatus "%s" with Offer! status',
 			async (ending_substatus) => {
 				const res = await req("post", "/api/jobs").send({
 					...BASE_JOB,
@@ -364,6 +364,37 @@ describe("ending_substatus validation", () => {
 				expect(res.body.ending_substatus).toBe(ending_substatus);
 			},
 		);
+
+		it.each([...VALID_REJECTED_SUBSTATUSES])(
+			'accepts ending_substatus "%s" with Rejected/Withdrawn status',
+			async (ending_substatus) => {
+				const res = await req("post", "/api/jobs").send({
+					...BASE_JOB,
+					ending_substatus,
+					status: "Rejected/Withdrawn",
+				});
+				expect(res.status).toBe(201);
+				expect(res.body.ending_substatus).toBe(ending_substatus);
+			},
+		);
+
+		it("rejects a rejection substatus for Offer! status", async () => {
+			const res = await req("post", "/api/jobs").send({
+				...BASE_JOB,
+				ending_substatus: "Ghosted",
+				status: "Offer!",
+			});
+			expect(res.status).toBe(422);
+		});
+
+		it("rejects an offer substatus for Rejected/Withdrawn status", async () => {
+			const res = await req("post", "/api/jobs").send({
+				...BASE_JOB,
+				ending_substatus: "Offer accepted",
+				status: "Rejected/Withdrawn",
+			});
+			expect(res.status).toBe(422);
+		});
 
 		it.each(NON_TERMINAL_CASES)(
 			'returns 422 when status is "%s" and ending_substatus is set',

--- a/backend/validators.spec.ts
+++ b/backend/validators.spec.ts
@@ -1,0 +1,90 @@
+import {
+	validateEndingSubstatus,
+	VALID_OFFER_SUBSTATUSES,
+	VALID_REJECTED_SUBSTATUSES,
+} from "./validators.js";
+
+describe(validateEndingSubstatus, () => {
+	describe("Offer! status", () => {
+		it("accepts 'Offer accepted'", () => {
+			expect(validateEndingSubstatus("Offer!", "Offer accepted")).toBeNull();
+		});
+
+		it("accepts 'Offer declined'", () => {
+			expect(validateEndingSubstatus("Offer!", "Offer declined")).toBeNull();
+		});
+
+		it("rejects null for Offer! (substatus is required)", () => {
+			expect(validateEndingSubstatus("Offer!", null)).not.toBeNull();
+		});
+
+		it("rejects a rejection substatus for Offer!", () => {
+			expect(validateEndingSubstatus("Offer!", "Ghosted")).not.toBeNull();
+		});
+
+		it("rejects every rejection substatus for Offer!", () => {
+			for (const s of VALID_REJECTED_SUBSTATUSES) {
+				expect(validateEndingSubstatus("Offer!", s)).not.toBeNull();
+			}
+		});
+
+		it("returns an error mentioning the valid offer values", () => {
+			const err = validateEndingSubstatus("Offer!", null);
+			expect(err).toMatch(/Offer accepted/);
+			expect(err).toMatch(/Offer declined/);
+		});
+	});
+
+	describe("Rejected/Withdrawn status", () => {
+		it.each([...VALID_REJECTED_SUBSTATUSES])("accepts '%s'", (substatus) => {
+			expect(
+				validateEndingSubstatus("Rejected/Withdrawn", substatus),
+			).toBeNull();
+		});
+
+		it("rejects null for Rejected/Withdrawn (substatus is required)", () => {
+			expect(
+				validateEndingSubstatus("Rejected/Withdrawn", null),
+			).not.toBeNull();
+		});
+
+		it("rejects 'Offer accepted' for Rejected/Withdrawn", () => {
+			expect(
+				validateEndingSubstatus("Rejected/Withdrawn", "Offer accepted"),
+			).not.toBeNull();
+		});
+
+		it("rejects every offer substatus for Rejected/Withdrawn", () => {
+			for (const s of VALID_OFFER_SUBSTATUSES) {
+				expect(validateEndingSubstatus("Rejected/Withdrawn", s)).not.toBeNull();
+			}
+		});
+
+		it("returns an error that does not mention offer substatuses", () => {
+			const err = validateEndingSubstatus("Rejected/Withdrawn", null);
+			expect(err).not.toMatch(/Offer accepted/);
+			expect(err).not.toMatch(/Offer declined/);
+		});
+	});
+
+	describe("non-terminal statuses", () => {
+		const ACTIVE_STATUSES = [
+			"Not started",
+			"Applied",
+			"Phone screen",
+			"Interviewing",
+		];
+
+		it.each(
+			ACTIVE_STATUSES,
+		)("accepts null for active status '%s'", (status) => {
+			expect(validateEndingSubstatus(status, null)).toBeNull();
+		});
+
+		it.each(
+			ACTIVE_STATUSES,
+		)("rejects a substatus value for active status '%s'", (status) => {
+			expect(validateEndingSubstatus(status, "Withdrawn")).not.toBeNull();
+		});
+	});
+});

--- a/backend/validators.ts
+++ b/backend/validators.ts
@@ -71,27 +71,42 @@ export const VALID_QUESTION_TYPES = new Set([
 	"coding",
 	"culture_fit",
 ]);
-export const VALID_ENDING_SUBSTATUSES = new Set([
+export const VALID_REJECTED_SUBSTATUSES = new Set([
 	"Withdrawn",
 	"Rejected",
 	"Ghosted",
 	"No response",
 	"Job closed",
 	"Not a good fit",
-	"Offer declined",
+]);
+
+export const VALID_OFFER_SUBSTATUSES = new Set([
 	"Offer accepted",
+	"Offer declined",
+]);
+
+export const VALID_ENDING_SUBSTATUSES = new Set([
+	...VALID_REJECTED_SUBSTATUSES,
+	...VALID_OFFER_SUBSTATUSES,
 ]);
 
 export function validateEndingSubstatus(
 	status: string,
 	ending_substatus: unknown,
 ): string | null {
-	if (TERMINAL_STATUSES.has(status)) {
+	if (status === "Offer!") {
 		if (
 			typeof ending_substatus !== "string" ||
-			!VALID_ENDING_SUBSTATUSES.has(ending_substatus)
+			!VALID_OFFER_SUBSTATUSES.has(ending_substatus)
 		) {
-			return `ending_substatus is required for status "${status}" and must be one of: ${[...VALID_ENDING_SUBSTATUSES].join(", ")}`;
+			return `ending_substatus is required for status "Offer!" and must be one of: ${[...VALID_OFFER_SUBSTATUSES].join(", ")}`;
+		}
+	} else if (status === "Rejected/Withdrawn") {
+		if (
+			typeof ending_substatus !== "string" ||
+			!VALID_REJECTED_SUBSTATUSES.has(ending_substatus)
+		) {
+			return `ending_substatus is required for status "Rejected/Withdrawn" and must be one of: ${[...VALID_REJECTED_SUBSTATUSES].join(", ")}`;
 		}
 	} else if (ending_substatus != null) {
 		return `ending_substatus must be null when status is "${status}"`;

--- a/frontend/src/components/EndingStatusDialog.spec.tsx
+++ b/frontend/src/components/EndingStatusDialog.spec.tsx
@@ -121,21 +121,69 @@ describe(EndingStatusDialog, () => {
 			);
 		});
 
-		it("disables the Final Resolution dropdown when destination is Offer!", () => {
+		it("leaves the Final Resolution dropdown enabled so the user can change it", () => {
 			render(<EndingStatusDialog {...OFFER_PROPS} />);
-			expect(screen.getByRole("combobox")).toHaveAttribute(
+			expect(screen.getByRole("combobox")).not.toHaveAttribute(
 				"aria-disabled",
 				"true",
 			);
 		});
 
-		it("calls onConfirm with 'Offer accepted' without any user selection", () => {
+		it("calls onConfirm with 'Offer accepted' when confirmed without changing the default", () => {
 			render(<EndingStatusDialog {...OFFER_PROPS} />);
 			fireEvent.click(screen.getByRole("button", { name: "OK" }));
 			expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith(
 				"Offer accepted",
 				"Some existing notes",
 			);
+		});
+
+		it("allows selecting 'Offer declined'", () => {
+			render(<EndingStatusDialog {...OFFER_PROPS} />);
+			changeSelect(/Final Resolution/i, "Offer declined");
+			fireEvent.click(screen.getByRole("button", { name: "OK" }));
+			expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith(
+				"Offer declined",
+				"Some existing notes",
+			);
+		});
+
+		it("only shows offer substatuses in the dropdown", () => {
+			render(<EndingStatusDialog {...OFFER_PROPS} />);
+			fireEvent.mouseDown(screen.getByLabelText(/Final Resolution/i));
+			expect(
+				screen.getByRole("option", { name: "Offer accepted" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("option", { name: "Offer declined" }),
+			).toBeInTheDocument();
+			// Rejection-only values must not appear
+			expect(
+				screen.queryByRole("option", { name: "Ghosted" }),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("option", { name: "Withdrawn" }),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("Rejected/Withdrawn destination", () => {
+		it("only shows rejection substatuses in the dropdown", () => {
+			render(<EndingStatusDialog {...DEFAULT_PROPS} />);
+			fireEvent.mouseDown(screen.getByLabelText(/Final Resolution/i));
+			expect(
+				screen.getByRole("option", { name: "Withdrawn" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("option", { name: "Ghosted" }),
+			).toBeInTheDocument();
+			// Offer-only values must not appear
+			expect(
+				screen.queryByRole("option", { name: "Offer accepted" }),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("option", { name: "Offer declined" }),
+			).not.toBeInTheDocument();
 		});
 	});
 });

--- a/frontend/src/components/EndingStatusDialog.tsx
+++ b/frontend/src/components/EndingStatusDialog.tsx
@@ -9,7 +9,7 @@ import {
 	TextField,
 	Typography,
 } from "@mui/material";
-import { ENDING_SUBSTATUSES } from "../constants";
+import { OFFER_SUBSTATUSES, REJECTED_SUBSTATUSES } from "../constants";
 import type { EndingSubstatus, Job, JobStatus } from "../types";
 
 interface Props {
@@ -31,15 +31,16 @@ export default function EndingStatusDialog({
 	const [notes, setNotes] = useState("");
 	const [error, setError] = useState("");
 
-	const isOffer = newStatus === "Offer!";
+	const substatusOptions =
+		newStatus === "Offer!" ? OFFER_SUBSTATUSES : REJECTED_SUBSTATUSES;
 
 	useEffect(() => {
 		if (open) {
-			setSubstatus(isOffer ? "Offer accepted" : "");
+			setSubstatus(newStatus === "Offer!" ? "Offer accepted" : "");
 			setNotes(job?.notes ?? "");
 			setError("");
 		}
-	}, [open, job, isOffer]);
+	}, [open, job, newStatus]);
 
 	function handleConfirm() {
 		if (!substatus) {
@@ -70,14 +71,13 @@ export default function EndingStatusDialog({
 							setError("");
 						}
 					}}
-					disabled={isOffer}
 					error={Boolean(error)}
 					helperText={error}
 					fullWidth
 					size="small"
 					sx={{ mb: 2 }}
 				>
-					{ENDING_SUBSTATUSES.map((s) => (
+					{substatusOptions.map((s) => (
 						<MenuItem key={s} value={s}>
 							{s}
 						</MenuItem>

--- a/frontend/src/components/JobDialog.spec.tsx
+++ b/frontend/src/components/JobDialog.spec.tsx
@@ -605,7 +605,7 @@ describe(JobDialog, () => {
 				expect(field).not.toHaveTextContent("Offer accepted");
 			});
 
-			it("preserves the substatus when switching between two terminal statuses", async () => {
+			it("clears the substatus when switching between terminal statuses with incompatible values", async () => {
 				vi.mocked(api.getJob).mockResolvedValue(
 					terminalJob("Offer!", "Offer accepted"),
 				);
@@ -616,9 +616,26 @@ describe(JobDialog, () => {
 					);
 				});
 				changeSelect(/^Status$/i, "Rejected/Withdrawn");
-				expect(screen.getByLabelText(/Final Resolution/i)).toHaveTextContent(
-					"Offer accepted",
+				// "Offer accepted" is not valid for Rejected/Withdrawn — must be cleared
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).not.toHaveTextContent("Offer accepted");
+			});
+
+			it("preserves the substatus when switching between terminal statuses with a compatible value", async () => {
+				vi.mocked(api.getJob).mockResolvedValue(
+					terminalJob("Rejected/Withdrawn", "Ghosted"),
 				);
+				render(<JobDialog {...DEFAULT_PROPS} jobId={42} />);
+				await waitFor(() => {
+					expect(screen.getByLabelText(/Final Resolution/i)).toHaveTextContent(
+						"Ghosted",
+					);
+				});
+				changeSelect(/^Status$/i, "Offer!");
+				expect(
+					screen.getByLabelText(/Final Resolution/i),
+				).not.toHaveTextContent("Ghosted");
 			});
 		});
 
@@ -729,6 +746,70 @@ describe(JobDialog, () => {
 				fireEvent.click(screen.getByRole("button", { name: "Add Job" }));
 				expect(DEFAULT_PROPS.onSave).toHaveBeenCalledWith(
 					expect.objectContaining({ ending_substatus: null }),
+				);
+			});
+		});
+
+		describe("substatus options filtered by status", () => {
+			it("shows only offer substatuses when status is Offer!", async () => {
+				vi.mocked(api.getJob).mockResolvedValue(
+					terminalJob("Offer!", "Offer accepted"),
+				);
+				render(<JobDialog {...DEFAULT_PROPS} jobId={42} />);
+				await waitFor(() =>
+					expect(screen.getByRole("button", { name: "Save" })).toBeEnabled(),
+				);
+				fireEvent.mouseDown(screen.getByLabelText(/Final Resolution/i));
+				expect(
+					screen.getByRole("option", { name: "Offer accepted" }),
+				).toBeInTheDocument();
+				expect(
+					screen.getByRole("option", { name: "Offer declined" }),
+				).toBeInTheDocument();
+				expect(
+					screen.queryByRole("option", { name: "Ghosted" }),
+				).not.toBeInTheDocument();
+				expect(
+					screen.queryByRole("option", { name: "Withdrawn" }),
+				).not.toBeInTheDocument();
+			});
+
+			it("shows only rejection substatuses when status is Rejected/Withdrawn", async () => {
+				vi.mocked(api.getJob).mockResolvedValue(
+					terminalJob("Rejected/Withdrawn", "Ghosted"),
+				);
+				render(<JobDialog {...DEFAULT_PROPS} jobId={42} />);
+				await waitFor(() =>
+					expect(screen.getByRole("button", { name: "Save" })).toBeEnabled(),
+				);
+				fireEvent.mouseDown(screen.getByLabelText(/Final Resolution/i));
+				expect(
+					screen.getByRole("option", { name: "Ghosted" }),
+				).toBeInTheDocument();
+				expect(
+					screen.getByRole("option", { name: "Withdrawn" }),
+				).toBeInTheDocument();
+				expect(
+					screen.queryByRole("option", { name: "Offer accepted" }),
+				).not.toBeInTheDocument();
+				expect(
+					screen.queryByRole("option", { name: "Offer declined" }),
+				).not.toBeInTheDocument();
+			});
+
+			it("can save with 'Offer declined' for an Offer! job", async () => {
+				vi.mocked(api.getJob).mockResolvedValue(terminalJob("Offer!", null));
+				render(<JobDialog {...DEFAULT_PROPS} jobId={42} />);
+				await waitFor(() =>
+					expect(screen.getByRole("button", { name: "Save" })).toBeEnabled(),
+				);
+				changeSelect(/Final Resolution/i, "Offer declined");
+				fireEvent.click(screen.getByRole("button", { name: "Save" }));
+				expect(DEFAULT_PROPS.onSave).toHaveBeenCalledWith(
+					expect.objectContaining({
+						ending_substatus: "Offer declined",
+						status: "Offer!",
+					}),
 				);
 			});
 		});

--- a/frontend/src/components/JobDialog.tsx
+++ b/frontend/src/components/JobDialog.tsx
@@ -28,7 +28,8 @@ import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import {
-	ENDING_SUBSTATUSES,
+	OFFER_SUBSTATUSES,
+	REJECTED_SUBSTATUSES,
 	FIT_SCORES,
 	JOB_MAX_LENGTHS,
 	JOB_TAGS,
@@ -434,13 +435,23 @@ export default function JobDialog({
 										onChange={(e) => {
 											const newStatus = e.target.value as JobStatus;
 											const isTerminal = TERMINAL_STATUSES.has(newStatus);
-											setForm((f) => ({
-												...f,
-												ending_substatus: isTerminal
-													? f.ending_substatus
-													: null,
-												status: newStatus,
-											}));
+											setForm((f) => {
+												const validSet =
+													newStatus === "Offer!"
+														? (OFFER_SUBSTATUSES as string[])
+														: (REJECTED_SUBSTATUSES as string[]);
+												const keepSubstatus =
+													isTerminal &&
+													f.ending_substatus !== null &&
+													validSet.includes(f.ending_substatus);
+												return {
+													...f,
+													ending_substatus: keepSubstatus
+														? f.ending_substatus
+														: null,
+													status: newStatus,
+												};
+											});
 											if (errors.status) {
 												setErrors(({ status: _, ...rest }) => rest);
 											}
@@ -479,7 +490,10 @@ export default function JobDialog({
 										<MenuItem value="">
 											<em>None</em>
 										</MenuItem>
-										{ENDING_SUBSTATUSES.map((s) => (
+										{(form.status === "Offer!"
+											? OFFER_SUBSTATUSES
+											: REJECTED_SUBSTATUSES
+										).map((s) => (
 											<MenuItem key={s} value={s}>
 												{s}
 											</MenuItem>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,4 +1,11 @@
-import type { EndingSubstatus, FitScore, JobStatus, JobTag } from "./types";
+import type {
+	EndingSubstatus,
+	FitScore,
+	JobStatus,
+	JobTag,
+	OfferSubstatus,
+	RejectedSubstatus,
+} from "./types";
 
 export const STATUSES: JobStatus[] = [
 	"Not started",
@@ -14,15 +21,23 @@ export const TERMINAL_STATUSES = new Set<JobStatus>([
 	"Rejected/Withdrawn",
 ]);
 
-export const ENDING_SUBSTATUSES: EndingSubstatus[] = [
+export const REJECTED_SUBSTATUSES: RejectedSubstatus[] = [
 	"Withdrawn",
 	"No response",
 	"Rejected",
 	"Ghosted",
 	"Job closed",
 	"Not a good fit",
-	"Offer declined",
+];
+
+export const OFFER_SUBSTATUSES: OfferSubstatus[] = [
 	"Offer accepted",
+	"Offer declined",
+];
+
+export const ENDING_SUBSTATUSES: EndingSubstatus[] = [
+	...REJECTED_SUBSTATUSES,
+	...OFFER_SUBSTATUSES,
 ];
 
 export const FIT_SCORES: FitScore[] = [

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -13,15 +13,17 @@ export type JobStatus =
 	| "Offer!"
 	| "Rejected/Withdrawn";
 
-export type EndingSubstatus =
+export type RejectedSubstatus =
 	| "Withdrawn"
 	| "Rejected"
 	| "Ghosted"
 	| "No response"
 	| "Job closed"
-	| "Not a good fit"
-	| "Offer declined"
-	| "Offer accepted";
+	| "Not a good fit";
+
+export type OfferSubstatus = "Offer accepted" | "Offer declined";
+
+export type EndingSubstatus = RejectedSubstatus | OfferSubstatus;
 
 export type FitScore =
 	| "Not sure"


### PR DESCRIPTION
## Summary

Introduces `OfferSubstatus` and `RejectedSubstatus` as typed sub-unions of `EndingSubstatus` so TypeScript enforces which substatus values are valid for each terminal `JobStatus`. Also fixes a UX bug where dragging a card to `Offer!` locked the Final Resolution dropdown to "Offer accepted" with no way to select "Offer declined".

## Details

- **`types.ts`** — `EndingSubstatus` is now `RejectedSubstatus | OfferSubstatus`; both sub-types are exported for use in components that need to constrain to one set
- **`constants.ts`** — adds `REJECTED_SUBSTATUSES` and `OFFER_SUBSTATUSES` typed arrays; the existing `ENDING_SUBSTATUSES` is now derived from both (no callsite changes for code that doesn't care about the split)
- **`EndingStatusDialog`** — removes the `disabled={isOffer}` lock; instead picks the correct substatus list based on `newStatus`, so `Offer!` shows only `["Offer accepted", "Offer declined"]` and `Rejected/Withdrawn` shows only the six rejection values. Pre-selects "Offer accepted" for `Offer!` as a sensible default
- **`JobDialog`** — the "Final Resolution" dropdown likewise filters to `OFFER_SUBSTATUSES` or `REJECTED_SUBSTATUSES` based on the currently selected status
- **`backend/validators.ts`** — `validateEndingSubstatus` now validates per-status: offer substatuses are only valid for `Offer!`, and rejection substatuses are only valid for `Rejected/Withdrawn`

## Test plan

- [x] Drag a card to `Offer!` — dialog opens with "Offer accepted" pre-selected; can change to "Offer declined"; no other values appear
- [x] Drag a card to `Rejected/Withdrawn` — dialog shows the six rejection values only; offer substatuses do not appear
- [x] Open the edit dialog for a job in `Offer!` status — Final Resolution dropdown shows only "Offer accepted" / "Offer declined"
- [x] Open the edit dialog for a job in `Rejected/Withdrawn` — Final Resolution dropdown shows only the six rejection values
- [x] TypeScript compiles with no errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)