### PR TITLE
tests: wrap async-triggering events in act() to silence React warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,3 +165,5 @@ interface Job {
 - `makeJob(overrides)` factory pattern for per-test job variants; always include all required `Job` fields
 - `beforeEach(() => vi.clearAllMocks())` in every top-level `describe`
 - `fireEvent` for interactions; MUI `Select` needs a `changeSelect` helper using `mouseDown` + `click`
+- Wrap `fireEvent` calls that kick off async state updates (e.g. API calls resolved via `.then(() => setState(...))`) in `await act(async () => { ... })` so the promise chain settles inside the act boundary and doesn't trigger "not wrapped in act" warnings
+- For tests that render a component with async data-fetching but only assert the immediate (pre-load) state, mock the fetch as a never-resolving promise (`vi.fn().mockReturnValue(new Promise(() => {}))`) so no state update fires after the synchronous assertion

--- a/frontend/src/components/jobs/JobDialog.spec.tsx
+++ b/frontend/src/components/jobs/JobDialog.spec.tsx
@@ -365,6 +365,7 @@ describe("jobDialog", () => {
 
 		it("shows a Delete button", async () => {
 			// Delete button is rendered immediately (disabled until load), then enabled
+			vi.mocked(api.getJob).mockReturnValue(new Promise(() => {}));
 			render(<JobDialog {...DEFAULT_PROPS} jobId={42} />);
 			expect(
 				screen.getByRole("button", { name: "Delete" }),
@@ -372,6 +373,7 @@ describe("jobDialog", () => {
 		});
 
 		it('shows "Save" as the submit button label', async () => {
+			vi.mocked(api.getJob).mockReturnValue(new Promise(() => {}));
 			render(<JobDialog {...DEFAULT_PROPS} jobId={42} />);
 			expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
 		});

--- a/frontend/src/components/jobs/JobManagementPage.spec.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+	act,
 	fireEvent,
 	render,
 	screen,
@@ -620,7 +621,9 @@ describe("jobManagementPage", () => {
 			);
 
 			const [{ onStatusChange }] = MockKanbanBoard.mock.lastCall!;
-			onStatusChange(job, "Applied");
+			act(() => {
+				onStatusChange(job, "Applied");
+			});
 
 			await waitFor(() => {
 				expect(vi.mocked(api.updateJob)).toHaveBeenCalledWith(
@@ -692,7 +695,9 @@ describe("jobManagementPage", () => {
 			fireEvent.click(screen.getByRole("button", { name: "Stats" }));
 			expect(screen.getByTestId("stats-page")).toBeInTheDocument();
 
-			fireEvent.click(screen.getByRole("button", { name: "Board" }));
+			await act(async () => {
+				fireEvent.click(screen.getByRole("button", { name: "Board" }));
+			});
 			expect(screen.queryByTestId("stats-page")).not.toBeInTheDocument();
 			expect(
 				screen.getByRole("button", { name: /Add Job/ }),

--- a/frontend/src/components/radar/RadarPage.spec.tsx
+++ b/frontend/src/components/radar/RadarPage.spec.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import RadarPage from "./RadarPage";
 import { api } from "../../api";
@@ -318,7 +324,9 @@ describe("radarPage", () => {
 
 			const notesField = screen.getByRole("textbox", { name: /^Notes$/i });
 			fireEvent.change(notesField, { target: { value: "Great company" } });
-			fireEvent.blur(notesField);
+			await act(async () => {
+				fireEvent.blur(notesField);
+			});
 
 			expect(mockPatch).toHaveBeenCalledWith(7, {
 				user_notes: "Great company",
@@ -347,7 +355,9 @@ describe("radarPage", () => {
 			await waitFor(() => screen.getByText("Acme"));
 			fireEvent.click(screen.getByText("Acme"));
 
-			fireEvent.click(screen.getByText("Hide from radar"));
+			await act(async () => {
+				fireEvent.click(screen.getByText("Hide from radar"));
+			});
 
 			expect(mockPatch).toHaveBeenCalledWith(3, { hidden: 1 });
 		});
@@ -364,7 +374,9 @@ describe("radarPage", () => {
 			const [restoreBtn] = screen.getAllByRole("button", {
 				name: /restore to radar/i,
 			});
-			fireEvent.click(restoreBtn!);
+			await act(async () => {
+				fireEvent.click(restoreBtn!);
+			});
 
 			expect(mockPatch).toHaveBeenCalledWith(4, { hidden: 0 });
 		});


### PR DESCRIPTION
## Summary

Fixes the React `act(...)` warnings that appeared in test output per #111.

- **RadarPage.spec.tsx**: three tests trigger `patchRadarEntry` whose `.then()` handler calls `setData`/`setLoading` — wrapped those `fireEvent` calls in `await act(async () => {...})` so the entire promise chain settles inside the act boundary
- **JobManagementPage.spec.tsx**: one test calls `onStatusChange()` directly (outside `fireEvent`) — wrapped in `act()`; a second test navigates back to the board which re-mounts `JobManagementPage` and triggers `api.getJobs()` — wrapped that click in `await act(async () => {...})`
- **JobDialog.spec.tsx**: two tests render with `jobId` to assert the pre-load state but didn't prevent `api.getJob` from resolving — overrode the mock to return a never-resolving promise so no state update fires after the synchronous assertion
- **CLAUDE.md**: added two test-writing guidelines documenting both patterns so future tests avoid the same issue

Closes #111

## Test plan

- [x] `npm test` — 1,043 tests pass (422 backend + 621 frontend)
- [x] `npm run lint:fix` — no issues
- [x] `npm run format:fix` — no issues
- [x] `npm run tsc` — no type errors
- [x] Re-ran frontend tests with `--reporter=verbose 2>&1 | grep "An update to"` — no output (zero act() warnings remain)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)