### PR TITLE
fix(stats): shrink status donut chart to fit card without clipping

### DIFF
--- a/frontend/src/components/stats/StatusDonutChart.tsx
+++ b/frontend/src/components/stats/StatusDonutChart.tsx
@@ -34,7 +34,7 @@ export default function StatusDonutChart({ byStatus }: Props) {
 				sx={{
 					alignItems: "center",
 					display: "flex",
-					height: 260,
+					height: 220,
 					justifyContent: "center",
 				}}
 			>
@@ -46,14 +46,14 @@ export default function StatusDonutChart({ byStatus }: Props) {
 	}
 
 	return (
-		<ResponsiveContainer width="100%" height={260}>
+		<ResponsiveContainer width="100%" height={220}>
 			<PieChart>
 				<Pie
 					data={data}
 					cx="50%"
-					cy="50%"
-					innerRadius={70}
-					outerRadius={100}
+					cy="44%"
+					innerRadius={35}
+					outerRadius={60}
 					paddingAngle={2}
 					dataKey="value"
 				>


### PR DESCRIPTION
## Summary

The status donut chart was 260px tall (vs. 220px for every other chart in the row), with radii large enough to clip the top inside the card and overlap the legend at the bottom.

## Details

- Reduced `ResponsiveContainer` height from 260 → 220px to match sibling charts
- Shrunk `outerRadius` 100 → 60 and `innerRadius` 70 → 35
- Shifted `cy` from 50% → 44% to give the legend more clearance at the bottom
- Same fix applied to the empty-state placeholder `Box` height

## Test plan

- [x] Visit Stats page and confirm the Status Breakdown card is the same height as the Avg. Days Per Stage / Applications per Week cards beside it on desktop
- [x] Confirm the donut is not clipped at the top and the legend doesn't overlap the chart

🤖 Generated with [Claude Code](https://claude.ai/claude-code)