### PR TITLE
refactor(JobCard): move fit score indicator to tags row

### DIFF
--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -183,17 +183,6 @@ const JobCard = React.memo(({ job, onCardClick, onToggleFavorite }: Props) => {
 					{job.company}
 				</Typography>
 
-				{job.fit_score && (
-					<Tooltip title={`Fit: ${job.fit_score}`} placement="top">
-						<Box
-							onPointerDown={(e) => e.stopPropagation()}
-							sx={{ alignItems: "center", cursor: "default", display: "flex" }}
-						>
-							<FitScoreBars score={job.fit_score} />
-						</Box>
-					</Tooltip>
-				)}
-
 				<Tooltip title="Open job listing">
 					<IconButton
 						size="small"
@@ -203,7 +192,7 @@ const JobCard = React.memo(({ job, onCardClick, onToggleFavorite }: Props) => {
 						rel="noopener noreferrer"
 						onPointerDown={(e) => e.stopPropagation()}
 						onClick={(e) => e.stopPropagation()}
-						sx={{ color: "text.disabled", flexShrink: 0 }}
+						sx={{ color: "text.disabled", flexShrink: 0, paddingX: "1px" }}
 					>
 						<OpenInNewIcon fontSize="small" />
 					</IconButton>
@@ -219,6 +208,7 @@ const JobCard = React.memo(({ job, onCardClick, onToggleFavorite }: Props) => {
 						sx={{
 							color: job.favorite ? "warning.main" : "text.disabled",
 							flexShrink: 0,
+							paddingX: "1px",
 						}}
 					>
 						{job.favorite ? (
@@ -265,6 +255,19 @@ const JobCard = React.memo(({ job, onCardClick, onToggleFavorite }: Props) => {
 									: { bgcolor: "#e0e0e0", color: "#757575" }
 							}
 						/>
+						{job.fit_score && (
+							<Tooltip title={`Fit: ${job.fit_score}`} placement="top">
+								<Box
+									sx={{
+										alignItems: "center",
+										cursor: "default",
+										display: "flex",
+									}}
+								>
+									<FitScoreBars score={job.fit_score} />
+								</Box>
+							</Tooltip>
+						)}
 						{job.referred_by && (
 							<Chip
 								icon={<PeopleIcon />}


### PR DESCRIPTION
## Summary

Moves the `FitScoreBars` widget from the card header (next to the company name) down into the tags/chips row, where it groups naturally with other metadata badges.

## Details

- Removes `FitScoreBars` from the header row (was sandwiched between company name and action buttons)
- Adds `FitScoreBars` to the chips/tags row alongside the status chip, referred-by chip, and tags
- Removes the `onPointerDown` stop-propagation handler that was only needed in the drag-sensitive header context
- Adds small `paddingX` to the open-link and favorite icon buttons to tighten spacing in the now-smaller header

## Test plan

- [x] Jobs with a fit score show the score bars in the tags row, not the header
- [x] Jobs without a fit score still render the tags row correctly
- [x] Tooltip still appears on hover over the fit score bars

🤖 Generated with [Claude Code](https://claude.ai/claude-code)