### PR TITLE
refactor(backend): Express housekeeping — imports, error handler, entrypoint split, NOT NULL

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -31,7 +31,7 @@ db.exec(`
 
   CREATE TABLE IF NOT EXISTS jobs (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id          INTEGER REFERENCES users(id),
+    user_id          INTEGER NOT NULL REFERENCES users(id),
     date_applied     TEXT     CHECK(length(date_applied) <= 16),
     company          TEXT NOT NULL CHECK(length(company) <= 128),
     role             TEXT NOT NULL CHECK(length(role) <= 256),

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,0 +1,13 @@
+import { config } from "dotenv";
+
+config({ path: `.env.${process.env["NODE_ENV"] ?? "development"}` });
+
+const { default: rawDb } = await import("./db.js");
+const { createApp } = await import("./server.js");
+
+const PORT = 3001;
+const app = createApp(rawDb);
+app.listen(PORT, () => {
+	// eslint-disable-next-line no-console
+	console.log(`JobMan API running at http://localhost:${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch server.ts",
-    "start": "tsx server.ts",
+    "dev": "tsx watch index.ts",
+    "start": "tsx index.ts",
     "test": "vitest run --coverage",
     "tsc": "tsc --noEmit",
     "deploy": "bash ./scripts/deploy-backend.sh"

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import express from "express";
+import { Router } from "express";
 import passport from "passport";
 import { Strategy as GoogleStrategy } from "passport-google-oauth20";
 import * as UsersDb from "../db/users.js";
@@ -17,12 +17,10 @@ declare global {
 	}
 }
 
-export function createAuthRouter(db: Database.Database) {
-	const router = express.Router();
-
-	// Only register the Google strategy when credentials are present.
-	// Auth routes exist in all environments but are non-functional in tests
-	// (no credentials → no strategy registered → passport.authenticate returns 500).
+// Only register the Google strategy when credentials are present.
+// Auth routes exist in all environments but are non-functional in tests
+// (no credentials → no strategy registered → passport.authenticate returns 500).
+export function registerStrategies(db: Database.Database) {
 	if (process.env["GOOGLE_CLIENT_ID"]) {
 		passport.use(
 			new GoogleStrategy(
@@ -55,6 +53,10 @@ export function createAuthRouter(db: Database.Database) {
 			),
 		);
 	}
+}
+
+export function createAuthRouter(db: Database.Database) {
+	const router = Router();
 
 	router.get(
 		"/google",

--- a/backend/routes/interviews.ts
+++ b/backend/routes/interviews.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import expressLib from "express";
+import { Router, type Response } from "express";
 import * as InterviewsDb from "../db/interviews.js";
 import { validateInterview, validateInterviewQuestion } from "../validators.js";
 
@@ -16,7 +16,7 @@ function toEnrichedResponse(rows: InterviewsDb.EnrichedInterviewRow[]) {
 //   Date-range mode:  ?from=<iso>&to=<iso>   (inclusive bounds, both optional)
 //   Cursor/page mode: ?after=<iso>&limit=<n>  (exclusive lower bound, limit 1–50)
 export function createInterviewSearchRouter(db: Database.Database) {
-	const router = expressLib.Router();
+	const router = Router();
 
 	router.get("/", (req, res) => {
 		const { from, to, after, limit } = req.query as {
@@ -70,7 +70,7 @@ function resolveInterview(
 	jobId: string,
 	interviewId: string,
 	userId: number,
-	res: expressLib.Response,
+	res: Response,
 ): InterviewsDb.InterviewRow | null {
 	if (!InterviewsDb.jobBelongsToUser(db, Number(jobId), userId)) {
 		res.status(404).json({ error: "Job not found" });
@@ -89,7 +89,7 @@ function resolveInterview(
 }
 
 export function createInterviewsRouter(db: Database.Database) {
-	const router = expressLib.Router({ mergeParams: true });
+	const router = Router({ mergeParams: true });
 
 	// GET all interviews for a job
 	router.get("/", (req, res) => {

--- a/backend/routes/jobs.ts
+++ b/backend/routes/jobs.ts
@@ -1,11 +1,11 @@
 import type Database from "better-sqlite3";
-import express from "express";
+import { Router } from "express";
 import * as JobsDb from "../db/jobs.js";
 import type { JobView } from "../db/jobs.js";
 import { validateEndingSubstatus, validateJobFields, validateOfferDate } from "../validators.js";
 
 export function createJobsRouter(db: Database.Database) {
-	const router = express.Router();
+	const router = Router();
 
 	router.get("/", (req, res) => {
 		const view: JobView = req.query.view === "full" ? "full" : "summary";

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -4,7 +4,7 @@ import session from "express-session";
 import passport from "passport";
 import SqliteStoreFactory from "better-sqlite3-session-store";
 import type Database from "better-sqlite3";
-import { createAuthRouter } from "./routes/auth.js";
+import { createAuthRouter, registerStrategies } from "./routes/auth.js";
 import { createInterviewInsightsRouter } from "./routes/interviewInsights.js";
 import {
 	createInterviewSearchRouter,
@@ -20,8 +20,6 @@ declare module "express-session" {
 		userId: number;
 	}
 }
-
-const PORT = 3001;
 
 function requireAuth(
 	req: express.Request,
@@ -61,6 +59,7 @@ export function createApp(db: Database.Database) {
 		}),
 	);
 
+	registerStrategies(db);
 	app.use(passport.initialize());
 
 	app.use("/api/auth", createAuthRouter(db));
@@ -79,19 +78,16 @@ export function createApp(db: Database.Database) {
 		createInterviewInsightsRouter(db),
 	);
 
-	return app;
-}
+	app.use(
+		(
+			err: unknown,
+			_req: express.Request,
+			res: express.Response,
+			_next: express.NextFunction,
+		) => {
+			res.status(500).json({ error: "Internal server error" });
+		},
+	);
 
-// Production startup — dynamic import keeps db.ts out of the module graph
-// When server.ts is imported by tests. dotenv is loaded first so env vars
-// Are available before db.ts runs its seed migration.
-if (process.env["NODE_ENV"] !== "test") {
-	const { config } = await import("dotenv");
-	config({ path: `.env.${process.env["NODE_ENV"] ?? "development"}` });
-	const { default: rawDb } = await import("./db.js");
-	const app = createApp(rawDb);
-	app.listen(PORT, () => {
-		// eslint-disable-next-line no-console
-		console.log(`JobMan API running at http://localhost:${PORT}`);
-	});
+	return app;
 }


### PR DESCRIPTION
## Summary

A handful of Express/structural issues surfaced during a backend architecture review, fixed in one pass.

## Details

- **Normalize express imports**: All route files now use `import { Router } from "express"` (was a mix of default import, an `expressLib` alias in `interviews.ts`, and the named import in the other three)
- **Decouple Passport strategy registration from router factory**: Extracted `registerStrategies(db)` from `createAuthRouter` so strategy registration is an explicit, visible call in `createApp` alongside `passport.initialize()` — not a hidden side effect inside a factory function
- **Global error handler**: Added a 4-argument error-handling middleware at the end of `createApp` that returns `{ "error": "Internal server error" }` with a 500 status; without it, unexpected throws produce HTML responses from an otherwise JSON API
- **Split entrypoint from factory**: Moved the production startup block out of `server.ts` into a new `index.ts`; `server.ts` is now a pure app factory (exports only `createApp`), and `dev`/`start` scripts point at `index.ts`
- **`jobs.user_id NOT NULL`**: Added the missing constraint to the schema definition in `db.ts`; the live database was already migrated via SQLite table-rebuild (preserving all data and timestamps)

## Test plan

- [ ] `npm run dev` starts the API as before
- [ ] Login / OAuth flow works
- [ ] Kanban board loads and drag-and-drop status changes persist

🤖 Generated with [Claude Code](https://claude.ai/claude-code)