### PR TITLE
feat(offers): backend — offers table, CRUD API, and status-change cascade

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -104,6 +104,33 @@ db.exec(`
 
   CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
 
+  CREATE TABLE IF NOT EXISTS offers (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id                  INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount         INTEGER,
+    target_bonus_percent    REAL,
+    equity_amount           INTEGER,
+    equity_vesting_years    INTEGER DEFAULT 4,
+    equity_type             TEXT CHECK(equity_type IN
+                              ('rsus', 'isos', 'nsos', 'profit_sharing', 'phantom')),
+    signing_bonus_amount    INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount            INTEGER,
+    other_label             TEXT     CHECK(length(other_label) <= 128),
+    other_is_recurring      INTEGER DEFAULT 0,
+    k401_match_percent      REAL,
+    offer_deadline          TEXT     CHECK(length(offer_deadline) <= 16),
+    notes                   TEXT     CHECK(length(notes) <= 20000),
+    created_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+
+  CREATE TRIGGER IF NOT EXISTS offers_updated_at
+  AFTER UPDATE ON offers FOR EACH ROW
+  BEGIN
+    UPDATE offers SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = OLD.id;
+  END;
+
   CREATE TABLE IF NOT EXISTS target_companies (
     id                         INTEGER PRIMARY KEY AUTOINCREMENT,
     name                       TEXT    NOT NULL UNIQUE,

--- a/backend/db/jobs.spec.ts
+++ b/backend/db/jobs.spec.ts
@@ -42,6 +42,26 @@ const SCHEMA = `
   );
 
   CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
+
+  CREATE TABLE IF NOT EXISTS offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount INTEGER,
+    target_bonus_percent REAL,
+    equity_amount INTEGER,
+    equity_vesting_years INTEGER DEFAULT 4,
+    equity_type TEXT,
+    signing_bonus_amount INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount INTEGER,
+    other_label TEXT,
+    other_is_recurring INTEGER DEFAULT 0,
+    k401_match_percent REAL,
+    offer_deadline TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
 `;
 
 function makeDb() {

--- a/backend/db/jobs.ts
+++ b/backend/db/jobs.ts
@@ -19,14 +19,16 @@ interface JobDbRow {
 	date_last_onsite: string | null;
 	date_offer_extended: string | null;
 	favorite: number;
+	has_offer: number;
 	created_at: string;
 	updated_at: string;
 	tags_csv: string | null;
 }
 
 // SQLite stores booleans as 0/1 — convert for the client
-export type Job = Omit<JobDbRow, "favorite" | "tags_csv" | "notes" | "job_description"> & {
+export type Job = Omit<JobDbRow, "favorite" | "has_offer" | "tags_csv" | "notes" | "job_description"> & {
 	favorite: boolean;
+	has_offer: boolean;
 	tags: string[];
 	/** Absent in summary view; present in full view. */
 	notes?: string | null;
@@ -39,7 +41,7 @@ export type JobView = "full" | "summary";
 function toClient(row: unknown): Job {
 	const r = row as JobDbRow;
 	const { tags_csv, ...rest } = r;
-	return { ...rest, favorite: Boolean(r.favorite), tags: tags_csv ? tags_csv.split(",") : [] };
+	return { ...rest, favorite: Boolean(r.favorite), has_offer: Boolean(r.has_offer), tags: tags_csv ? tags_csv.split(",") : [] };
 }
 
 export interface JobCreateData {
@@ -74,7 +76,8 @@ export type JobUpdateData = Omit<JobCreateData, "user_id" | "notes" | "job_descr
 };
 
 const JOBS_WITH_TAGS_SQL = `
-  SELECT j.*, GROUP_CONCAT(jt.tag) AS tags_csv
+  SELECT j.*, GROUP_CONCAT(jt.tag) AS tags_csv,
+         EXISTS(SELECT 1 FROM offers o WHERE o.job_id = j.id) AS has_offer
   FROM jobs j
   LEFT JOIN job_tags jt ON j.id = jt.job_id
 `;

--- a/backend/db/offers.spec.ts
+++ b/backend/db/offers.spec.ts
@@ -1,0 +1,245 @@
+import Database from "better-sqlite3";
+import {
+	getOffer,
+	createOffer,
+	updateOffer,
+	deleteOffer,
+	getOffersWithJobs,
+	type OfferCreateData,
+} from "./offers.js";
+
+const SCHEMA = `
+  CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL
+  );
+  CREATE TABLE jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    company TEXT NOT NULL,
+    role TEXT NOT NULL,
+    link TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'not_started',
+    fit_score TEXT,
+    salary TEXT,
+    favorite INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+  );
+  CREATE TABLE job_tags (
+    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    tag    TEXT NOT NULL,
+    PRIMARY KEY (job_id, tag)
+  );
+  CREATE TABLE offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount INTEGER,
+    target_bonus_percent REAL,
+    equity_amount INTEGER,
+    equity_vesting_years INTEGER DEFAULT 4,
+    equity_type TEXT,
+    signing_bonus_amount INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount INTEGER,
+    other_label TEXT,
+    other_is_recurring INTEGER DEFAULT 0,
+    k401_match_percent REAL,
+    offer_deadline TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+`;
+
+const BASE_OFFER: Omit<OfferCreateData, "job_id"> = {
+	base_pay_amount: 150_000,
+	target_bonus_percent: 15,
+	equity_amount: 400_000,
+	equity_vesting_years: 4,
+	equity_type: "rsus",
+	signing_bonus_amount: 20_000,
+	wellness_stipend_amount: 1200,
+	other_amount: null,
+	other_label: null,
+	other_is_recurring: false,
+	k401_match_percent: 4,
+	offer_deadline: "2026-07-01",
+	notes: "Great package",
+};
+
+function makeDb() {
+	const db = new Database(":memory:");
+	db.exec(SCHEMA);
+	return db;
+}
+
+describe("offers db", () => {
+	let db: Database.Database;
+	let jobId: number;
+	const USER_ID = 1;
+
+	beforeEach(() => {
+		db = makeDb();
+		db.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(USER_ID, "user@example.com");
+		const result = db
+			.prepare("INSERT INTO jobs (user_id, company, role, link, status) VALUES (?, ?, ?, ?, ?)")
+			.run(USER_ID, "Acme", "Engineer", "https://example.com", "offer");
+		jobId = Number(result.lastInsertRowid);
+	});
+
+	describe("getOffer", () => {
+		it("returns undefined when no offer exists", () => {
+			expect(getOffer(db, jobId)).toBeUndefined();
+		});
+
+		it("returns the offer when it exists", () => {
+			createOffer(db, { ...BASE_OFFER, job_id: jobId });
+			const offer = getOffer(db, jobId);
+			expect(offer).toBeDefined();
+			expect(offer!.job_id).toBe(jobId);
+			expect(offer!.base_pay_amount).toBe(150_000);
+		});
+
+		it("coalesces null equity_vesting_years to 4", () => {
+			db.prepare("INSERT INTO offers (job_id, equity_vesting_years) VALUES (?, NULL)").run(jobId);
+			const offer = getOffer(db, jobId);
+			expect(offer!.equity_vesting_years).toBe(4);
+		});
+
+		it("returns other_is_recurring as a boolean", () => {
+			createOffer(db, { ...BASE_OFFER, job_id: jobId, other_is_recurring: true });
+			const offer = getOffer(db, jobId);
+			expect(offer!.other_is_recurring).toBeTruthy();
+		});
+	});
+
+	describe("createOffer", () => {
+		it("inserts and returns the full offer row", () => {
+			const offer = createOffer(db, { ...BASE_OFFER, job_id: jobId });
+			expect(offer.id).toBeTypeOf("number");
+			expect(offer.job_id).toBe(jobId);
+			expect(offer.base_pay_amount).toBe(150_000);
+			expect(offer.equity_type).toBe("rsus");
+			expect(offer.other_is_recurring).toBeFalsy();
+		});
+
+		it("stores other_is_recurring=true as 1 and returns as boolean true", () => {
+			const offer = createOffer(db, { ...BASE_OFFER, job_id: jobId, other_is_recurring: true });
+			expect(offer.other_is_recurring).toBeTruthy();
+		});
+
+		it("defaults equity_vesting_years to 4 when null", () => {
+			const offer = createOffer(db, { ...BASE_OFFER, job_id: jobId, equity_vesting_years: null });
+			expect(offer.equity_vesting_years).toBe(4);
+		});
+	});
+
+	describe("updateOffer", () => {
+		it("replaces all fields and returns updated offer", () => {
+			createOffer(db, { ...BASE_OFFER, job_id: jobId });
+			const updated = updateOffer(db, jobId, {
+				...BASE_OFFER,
+				base_pay_amount: 200_000,
+				notes: "Updated notes",
+			});
+			expect(updated).toBeDefined();
+			expect(updated!.base_pay_amount).toBe(200_000);
+			expect(updated!.notes).toBe("Updated notes");
+		});
+
+		it("can null out fields", () => {
+			createOffer(db, { ...BASE_OFFER, job_id: jobId });
+			const updated = updateOffer(db, jobId, {
+				...BASE_OFFER,
+				base_pay_amount: null,
+				signing_bonus_amount: null,
+			});
+			expect(updated!.base_pay_amount).toBeNull();
+			expect(updated!.signing_bonus_amount).toBeNull();
+		});
+
+		it("returns null when no offer exists for the job", () => {
+			const result = updateOffer(db, jobId, BASE_OFFER);
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("deleteOffer", () => {
+		it("deletes the offer and returns true", () => {
+			createOffer(db, { ...BASE_OFFER, job_id: jobId });
+			expect(deleteOffer(db, jobId)).toBeTruthy();
+			expect(getOffer(db, jobId)).toBeUndefined();
+		});
+
+		it("returns false when no offer exists", () => {
+			expect(deleteOffer(db, jobId)).toBeFalsy();
+		});
+	});
+
+	describe("getOffersWithJobs", () => {
+		it("returns only jobs with offer status", () => {
+			db.prepare("INSERT INTO jobs (user_id, company, role, link, status) VALUES (?, ?, ?, ?, ?)")
+				.run(USER_ID, "Other Co", "PM", "https://other.com", "applied");
+			createOffer(db, { ...BASE_OFFER, job_id: jobId });
+
+			const results = getOffersWithJobs(db, USER_ID);
+			expect(results).toHaveLength(1);
+			const [first] = results;
+			expect(first!.job).toMatchObject({ id: jobId, company: "Acme" });
+		});
+
+		it("includes offer as null when job has no offer", () => {
+			const results = getOffersWithJobs(db, USER_ID);
+			expect(results).toHaveLength(1);
+			const [first] = results;
+			expect(first!.offer).toBeNull();
+		});
+
+		it("includes offer data when job has an offer", () => {
+			createOffer(db, { ...BASE_OFFER, job_id: jobId });
+			const results = getOffersWithJobs(db, USER_ID);
+			const [first] = results;
+			expect(first!.offer).toBeDefined();
+			expect((first!.offer as { base_pay_amount: number }).base_pay_amount).toBe(150_000);
+		});
+
+		it("only returns jobs belonging to the requesting user", () => {
+			db.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(2, "other@example.com");
+			db.prepare("INSERT INTO jobs (user_id, company, role, link, status) VALUES (?, ?, ?, ?, ?)")
+				.run(2, "Other Co", "PM", "https://other.com", "offer");
+
+			const results = getOffersWithJobs(db, USER_ID);
+			expect(results).toHaveLength(1);
+			const [first] = results;
+			expect(first!.job).toMatchObject({ company: "Acme" });
+		});
+
+		it("coalesces null equity_vesting_years to 4 in offer", () => {
+			db.prepare("INSERT INTO offers (job_id, equity_vesting_years) VALUES (?, NULL)").run(jobId);
+			const results = getOffersWithJobs(db, USER_ID);
+			const [first] = results;
+			expect((first!.offer as { equity_vesting_years: number }).equity_vesting_years).toBe(4);
+		});
+
+		it("returns other_is_recurring as a boolean in offer", () => {
+			createOffer(db, { ...BASE_OFFER, job_id: jobId, other_is_recurring: true });
+			const results = getOffersWithJobs(db, USER_ID);
+			const [first] = results;
+			expect((first!.offer as { other_is_recurring: boolean }).other_is_recurring).toBeTruthy();
+		});
+
+		it("returns has_offer=true on the job when an offer exists", () => {
+			createOffer(db, { ...BASE_OFFER, job_id: jobId });
+			const results = getOffersWithJobs(db, USER_ID);
+			const [first] = results;
+			expect((first!.job as { has_offer: boolean }).has_offer).toBeTruthy();
+		});
+
+		it("returns has_offer=false on the job when no offer exists", () => {
+			const results = getOffersWithJobs(db, USER_ID);
+			const [first] = results;
+			expect((first!.job as { has_offer: boolean }).has_offer).toBeFalsy();
+		});
+	});
+});

--- a/backend/db/offers.ts
+++ b/backend/db/offers.ts
@@ -1,0 +1,231 @@
+import type Database from "better-sqlite3";
+
+export interface OfferRow {
+	id: number;
+	job_id: number;
+	base_pay_amount: number | null;
+	target_bonus_percent: number | null;
+	equity_amount: number | null;
+	equity_vesting_years: number;
+	equity_type: string | null;
+	signing_bonus_amount: number | null;
+	wellness_stipend_amount: number | null;
+	other_amount: number | null;
+	other_label: string | null;
+	other_is_recurring: boolean;
+	k401_match_percent: number | null;
+	offer_deadline: string | null;
+	notes: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+interface OfferDbRow extends Omit<OfferRow, "equity_vesting_years" | "other_is_recurring"> {
+	equity_vesting_years: number | null;
+	other_is_recurring: number;
+}
+
+export interface OfferCreateData {
+	job_id: number;
+	base_pay_amount: number | null;
+	target_bonus_percent: number | null;
+	equity_amount: number | null;
+	equity_vesting_years: number | null;
+	equity_type: string | null;
+	signing_bonus_amount: number | null;
+	wellness_stipend_amount: number | null;
+	other_amount: number | null;
+	other_label: string | null;
+	other_is_recurring: boolean;
+	k401_match_percent: number | null;
+	offer_deadline: string | null;
+	notes: string | null;
+}
+
+export type OfferUpdateData = Omit<OfferCreateData, "job_id">;
+
+export interface OfferWithJobRow {
+	job_id: number;
+	company: string;
+	role: string;
+	link: string;
+	fit_score: string | null;
+	salary: string | null;
+	favorite: number;
+	tags_csv: string | null;
+	has_offer: number;
+	offer_id: number | null;
+	base_pay_amount: number | null;
+	target_bonus_percent: number | null;
+	equity_amount: number | null;
+	equity_vesting_years: number | null;
+	equity_type: string | null;
+	signing_bonus_amount: number | null;
+	wellness_stipend_amount: number | null;
+	other_amount: number | null;
+	other_label: string | null;
+	other_is_recurring: number | null;
+	k401_match_percent: number | null;
+	offer_deadline: string | null;
+	offer_notes: string | null;
+	offer_created_at: string | null;
+	offer_updated_at: string | null;
+}
+
+function toClient(row: OfferDbRow): OfferRow {
+	return {
+		...row,
+		equity_vesting_years: row.equity_vesting_years ?? 4,
+		other_is_recurring: Boolean(row.other_is_recurring),
+	};
+}
+
+export function getOffer(
+	db: Database.Database,
+	jobId: number,
+): OfferRow | undefined {
+	const row = db
+		.prepare("SELECT * FROM offers WHERE job_id = ?")
+		.get(jobId) as OfferDbRow | undefined;
+	return row ? toClient(row) : undefined;
+}
+
+export function createOffer(
+	db: Database.Database,
+	data: OfferCreateData,
+): OfferRow {
+	const result = db
+		.prepare(
+			`INSERT INTO offers (job_id, base_pay_amount, target_bonus_percent, equity_amount,
+        equity_vesting_years, equity_type, signing_bonus_amount, wellness_stipend_amount,
+        other_amount, other_label, other_is_recurring, k401_match_percent,
+        offer_deadline, notes)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			data.job_id,
+			data.base_pay_amount,
+			data.target_bonus_percent,
+			data.equity_amount,
+			data.equity_vesting_years,
+			data.equity_type,
+			data.signing_bonus_amount,
+			data.wellness_stipend_amount,
+			data.other_amount,
+			data.other_label,
+			data.other_is_recurring ? 1 : 0,
+			data.k401_match_percent,
+			data.offer_deadline,
+			data.notes,
+		);
+	return toClient(
+		db.prepare("SELECT * FROM offers WHERE id = ?").get(result.lastInsertRowid) as OfferDbRow,
+	);
+}
+
+export function updateOffer(
+	db: Database.Database,
+	jobId: number,
+	data: OfferUpdateData,
+): OfferRow | null {
+	const info = db
+		.prepare(
+			`UPDATE offers SET
+        base_pay_amount = ?, target_bonus_percent = ?, equity_amount = ?,
+        equity_vesting_years = ?, equity_type = ?, signing_bonus_amount = ?,
+        wellness_stipend_amount = ?, other_amount = ?, other_label = ?,
+        other_is_recurring = ?, k401_match_percent = ?, offer_deadline = ?, notes = ?
+      WHERE job_id = ?`,
+		)
+		.run(
+			data.base_pay_amount,
+			data.target_bonus_percent,
+			data.equity_amount,
+			data.equity_vesting_years,
+			data.equity_type,
+			data.signing_bonus_amount,
+			data.wellness_stipend_amount,
+			data.other_amount,
+			data.other_label,
+			data.other_is_recurring ? 1 : 0,
+			data.k401_match_percent,
+			data.offer_deadline,
+			data.notes,
+			jobId,
+		);
+	if (info.changes === 0) {return null;}
+	return toClient(
+		db.prepare("SELECT * FROM offers WHERE job_id = ?").get(jobId) as OfferDbRow,
+	);
+}
+
+export function deleteOffer(
+	db: Database.Database,
+	jobId: number,
+): boolean {
+	return db
+		.prepare("DELETE FROM offers WHERE job_id = ?")
+		.run(jobId).changes > 0;
+}
+
+export function getOffersWithJobs(
+	db: Database.Database,
+	userId: number,
+): { job: object; offer: OfferRow | null }[] {
+	const rows = db
+		.prepare(
+			`SELECT j.id AS job_id, j.company, j.role, j.link, j.fit_score, j.salary,
+              j.favorite, GROUP_CONCAT(jt.tag) AS tags_csv,
+              CASE WHEN o.id IS NOT NULL THEN 1 ELSE 0 END AS has_offer,
+              o.id AS offer_id,
+              o.base_pay_amount, o.target_bonus_percent, o.equity_amount,
+              o.equity_vesting_years, o.equity_type, o.signing_bonus_amount,
+              o.wellness_stipend_amount, o.other_amount, o.other_label,
+              o.other_is_recurring, o.k401_match_percent, o.offer_deadline,
+              o.notes AS offer_notes, o.created_at AS offer_created_at,
+              o.updated_at AS offer_updated_at
+       FROM jobs j
+       LEFT JOIN offers o ON o.job_id = j.id
+       LEFT JOIN job_tags jt ON jt.job_id = j.id
+       WHERE j.user_id = ? AND j.status = 'offer'
+       GROUP BY j.id
+       ORDER BY j.created_at DESC`,
+		)
+		.all(userId) as OfferWithJobRow[];
+
+	return rows.map((r) => {
+		const job = {
+			id: r.job_id,
+			company: r.company,
+			role: r.role,
+			link: r.link,
+			fit_score: r.fit_score,
+			salary: r.salary,
+			favorite: Boolean(r.favorite),
+			tags: r.tags_csv ? r.tags_csv.split(",") : [],
+			has_offer: Boolean(r.has_offer),
+		};
+		const offer = r.offer_id != null
+			? {
+				id: r.offer_id,
+				job_id: r.job_id,
+				base_pay_amount: r.base_pay_amount,
+				target_bonus_percent: r.target_bonus_percent,
+				equity_amount: r.equity_amount,
+				equity_vesting_years: r.equity_vesting_years ?? 4,
+				equity_type: r.equity_type,
+				signing_bonus_amount: r.signing_bonus_amount,
+				wellness_stipend_amount: r.wellness_stipend_amount,
+				other_amount: r.other_amount,
+				other_label: r.other_label,
+				other_is_recurring: Boolean(r.other_is_recurring),
+				k401_match_percent: r.k401_match_percent,
+				offer_deadline: r.offer_deadline,
+				notes: r.offer_notes,
+				created_at: r.offer_created_at as string,
+				updated_at: r.offer_updated_at as string,
+			}
+			: null;
+		return { job, offer };
+	});
+}

--- a/backend/routes/interviewInsights.spec.ts
+++ b/backend/routes/interviewInsights.spec.ts
@@ -67,6 +67,26 @@ const SCHEMA = `
     PRIMARY KEY (job_id, tag)
   );
   CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
+
+  CREATE TABLE IF NOT EXISTS offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount INTEGER,
+    target_bonus_percent REAL,
+    equity_amount INTEGER,
+    equity_vesting_years INTEGER DEFAULT 4,
+    equity_type TEXT,
+    signing_bonus_amount INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount INTEGER,
+    other_label TEXT,
+    other_is_recurring INTEGER DEFAULT 0,
+    k401_match_percent REAL,
+    offer_deadline TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
 `;
 
 const TEST_USER_ID = 1;

--- a/backend/routes/interviews.spec.ts
+++ b/backend/routes/interviews.spec.ts
@@ -76,6 +76,26 @@ const SCHEMA = `
   );
 
   CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
+
+  CREATE TABLE IF NOT EXISTS offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount INTEGER,
+    target_bonus_percent REAL,
+    equity_amount INTEGER,
+    equity_vesting_years INTEGER DEFAULT 4,
+    equity_type TEXT,
+    signing_bonus_amount INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount INTEGER,
+    other_label TEXT,
+    other_is_recurring INTEGER DEFAULT 0,
+    k401_match_percent REAL,
+    offer_deadline TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
 `;
 
 const TEST_USER_ID = 1;

--- a/backend/routes/jobs.spec.ts
+++ b/backend/routes/jobs.spec.ts
@@ -71,6 +71,26 @@ const SCHEMA = `
   );
 
   CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
+
+  CREATE TABLE IF NOT EXISTS offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount INTEGER,
+    target_bonus_percent REAL,
+    equity_amount INTEGER,
+    equity_vesting_years INTEGER DEFAULT 4,
+    equity_type TEXT,
+    signing_bonus_amount INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount INTEGER,
+    other_label TEXT,
+    other_is_recurring INTEGER DEFAULT 0,
+    k401_match_percent REAL,
+    offer_deadline TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
 `;
 
 const TEST_USER_ID = 1;

--- a/backend/routes/jobs.ts
+++ b/backend/routes/jobs.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import * as JobsDb from "../db/jobs.js";
 import type { JobView } from "../db/jobs.js";
 import { validateEndingSubstatus, validateJobFields, validateOfferDate } from "../validators.js";
+import * as OffersDb from "../db/offers.js";
 
 export function createJobsRouter(db: Database.Database) {
 	const router = Router();
@@ -82,9 +83,17 @@ export function createJobsRouter(db: Database.Database) {
 		);
 		if (offerDateError) {return res.status(422).json({ error: offerDateError });}
 
+		const jobId = Number(req.params.id);
+		const currentJob = db
+			.prepare("SELECT status FROM jobs WHERE id = ? AND user_id = ?")
+			.get(jobId, req.session.userId!) as { status: string } | undefined;
+		if (f.status !== undefined && currentJob?.status === "offer" && f.status !== "offer") {
+			OffersDb.deleteOffer(db, jobId);
+		}
+
 		const job = JobsDb.updateJob(
 			db,
-			Number(req.params.id),
+			jobId,
 			req.session.userId!,
 			{
 				date_applied: f.date_applied ?? null,

--- a/backend/routes/offers.spec.ts
+++ b/backend/routes/offers.spec.ts
@@ -1,0 +1,514 @@
+import { createHmac } from "node:crypto";
+import Database from "better-sqlite3";
+import request from "supertest";
+import { createApp } from "../server.js";
+
+const SCHEMA = `
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    date_applied TEXT,
+    company TEXT NOT NULL,
+    role TEXT NOT NULL,
+    link TEXT NOT NULL,
+    salary TEXT,
+    fit_score TEXT,
+    referred_by TEXT,
+    status TEXT DEFAULT 'not_started',
+    recruiter TEXT,
+    notes TEXT,
+    favorite INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    job_description TEXT,
+    ending_substatus TEXT,
+    date_phone_screen TEXT,
+    date_last_onsite TEXT,
+    date_offer_extended TEXT
+  );
+  CREATE TABLE IF NOT EXISTS job_status_history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id     INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    status     TEXT NOT NULL,
+    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+  CREATE TABLE IF NOT EXISTS interviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL,
+    interview_stage TEXT NOT NULL,
+    interview_dttm TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS interview_questions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    interview_id INTEGER NOT NULL,
+    question_type TEXT NOT NULL,
+    question_text TEXT NOT NULL,
+    difficulty INTEGER NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS job_tags (
+    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    tag    TEXT NOT NULL,
+    PRIMARY KEY (job_id, tag)
+  );
+  CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
+  CREATE TABLE IF NOT EXISTS offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount INTEGER,
+    target_bonus_percent REAL,
+    equity_amount INTEGER,
+    equity_vesting_years INTEGER DEFAULT 4,
+    equity_type TEXT,
+    signing_bonus_amount INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount INTEGER,
+    other_label TEXT,
+    other_is_recurring INTEGER DEFAULT 0,
+    k401_match_percent REAL,
+    offer_deadline TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+`;
+
+const TEST_USER_ID = 1;
+const OTHER_USER_ID = 2;
+const TEST_SESSION_ID = "test-session-offers-routes";
+const OTHER_SESSION_ID = "test-session-offers-routes-other";
+const SESSION_SECRET = "dev-secret";
+
+const testDb = new Database(":memory:");
+testDb.exec(SCHEMA);
+testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(TEST_USER_ID, "test@test.com");
+testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(OTHER_USER_ID, "other@test.com");
+testDb
+	.prepare("INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))")
+	.run(TEST_SESSION_ID, JSON.stringify({ cookie: { originalMaxAge: 604_800_000 }, userId: TEST_USER_ID }));
+testDb
+	.prepare("INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))")
+	.run(OTHER_SESSION_ID, JSON.stringify({ cookie: { originalMaxAge: 604_800_000 }, userId: OTHER_USER_ID }));
+
+function makeCookie(sessionId: string): string {
+	const sig = createHmac("sha256", SESSION_SECRET)
+		.update(sessionId)
+		.digest("base64")
+		.replace(/=+$/, "");
+	return `connect.sid=${encodeURIComponent(`s:${sessionId}.${sig}`)}`;
+}
+
+const AUTH_COOKIE = makeCookie(TEST_SESSION_ID);
+const OTHER_COOKIE = makeCookie(OTHER_SESSION_ID);
+
+const app = createApp(testDb);
+
+function req(method: "get" | "post" | "put" | "delete", url: string) {
+	return request(app)[method](url).set("Cookie", AUTH_COOKIE);
+}
+
+const BASE_OFFER = {
+	base_pay_amount: 150_000,
+	target_bonus_percent: 15,
+	equity_amount: 400_000,
+	equity_vesting_years: 4,
+	equity_type: "rsus",
+	signing_bonus_amount: 20_000,
+	wellness_stipend_amount: 1200,
+	other_amount: null,
+	other_label: null,
+	other_is_recurring: false,
+	k401_match_percent: 4,
+	offer_deadline: "2026-07-01",
+	notes: "Great package",
+};
+
+function insertJob(overrides: Record<string, unknown> = {}) {
+	const result = testDb
+		.prepare("INSERT INTO jobs (user_id, company, role, link, status) VALUES (?, ?, ?, ?, ?)")
+		.run(TEST_USER_ID, "Acme", "Engineer", "https://example.com/job/1", overrides.status ?? "offer");
+	return Number(result.lastInsertRowid);
+}
+
+afterEach(() => {
+	testDb.exec("DELETE FROM offers");
+	testDb.exec("DELETE FROM jobs");
+});
+
+describe("gET /api/jobs/:jobId/offer", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const jobId = insertJob();
+		const res = await request(app).get(`/api/jobs/${jobId}/offer`);
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 404 when job does not exist", async () => {
+		const res = await req("get", "/api/jobs/99999/offer");
+		expect(res.status).toBe(404);
+		expect(res.body.error).toBe("Job not found");
+	});
+
+	it("returns 404 when job belongs to another user", async () => {
+		const jobId = insertJob();
+		const res = await request(app)
+			.get(`/api/jobs/${jobId}/offer`)
+			.set("Cookie", OTHER_COOKIE);
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 404 when no offer exists", async () => {
+		const jobId = insertJob();
+		const res = await req("get", `/api/jobs/${jobId}/offer`);
+		expect(res.status).toBe(404);
+		expect(res.body.error).toBe("Offer not found");
+	});
+
+	it("returns 200 with the offer when it exists", async () => {
+		const jobId = insertJob();
+		testDb
+			.prepare("INSERT INTO offers (job_id, base_pay_amount) VALUES (?, ?)")
+			.run(jobId, 150_000);
+		const res = await req("get", `/api/jobs/${jobId}/offer`);
+		expect(res.status).toBe(200);
+		expect(res.body.job_id).toBe(jobId);
+		expect(res.body.base_pay_amount).toBe(150_000);
+	});
+});
+
+describe("pOST /api/jobs/:jobId/offer", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const jobId = insertJob();
+		const res = await request(app).post(`/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 404 when job does not exist", async () => {
+		const res = await req("post", "/api/jobs/99999/offer").send(BASE_OFFER);
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 404 when job belongs to another user", async () => {
+		const jobId = insertJob();
+		const res = await request(app)
+			.post(`/api/jobs/${jobId}/offer`)
+			.set("Cookie", OTHER_COOKIE)
+			.send(BASE_OFFER);
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 400 when job is not in offer status", async () => {
+		const jobId = insertJob({ status: "interviewing" });
+		const res = await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		expect(res.status).toBe(400);
+		expect(res.body.error).toMatch(/offer status/);
+	});
+
+	it("returns 409 when an offer already exists", async () => {
+		const jobId = insertJob();
+		await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		const second = await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		expect(second.status).toBe(409);
+		expect(second.body.error).toMatch(/already exists/);
+	});
+
+	it("creates the offer and returns 201", async () => {
+		const jobId = insertJob();
+		const res = await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		expect(res.status).toBe(201);
+		expect(res.body.job_id).toBe(jobId);
+		expect(res.body.base_pay_amount).toBe(150_000);
+		expect(res.body.other_is_recurring).toBeFalsy();
+		expect(res.body.equity_vesting_years).toBe(4);
+	});
+
+	it("coalesces null equity_vesting_years to 4", async () => {
+		const jobId = insertJob();
+		const res = await req("post", `/api/jobs/${jobId}/offer`).send({
+			...BASE_OFFER,
+			equity_vesting_years: null,
+		});
+		expect(res.status).toBe(201);
+		expect(res.body.equity_vesting_years).toBe(4);
+	});
+
+	it("returns other_is_recurring as boolean true", async () => {
+		const jobId = insertJob();
+		const res = await req("post", `/api/jobs/${jobId}/offer`).send({
+			...BASE_OFFER,
+			other_is_recurring: true,
+		});
+		expect(res.status).toBe(201);
+		expect(res.body.other_is_recurring).toBeTruthy();
+	});
+
+	it("stores null for all optional fields when body is empty", async () => {
+		const jobId = insertJob();
+		const res = await req("post", `/api/jobs/${jobId}/offer`).send({});
+		expect(res.status).toBe(201);
+		expect(res.body).toMatchObject({
+			base_pay_amount: null,
+			target_bonus_percent: null,
+			equity_amount: null,
+			equity_vesting_years: 4,
+			equity_type: null,
+			signing_bonus_amount: null,
+			wellness_stipend_amount: null,
+			other_amount: null,
+			other_label: null,
+			other_is_recurring: false,
+			k401_match_percent: null,
+			offer_deadline: null,
+			notes: null,
+		});
+	});
+});
+
+describe("pUT /api/jobs/:jobId/offer", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const jobId = insertJob();
+		const res = await request(app).put(`/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 400 when job is not in offer status", async () => {
+		const jobId = insertJob({ status: "applied" });
+		const res = await req("put", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 404 when no offer exists to update", async () => {
+		const jobId = insertJob();
+		const res = await req("put", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		expect(res.status).toBe(404);
+		expect(res.body.error).toBe("Offer not found");
+	});
+
+	it("returns 404 when job belongs to another user", async () => {
+		const jobId = insertJob();
+		testDb.prepare("INSERT INTO offers (job_id) VALUES (?)").run(jobId);
+		const res = await request(app)
+			.put(`/api/jobs/${jobId}/offer`)
+			.set("Cookie", OTHER_COOKIE)
+			.send(BASE_OFFER);
+		expect(res.status).toBe(404);
+	});
+
+	it("updates all fields and returns 200", async () => {
+		const jobId = insertJob();
+		await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		const res = await req("put", `/api/jobs/${jobId}/offer`).send({
+			...BASE_OFFER,
+			base_pay_amount: 200_000,
+			notes: "Updated",
+		});
+		expect(res.status).toBe(200);
+		expect(res.body.base_pay_amount).toBe(200_000);
+		expect(res.body.notes).toBe("Updated");
+	});
+
+	it("can null out fields (full replace)", async () => {
+		const jobId = insertJob();
+		await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		const res = await req("put", `/api/jobs/${jobId}/offer`).send({
+			...BASE_OFFER,
+			base_pay_amount: null,
+		});
+		expect(res.status).toBe(200);
+		expect(res.body.base_pay_amount).toBeNull();
+	});
+
+	it("stores null for all optional fields when body is empty", async () => {
+		const jobId = insertJob();
+		await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		const res = await req("put", `/api/jobs/${jobId}/offer`).send({});
+		expect(res.status).toBe(200);
+		expect(res.body).toMatchObject({
+			base_pay_amount: null,
+			target_bonus_percent: null,
+			equity_amount: null,
+			equity_vesting_years: 4,
+			equity_type: null,
+			signing_bonus_amount: null,
+			wellness_stipend_amount: null,
+			other_amount: null,
+			other_label: null,
+			other_is_recurring: false,
+			k401_match_percent: null,
+			offer_deadline: null,
+			notes: null,
+		});
+	});
+
+	it("returns other_is_recurring as boolean true", async () => {
+		const jobId = insertJob();
+		await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		const res = await req("put", `/api/jobs/${jobId}/offer`).send({
+			...BASE_OFFER,
+			other_is_recurring: true,
+		});
+		expect(res.status).toBe(200);
+		expect(res.body.other_is_recurring).toBeTruthy();
+	});
+});
+
+describe("dELETE /api/jobs/:jobId/offer", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const jobId = insertJob();
+		const res = await request(app).delete(`/api/jobs/${jobId}/offer`);
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 404 when job does not exist", async () => {
+		const res = await req("delete", "/api/jobs/99999/offer");
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 404 when job belongs to another user", async () => {
+		const jobId = insertJob();
+		testDb.prepare("INSERT INTO offers (job_id) VALUES (?)").run(jobId);
+		const res = await request(app)
+			.delete(`/api/jobs/${jobId}/offer`)
+			.set("Cookie", OTHER_COOKIE);
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 404 when no offer exists", async () => {
+		const jobId = insertJob();
+		const res = await req("delete", `/api/jobs/${jobId}/offer`);
+		expect(res.status).toBe(404);
+		expect(res.body.error).toBe("Offer not found");
+	});
+
+	it("deletes the offer and returns 204", async () => {
+		const jobId = insertJob();
+		testDb.prepare("INSERT INTO offers (job_id) VALUES (?)").run(jobId);
+		const res = await req("delete", `/api/jobs/${jobId}/offer`);
+		expect(res.status).toBe(204);
+
+		// Confirm it's gone
+		const getRes = await req("get", `/api/jobs/${jobId}/offer`);
+		expect(getRes.status).toBe(404);
+	});
+});
+
+describe("gET /api/offers", () => {
+	it("returns 401 when unauthenticated", async () => {
+		const res = await request(app).get("/api/offers");
+		expect(res.status).toBe(401);
+	});
+
+	it("returns empty array when no jobs are in offer status", async () => {
+		insertJob({ status: "applied" });
+		const res = await req("get", "/api/offers");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(0);
+	});
+
+	it("returns jobs in offer status with null offer when none created", async () => {
+		insertJob();
+		const res = await req("get", "/api/offers");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(1);
+		expect(res.body[0].offer).toBeNull();
+	});
+
+	it("returns jobs in offer status with their offer", async () => {
+		const jobId = insertJob();
+		testDb
+			.prepare("INSERT INTO offers (job_id, base_pay_amount) VALUES (?, ?)")
+			.run(jobId, 180_000);
+		const res = await req("get", "/api/offers");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(1);
+		expect(res.body[0].job.id).toBe(jobId);
+		expect(res.body[0].offer.base_pay_amount).toBe(180_000);
+	});
+
+	it("does not return jobs belonging to other users", async () => {
+		const result = testDb
+			.prepare("INSERT INTO jobs (user_id, company, role, link, status) VALUES (?, ?, ?, ?, ?)")
+			.run(OTHER_USER_ID, "Other Co", "PM", "https://other.com", "offer");
+		testDb.prepare("INSERT INTO offers (job_id) VALUES (?)").run(Number(result.lastInsertRowid));
+
+		const res = await req("get", "/api/offers");
+		expect(res.status).toBe(200);
+		expect(res.body).toHaveLength(0);
+	});
+});
+
+describe("offer cascade delete on job status change", () => {
+	it("deletes the offer when job moves away from offer status", async () => {
+		const jobId = insertJob();
+		await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+
+		// Verify offer exists
+		let offerRes = await req("get", `/api/jobs/${jobId}/offer`);
+		expect(offerRes.status).toBe(200);
+
+		// Move job out of offer status
+		await request(app)
+			.put(`/api/jobs/${jobId}`)
+			.set("Cookie", AUTH_COOKIE)
+			.send({
+				company: "Acme",
+				role: "Engineer",
+				link: "https://example.com/job/1",
+				status: "rejected_or_withdrawn",
+				ending_substatus: "Withdrawn",
+				date_offer_extended: null,
+				favorite: false,
+				tags: [],
+			});
+
+		// Offer should be gone
+		offerRes = await req("get", `/api/jobs/${jobId}/offer`);
+		expect(offerRes.status).toBe(404);
+	});
+
+	it("does not delete the offer when job stays in offer status", async () => {
+		const jobId = insertJob();
+		await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+
+		await request(app)
+			.put(`/api/jobs/${jobId}`)
+			.set("Cookie", AUTH_COOKIE)
+			.send({
+				company: "Acme Updated",
+				role: "Engineer",
+				link: "https://example.com/job/1",
+				status: "offer",
+				ending_substatus: null,
+				date_offer_extended: "2026-07-01",
+				favorite: false,
+				tags: [],
+			});
+
+		const offerRes = await req("get", `/api/jobs/${jobId}/offer`);
+		expect(offerRes.status).toBe(200);
+	});
+});
+
+describe("has_offer field on job list", () => {
+	it("returns has_offer=false when no offer exists", async () => {
+		insertJob();
+		const res = await req("get", "/api/jobs");
+		expect(res.status).toBe(200);
+		expect(res.body[0].has_offer).toBeFalsy();
+	});
+
+	it("returns has_offer=true when an offer exists", async () => {
+		const jobId = insertJob();
+		testDb.prepare("INSERT INTO offers (job_id) VALUES (?)").run(jobId);
+		const res = await req("get", "/api/jobs");
+		expect(res.status).toBe(200);
+		expect(res.body[0].has_offer).toBeTruthy();
+	});
+});

--- a/backend/routes/offers.ts
+++ b/backend/routes/offers.ts
@@ -1,0 +1,124 @@
+import type Database from "better-sqlite3";
+import { Router } from "express";
+import * as JobsDb from "../db/jobs.js";
+import * as OffersDb from "../db/offers.js";
+
+function getJobInOfferStatus(
+	db: Database.Database,
+	jobId: number,
+	userId: number,
+	res: Parameters<Parameters<ReturnType<typeof Router>["get"]>[1]>[1],
+): boolean {
+	const job = JobsDb.findJob(db, jobId, userId);
+	if (!job) {
+		res.status(404).json({ error: "Job not found" });
+		return false;
+	}
+	if (job.status !== "offer") {
+		res.status(400).json({ error: "Job is not in offer status" });
+		return false;
+	}
+	return true;
+}
+
+export function createOffersRouter(db: Database.Database) {
+	const router = Router({ mergeParams: true });
+
+	// GET /api/jobs/:jobId/offer
+	router.get("/", (req, res) => {
+		const { jobId } = req.params as { jobId: string };
+		const userId = req.session.userId!;
+
+		const job = JobsDb.findJob(db, Number(jobId), userId);
+		if (!job) {return res.status(404).json({ error: "Job not found" });}
+
+		const offer = OffersDb.getOffer(db, Number(jobId));
+		if (!offer) {return res.status(404).json({ error: "Offer not found" });}
+		return res.json(offer);
+	});
+
+	// POST /api/jobs/:jobId/offer
+	router.post("/", (req, res) => {
+		const { jobId } = req.params as { jobId: string };
+		const userId = req.session.userId!;
+		const f = req.body as Record<string, unknown>;
+
+		if (!getJobInOfferStatus(db, Number(jobId), userId, res)) {return;}
+
+		if (OffersDb.getOffer(db, Number(jobId))) {
+			return res.status(409).json({ error: "Offer already exists for this job" });
+		}
+
+		const offer = OffersDb.createOffer(db, {
+			job_id: Number(jobId),
+			base_pay_amount: (f.base_pay_amount as number | null) ?? null,
+			target_bonus_percent: (f.target_bonus_percent as number | null) ?? null,
+			equity_amount: (f.equity_amount as number | null) ?? null,
+			equity_vesting_years: (f.equity_vesting_years as number | null) ?? null,
+			equity_type: (f.equity_type as string | null) ?? null,
+			signing_bonus_amount: (f.signing_bonus_amount as number | null) ?? null,
+			wellness_stipend_amount: (f.wellness_stipend_amount as number | null) ?? null,
+			other_amount: (f.other_amount as number | null) ?? null,
+			other_label: (f.other_label as string | null) ?? null,
+			other_is_recurring: Boolean(f.other_is_recurring),
+			k401_match_percent: (f.k401_match_percent as number | null) ?? null,
+			offer_deadline: (f.offer_deadline as string | null) ?? null,
+			notes: (f.notes as string | null) ?? null,
+		});
+		return res.status(201).json(offer);
+	});
+
+	// PUT /api/jobs/:jobId/offer
+	router.put("/", (req, res) => {
+		const { jobId } = req.params as { jobId: string };
+		const userId = req.session.userId!;
+		const f = req.body as Record<string, unknown>;
+
+		if (!getJobInOfferStatus(db, Number(jobId), userId, res)) {return;}
+
+		const offer = OffersDb.updateOffer(db, Number(jobId), {
+			base_pay_amount: (f.base_pay_amount as number | null) ?? null,
+			target_bonus_percent: (f.target_bonus_percent as number | null) ?? null,
+			equity_amount: (f.equity_amount as number | null) ?? null,
+			equity_vesting_years: (f.equity_vesting_years as number | null) ?? null,
+			equity_type: (f.equity_type as string | null) ?? null,
+			signing_bonus_amount: (f.signing_bonus_amount as number | null) ?? null,
+			wellness_stipend_amount: (f.wellness_stipend_amount as number | null) ?? null,
+			other_amount: (f.other_amount as number | null) ?? null,
+			other_label: (f.other_label as string | null) ?? null,
+			other_is_recurring: Boolean(f.other_is_recurring),
+			k401_match_percent: (f.k401_match_percent as number | null) ?? null,
+			offer_deadline: (f.offer_deadline as string | null) ?? null,
+			notes: (f.notes as string | null) ?? null,
+		});
+		if (!offer) {return res.status(404).json({ error: "Offer not found" });}
+		return res.json(offer);
+	});
+
+	// DELETE /api/jobs/:jobId/offer
+	router.delete("/", (req, res) => {
+		const { jobId } = req.params as { jobId: string };
+		const userId = req.session.userId!;
+
+		const job = JobsDb.findJob(db, Number(jobId), userId);
+		if (!job) {return res.status(404).json({ error: "Job not found" });}
+
+		const deleted = OffersDb.deleteOffer(db, Number(jobId));
+		if (!deleted) {return res.status(404).json({ error: "Offer not found" });}
+		return res.status(204).send();
+	});
+
+	return router;
+}
+
+export function createOffersListRouter(db: Database.Database) {
+	const router = Router();
+
+	// GET /api/offers — all jobs in offer status with their offer (or null)
+	router.get("/", (req, res) => {
+		const results = OffersDb.getOffersWithJobs(db, req.session.userId!);
+		return res.json(results);
+	});
+
+	return router;
+}

--- a/backend/routes/radar.spec.ts
+++ b/backend/routes/radar.spec.ts
@@ -51,6 +51,32 @@ const SCHEMA = `
     job_id INTEGER NOT NULL,
     interview_dttm TEXT NOT NULL
   );
+
+  CREATE TABLE IF NOT EXISTS offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount INTEGER,
+    target_bonus_percent REAL,
+    equity_amount INTEGER,
+    equity_vesting_years INTEGER DEFAULT 4,
+    equity_type TEXT,
+    signing_bonus_amount INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount INTEGER,
+    other_label TEXT,
+    other_is_recurring INTEGER DEFAULT 0,
+    k401_match_percent REAL,
+    offer_deadline TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS job_tags (
+    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    tag    TEXT NOT NULL,
+    PRIMARY KEY (job_id, tag)
+  );
 `;
 
 const SESSION_SECRET = "dev-secret";

--- a/backend/routes/stats.spec.ts
+++ b/backend/routes/stats.spec.ts
@@ -66,6 +66,26 @@ const SCHEMA = `
   );
 
   CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
+
+  CREATE TABLE IF NOT EXISTS offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount INTEGER,
+    target_bonus_percent REAL,
+    equity_amount INTEGER,
+    equity_vesting_years INTEGER DEFAULT 4,
+    equity_type TEXT,
+    signing_bonus_amount INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount INTEGER,
+    other_label TEXT,
+    other_is_recurring INTEGER DEFAULT 0,
+    k401_match_percent REAL,
+    offer_deadline TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
 `;
 
 const TEST_USER_ID = 1;

--- a/backend/server.spec.ts
+++ b/backend/server.spec.ts
@@ -67,6 +67,26 @@ const SCHEMA = `
   );
 
   CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
+
+  CREATE TABLE IF NOT EXISTS offers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
+    base_pay_amount INTEGER,
+    target_bonus_percent REAL,
+    equity_amount INTEGER,
+    equity_vesting_years INTEGER DEFAULT 4,
+    equity_type TEXT,
+    signing_bonus_amount INTEGER,
+    wellness_stipend_amount INTEGER,
+    other_amount INTEGER,
+    other_label TEXT,
+    other_is_recurring INTEGER DEFAULT 0,
+    k401_match_percent REAL,
+    offer_deadline TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
 `;
 
 const TEST_USER_ID = 1;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -11,6 +11,7 @@ import {
 	createInterviewsRouter,
 } from "./routes/interviews.js";
 import { createJobsRouter } from "./routes/jobs.js";
+import { createOffersListRouter, createOffersRouter } from "./routes/offers.js";
 import { createRadarRouter } from "./routes/radar.js";
 import { createStatsRouter } from "./routes/stats.js";
 
@@ -70,6 +71,8 @@ export function createApp(db: Database.Database) {
 		requireAuth,
 		createInterviewsRouter(db),
 	);
+	app.use("/api/jobs/:jobId/offer", requireAuth, createOffersRouter(db));
+	app.use("/api/offers", requireAuth, createOffersListRouter(db));
 	app.use("/api/radar", requireAuth, createRadarRouter(db));
 	app.use("/api/stats", requireAuth, createStatsRouter(db));
 	app.use(


### PR DESCRIPTION
## Summary

- Adds the `offers` table (and `offers_updated_at` trigger) to the SQLite schema in `db.ts`
- Adds `has_offer` boolean (via `EXISTS` subquery) to every job list response
- New `backend/db/offers.ts` with `getOffer`, `createOffer`, `updateOffer`, `deleteOffer`, `getOffersWithJobs`
- New `backend/routes/offers.ts` mounting at `GET/POST/PUT/DELETE /api/jobs/:jobId/offer` and `GET /api/offers`
- `PUT /api/jobs/:id` auto-deletes any associated offer row when the job's status transitions away from `offer`
- All coercions applied: `equity_vesting_years` null→4; `other_is_recurring` 0/1→boolean

## Test plan

- [x] `npm test` — all 475 backend + 631 frontend tests pass
- [x] `npm run tsc` — no type errors
- [x] `npm run lint:fix` — no lint failures
- [x] `npm run format:fix` — no format failures
- [x] New `backend/db/offers.spec.ts` covers all db functions and coercions
- [x] New `backend/routes/offers.spec.ts` covers all routes, auth, ownership, status guards, 409, 204, cascade delete, `has_offer` field

Closes #124

🤖 Generated with [Claude Code](https://claude.ai/claude-code)