### PR TITLE
refactor(tests): consolidate inline DDL into applySchema() from db.ts

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -1,12 +1,8 @@
 import Database from "better-sqlite3";
 import { join } from "node:path";
 
-const db = new Database(join(import.meta.dirname, "jobman.db"));
-
-// Enable foreign key enforcement
-db.pragma("foreign_keys = ON");
-
-db.exec(`
+export function applySchema(db: Database.Database): void {
+	db.exec(`
   CREATE TABLE IF NOT EXISTS users (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     email        TEXT NOT NULL,
@@ -150,6 +146,13 @@ db.exec(`
     hidden                     INTEGER NOT NULL DEFAULT 0
   );
 `);
+}
+
+const db = new Database(join(import.meta.dirname, "jobman.db"));
+
+// Enable foreign key enforcement
+db.pragma("foreign_keys = ON");
+applySchema(db);
 
 // Seed target companies (INSERT OR IGNORE — safe to re-run)
 db.exec(`

--- a/backend/db/interviewInsights.spec.ts
+++ b/backend/db/interviewInsights.spec.ts
@@ -1,43 +1,11 @@
 
 import Database from "better-sqlite3";
 import { getInterviewInsights } from "./interviewInsights.js";
-
-const SCHEMA = `
-  CREATE TABLE users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    company TEXT NOT NULL DEFAULT 'Acme',
-    role TEXT NOT NULL DEFAULT 'Engineer',
-    link TEXT NOT NULL DEFAULT 'https://example.com',
-    status TEXT DEFAULT 'Not started'
-  );
-  CREATE TABLE interviews (
-    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id              INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    interview_stage     TEXT NOT NULL,
-    interview_dttm      TEXT NOT NULL,
-    interview_type      TEXT,
-    interview_vibe      TEXT,
-    interview_result    TEXT,
-    interview_feeling   TEXT
-  );
-  CREATE TABLE interview_questions (
-    id             INTEGER PRIMARY KEY AUTOINCREMENT,
-    interview_id   INTEGER NOT NULL REFERENCES interviews(id) ON DELETE CASCADE,
-    question_type  TEXT NOT NULL,
-    question_text  TEXT NOT NULL,
-    question_notes TEXT,
-    difficulty     INTEGER NOT NULL
-  );
-`;
+import { applySchema } from "../db.js";
 
 function makeDb() {
 	const db = new Database(":memory:");
-	db.exec(SCHEMA);
+	applySchema(db);
 	return db;
 }
 
@@ -49,7 +17,7 @@ function insertJob(
 	const res = db
 		.prepare(
 			`INSERT INTO jobs (user_id, company, role, link, status)
-       VALUES (?, ?, 'Engineer', 'https://example.com', 'Interviewing')`,
+       VALUES (?, ?, 'Engineer', 'https://example.com', 'interviewing')`,
 		)
 		.run(userId, overrides.company ?? "Acme") as { lastInsertRowid: number };
 	return Number(res.lastInsertRowid);

--- a/backend/db/interviews.spec.ts
+++ b/backend/db/interviews.spec.ts
@@ -1,53 +1,16 @@
 
 import Database from "better-sqlite3";
 import { jobBelongsToUser, listInterviews, findInterview, createInterview, updateInterview, deleteInterview, listQuestions, findQuestion, createQuestion, updateQuestion, deleteQuestion, type InterviewCreateData, type QuestionCreateData } from './interviews.js';
-
-const SCHEMA = `
-  CREATE TABLE users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    status TEXT DEFAULT 'Not started',
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now'))
-  );
-  CREATE TABLE interviews (
-    id                     INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id                 INTEGER NOT NULL,
-    interview_stage        TEXT NOT NULL,
-    interview_dttm         TEXT NOT NULL,
-    interview_interviewers TEXT,
-    interview_type         TEXT,
-    interview_vibe         TEXT,
-    interview_notes        TEXT,
-    interview_result       TEXT,
-    interview_feeling      TEXT
-  );
-  CREATE TABLE interview_questions (
-    id             INTEGER PRIMARY KEY AUTOINCREMENT,
-    interview_id   INTEGER NOT NULL,
-    question_type  TEXT NOT NULL,
-    question_text  TEXT NOT NULL,
-    question_notes TEXT,
-    difficulty     INTEGER NOT NULL
-  );
-`;
+import { applySchema } from "../db.js";
 
 function makeDb() {
 	const db = new Database(":memory:");
-	db.exec(SCHEMA);
+	applySchema(db);
 	return db;
 }
 
 const BASE_INTERVIEW: Omit<InterviewCreateData, "job_id"> = {
-	interview_dttm: "2025-06-01T10:00:00Z",
+	interview_dttm: "2025-06-01T10:00",
 	interview_feeling: null,
 	interview_interviewers: "Alice",
 	interview_notes: "Went well",
@@ -142,7 +105,7 @@ describe("interviews db", () => {
 			expect(interview.id).toBeGreaterThan(0);
 			expect(interview.job_id).toBe(jobId);
 			expect(interview.interview_stage).toBe("Technical");
-			expect(interview.interview_dttm).toBe("2025-06-01T10:00:00Z");
+			expect(interview.interview_dttm).toBe("2025-06-01T10:00");
 		});
 
 		it("stores nullable fields as null", () => {

--- a/backend/db/jobs.spec.ts
+++ b/backend/db/jobs.spec.ts
@@ -1,72 +1,11 @@
 
 import Database from "better-sqlite3";
 import { listJobs, findJob, jobExists, createJob, updateJob, deleteJob, type JobCreateData } from './jobs.js';
-
-const SCHEMA = `
-  CREATE TABLE users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    date_applied TEXT,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    salary TEXT,
-    fit_score TEXT,
-    referred_by TEXT,
-    status TEXT DEFAULT 'not_started',
-    recruiter TEXT,
-    notes TEXT,
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now')),
-    job_description TEXT,
-    ending_substatus TEXT,
-    date_phone_screen TEXT,
-    date_last_onsite TEXT,
-    date_offer_extended TEXT
-  );
-  CREATE TABLE job_status_history (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id     INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    status     TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE job_tags (
-    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
-    PRIMARY KEY (job_id, tag)
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
-
-  CREATE TABLE IF NOT EXISTS offers (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
-    base_pay_amount INTEGER,
-    target_bonus_percent REAL,
-    equity_amount INTEGER,
-    equity_vesting_years INTEGER DEFAULT 4,
-    equity_type TEXT,
-    signing_bonus_amount INTEGER,
-    wellness_stipend_amount INTEGER,
-    other_amount INTEGER,
-    other_label TEXT,
-    other_is_recurring INTEGER DEFAULT 0,
-    k401_match_percent REAL,
-    offer_deadline TEXT,
-    notes TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-`;
+import { applySchema } from "../db.js";
 
 function makeDb() {
 	const db = new Database(":memory:");
-	db.exec(SCHEMA);
+	applySchema(db);
 	return db;
 }
 

--- a/backend/db/offers.spec.ts
+++ b/backend/db/offers.spec.ts
@@ -7,50 +7,7 @@ import {
 	getOffersWithJobs,
 	type OfferCreateData,
 } from "./offers.js";
-
-const SCHEMA = `
-  CREATE TABLE users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'not_started',
-    fit_score TEXT,
-    salary TEXT,
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now'))
-  );
-  CREATE TABLE job_tags (
-    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
-    PRIMARY KEY (job_id, tag)
-  );
-  CREATE TABLE offers (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
-    base_pay_amount INTEGER,
-    target_bonus_percent REAL,
-    equity_amount INTEGER,
-    equity_vesting_years INTEGER DEFAULT 4,
-    equity_type TEXT,
-    signing_bonus_amount INTEGER,
-    wellness_stipend_amount INTEGER,
-    other_amount INTEGER,
-    other_label TEXT,
-    other_is_recurring INTEGER DEFAULT 0,
-    k401_match_percent REAL,
-    offer_deadline TEXT,
-    notes TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-`;
+import { applySchema } from "../db.js";
 
 const BASE_OFFER: Omit<OfferCreateData, "job_id"> = {
 	base_pay_amount: 150_000,
@@ -70,7 +27,7 @@ const BASE_OFFER: Omit<OfferCreateData, "job_id"> = {
 
 function makeDb() {
 	const db = new Database(":memory:");
-	db.exec(SCHEMA);
+	applySchema(db);
 	return db;
 }
 

--- a/backend/db/radar.spec.ts
+++ b/backend/db/radar.spec.ts
@@ -1,59 +1,21 @@
 
 import Database from "better-sqlite3";
 import { getRadar, patchRadarEntry } from "./radar.js";
+import { applySchema } from "../db.js";
 
-const SCHEMA = `
-  CREATE TABLE target_companies (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL UNIQUE,
-    tier TEXT NOT NULL DEFAULT 'faang_adjacent',
-    application_cooldown_days INTEGER,
-    phone_screen_cooldown_days INTEGER,
-    onsite_cooldown_days INTEGER,
-    max_apps_per_period INTEGER,
-    apps_period_days INTEGER,
-    policy_summary TEXT,
-    policy_url TEXT,
-    policy_confidence TEXT,
-    policy_updated_at TEXT,
-    user_notes TEXT,
-    hidden INTEGER NOT NULL DEFAULT 0
-  );
-  CREATE TABLE jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL DEFAULT 'Engineer',
-    link TEXT NOT NULL DEFAULT 'https://example.com',
-    status TEXT NOT NULL DEFAULT 'not_started',
-    ending_substatus TEXT,
-    date_applied TEXT,
-    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE job_status_history (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    status TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE interviews (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    interview_dttm TEXT NOT NULL
-  );
-`;
+const USER_ID = 1;
 
 function makeDb() {
 	const db = new Database(":memory:");
-	db.exec(SCHEMA);
+	applySchema(db);
+	db.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(USER_ID, "test@example.com");
+	db.prepare("INSERT INTO users (id, email) VALUES (2, 'other@example.com')").run();
 	return db;
 }
 
 function daysAgo(n: number): string {
 	return new Date(Date.now() - n * 86_400_000).toISOString().slice(0, 10);
 }
-
-const USER_ID = 1;
 
 interface CompanyOverrides {
 	name?: string;
@@ -229,7 +191,7 @@ describe("getRadar", () => {
 	it("only returns jobs for the specified user", () => {
 		const db = makeDb();
 		insertCompany(db, { name: "Acme" });
-		insertJob(db, { company: "Acme", user_id: 999 });
+		insertJob(db, { company: "Acme", user_id: 2 });
 		const result = getRadar(db, USER_ID);
 		expect(result.entries).toHaveLength(0);
 	});
@@ -297,7 +259,7 @@ describe("getRadar", () => {
 		const db = makeDb();
 		insertCompany(db, { name: "Acme" });
 		const jobId = insertJob(db, { company: "Acme", status: "interviewing", date_applied: daysAgo(20) });
-		db.prepare("INSERT INTO interviews (job_id, interview_dttm) VALUES (?, '2026-03-15T10:00')").run(jobId);
+		db.prepare("INSERT INTO interviews (job_id, interview_dttm, interview_stage) VALUES (?, '2026-03-15T10:00', 'Technical')").run(jobId);
 		const result = getRadar(db, USER_ID);
 		expect(result.entries[0]!.last_interview_date).toBe("2026-03-15T10:00");
 	});

--- a/backend/db/stats.spec.ts
+++ b/backend/db/stats.spec.ts
@@ -1,57 +1,11 @@
 
 import Database from "better-sqlite3";
 import { getJobsForLink, getStats } from "./stats.js";
-
-const SCHEMA = `
-  CREATE TABLE users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    date_applied TEXT,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    salary TEXT,
-    fit_score TEXT,
-    referred_by TEXT,
-    status TEXT DEFAULT 'not_started',
-    recruiter TEXT,
-    notes TEXT,
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now')),
-    job_description TEXT,
-    ending_substatus TEXT,
-    date_phone_screen TEXT,
-    date_last_onsite TEXT,
-    date_offer_extended TEXT
-  );
-  CREATE TABLE job_status_history (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id     INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    status     TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE interviews (
-    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id                INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    interview_stage       TEXT NOT NULL,
-    interview_dttm        TEXT NOT NULL,
-    interview_interviewers TEXT,
-    interview_type        TEXT,
-    interview_vibe        TEXT,
-    interview_notes       TEXT,
-    interview_result      TEXT,
-    interview_feeling     TEXT
-  );
-`;
+import { applySchema } from "../db.js";
 
 function makeDb() {
 	const db = new Database(":memory:");
-	db.exec(SCHEMA);
+	applySchema(db);
 	return db;
 }
 

--- a/backend/db/users.spec.ts
+++ b/backend/db/users.spec.ts
@@ -6,29 +6,11 @@ import {
 	findUserById,
 	updateGoogleTokens,
 } from "./users.js";
-
-const SCHEMA = `
-  CREATE TABLE users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL,
-    display_name TEXT,
-    avatar_url TEXT
-  );
-  CREATE TABLE user_identities (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    provider TEXT NOT NULL,
-    provider_user_id TEXT NOT NULL,
-    email TEXT NOT NULL,
-    access_token TEXT NOT NULL,
-    refresh_token TEXT,
-    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-`;
+import { applySchema } from "../db.js";
 
 function makeDb() {
 	const db = new Database(":memory:");
-	db.exec(SCHEMA);
+	applySchema(db);
 	return db;
 }
 

--- a/backend/routes/auth.spec.ts
+++ b/backend/routes/auth.spec.ts
@@ -2,20 +2,7 @@ import { createHmac } from "node:crypto";
 import Database from "better-sqlite3";
 import request from "supertest";
 import { createApp } from "../server.js";
-
-const SCHEMA = `
-  CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL,
-    display_name TEXT,
-    avatar_url TEXT
-  );
-  CREATE TABLE IF NOT EXISTS sessions (
-    sid TEXT NOT NULL PRIMARY KEY,
-    sess JSON NOT NULL,
-    expire TEXT NOT NULL
-  );
-`;
+import { applySchema } from "../db.js";
 
 const SESSION_SECRET = "dev-secret";
 
@@ -35,7 +22,14 @@ function insertSession(db: Database.Database, id: string, userId: number) {
 }
 
 const testDb = new Database(":memory:");
-testDb.exec(SCHEMA);
+applySchema(testDb);
+testDb.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+`);
 
 const TEST_USER_ID = 1;
 testDb

--- a/backend/routes/interviewInsights.spec.ts
+++ b/backend/routes/interviewInsights.spec.ts
@@ -2,99 +2,21 @@ import { createHmac } from "node:crypto";
 import Database from "better-sqlite3";
 import request from "supertest";
 import { createApp } from "../server.js";
-
-const SCHEMA = `
-  CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS sessions (
-    sid TEXT NOT NULL PRIMARY KEY,
-    sess JSON NOT NULL,
-    expire TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    date_applied TEXT,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    salary TEXT,
-    fit_score TEXT,
-    referred_by TEXT,
-    status TEXT DEFAULT 'Not started',
-    recruiter TEXT,
-    notes TEXT,
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now')),
-    job_description TEXT,
-    ending_substatus TEXT,
-    date_phone_screen TEXT,
-    date_last_onsite TEXT,
-    date_offer_extended TEXT
-  );
-  CREATE TABLE IF NOT EXISTS job_status_history (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id     INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    status     TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE IF NOT EXISTS interviews (
-    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id                INTEGER NOT NULL,
-    interview_stage       TEXT NOT NULL,
-    interview_dttm        TEXT NOT NULL,
-    interview_interviewers TEXT,
-    interview_type        TEXT,
-    interview_vibe        TEXT,
-    interview_notes       TEXT,
-    interview_result      TEXT,
-    interview_feeling     TEXT
-  );
-  CREATE TABLE IF NOT EXISTS interview_questions (
-    id             INTEGER PRIMARY KEY AUTOINCREMENT,
-    interview_id   INTEGER NOT NULL,
-    question_type  TEXT NOT NULL,
-    question_text  TEXT NOT NULL,
-    question_notes TEXT,
-    difficulty     INTEGER NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS job_tags (
-    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
-    PRIMARY KEY (job_id, tag)
-  );
-  CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
-
-  CREATE TABLE IF NOT EXISTS offers (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
-    base_pay_amount INTEGER,
-    target_bonus_percent REAL,
-    equity_amount INTEGER,
-    equity_vesting_years INTEGER DEFAULT 4,
-    equity_type TEXT,
-    signing_bonus_amount INTEGER,
-    wellness_stipend_amount INTEGER,
-    other_amount INTEGER,
-    other_label TEXT,
-    other_is_recurring INTEGER DEFAULT 0,
-    k401_match_percent REAL,
-    offer_deadline TEXT,
-    notes TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-`;
+import { applySchema } from "../db.js";
 
 const TEST_USER_ID = 1;
 const TEST_SESSION_ID = "test-session-interview-insights";
 const SESSION_SECRET = "dev-secret";
 
 const testDb = new Database(":memory:");
-testDb.exec(SCHEMA);
+applySchema(testDb);
+testDb.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+`);
 testDb
 	.prepare("INSERT INTO users (id, email) VALUES (?, ?)")
 	.run(TEST_USER_ID, "test@test.com");
@@ -126,7 +48,7 @@ function insertJob(): number {
 	const res = testDb
 		.prepare(
 			`INSERT INTO jobs (user_id, company, role, link, status)
-       VALUES (?, 'Acme', 'Engineer', 'https://example.com', 'Interviewing')`,
+       VALUES (?, 'Acme', 'Engineer', 'https://example.com', 'interviewing')`,
 		)
 		.run(TEST_USER_ID) as { lastInsertRowid: number };
 	return Number(res.lastInsertRowid);

--- a/backend/routes/interviews.spec.ts
+++ b/backend/routes/interviews.spec.ts
@@ -11,100 +11,23 @@ import {
 	VALID_INTERVIEW_VIBES,
 	VALID_QUESTION_TYPES,
 } from "../validators.js";
-
-const SCHEMA = `
-  CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS sessions (
-    sid TEXT NOT NULL PRIMARY KEY,
-    sess JSON NOT NULL,
-    expire TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    date_applied TEXT,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    salary TEXT,
-    fit_score TEXT,
-    referred_by TEXT,
-    status TEXT DEFAULT 'not_started',
-    recruiter TEXT,
-    notes TEXT,
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now')),
-    job_description TEXT,
-    ending_substatus TEXT,
-    date_phone_screen TEXT,
-    date_last_onsite TEXT,
-    date_offer_extended TEXT
-  );
-  CREATE TABLE IF NOT EXISTS job_status_history (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id     INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    status     TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE IF NOT EXISTS interviews (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    interview_stage TEXT NOT NULL,
-    interview_dttm TEXT NOT NULL,
-    interview_interviewers TEXT,
-    interview_type TEXT,
-    interview_vibe TEXT,
-    interview_notes TEXT,
-    interview_result TEXT,
-    interview_feeling TEXT
-  );
-  CREATE TABLE IF NOT EXISTS interview_questions (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    interview_id INTEGER NOT NULL,
-    question_type TEXT NOT NULL,
-    question_text TEXT NOT NULL,
-    question_notes TEXT,
-    difficulty INTEGER NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS job_tags (
-    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
-    PRIMARY KEY (job_id, tag)
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
-
-  CREATE TABLE IF NOT EXISTS offers (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
-    base_pay_amount INTEGER,
-    target_bonus_percent REAL,
-    equity_amount INTEGER,
-    equity_vesting_years INTEGER DEFAULT 4,
-    equity_type TEXT,
-    signing_bonus_amount INTEGER,
-    wellness_stipend_amount INTEGER,
-    other_amount INTEGER,
-    other_label TEXT,
-    other_is_recurring INTEGER DEFAULT 0,
-    k401_match_percent REAL,
-    offer_deadline TEXT,
-    notes TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-`;
+import { applySchema } from "../db.js";
 
 const TEST_USER_ID = 1;
 const TEST_SESSION_ID = "test-session-interviews-routes";
 const SESSION_SECRET = "dev-secret";
 
 const testDb = new Database(":memory:");
-testDb.exec(SCHEMA);
+applySchema(testDb);
+testDb.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+`);
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(TEST_USER_ID, "test@test.com");
+testDb.prepare("INSERT INTO users (id, email) VALUES (2, 'other@test.com')").run();
 testDb
 	.prepare("INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))")
 	.run(TEST_SESSION_ID, JSON.stringify({ cookie: { originalMaxAge: 604_800_000 }, userId: TEST_USER_ID }));

--- a/backend/routes/jobs.spec.ts
+++ b/backend/routes/jobs.spec.ts
@@ -8,97 +8,21 @@ import {
 	VALID_OFFER_SUBSTATUSES,
 	VALID_REJECTED_SUBSTATUSES,
 } from "../validators.js";
-
-const SCHEMA = `
-  CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS sessions (
-    sid TEXT NOT NULL PRIMARY KEY,
-    sess JSON NOT NULL,
-    expire TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    date_applied TEXT,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    salary TEXT,
-    fit_score TEXT,
-    referred_by TEXT,
-    status TEXT DEFAULT 'not_started',
-    recruiter TEXT,
-    notes TEXT,
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now')),
-    job_description TEXT,
-    ending_substatus TEXT,
-    date_phone_screen TEXT,
-    date_last_onsite TEXT,
-    date_offer_extended TEXT
-  );
-  CREATE TABLE IF NOT EXISTS job_status_history (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id     INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    status     TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE IF NOT EXISTS interviews (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    interview_stage TEXT NOT NULL,
-    interview_dttm TEXT NOT NULL,
-    interview_interviewers TEXT,
-    interview_type TEXT,
-    interview_vibe TEXT,
-    interview_notes TEXT
-  );
-  CREATE TABLE IF NOT EXISTS interview_questions (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    interview_id INTEGER NOT NULL,
-    question_type TEXT NOT NULL,
-    question_text TEXT NOT NULL,
-    question_notes TEXT,
-    difficulty INTEGER NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS job_tags (
-    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
-    PRIMARY KEY (job_id, tag)
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
-
-  CREATE TABLE IF NOT EXISTS offers (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
-    base_pay_amount INTEGER,
-    target_bonus_percent REAL,
-    equity_amount INTEGER,
-    equity_vesting_years INTEGER DEFAULT 4,
-    equity_type TEXT,
-    signing_bonus_amount INTEGER,
-    wellness_stipend_amount INTEGER,
-    other_amount INTEGER,
-    other_label TEXT,
-    other_is_recurring INTEGER DEFAULT 0,
-    k401_match_percent REAL,
-    offer_deadline TEXT,
-    notes TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-`;
+import { applySchema } from "../db.js";
 
 const TEST_USER_ID = 1;
 const TEST_SESSION_ID = "test-session-jobs-routes";
 const SESSION_SECRET = "dev-secret";
 
 const testDb = new Database(":memory:");
-testDb.exec(SCHEMA);
+applySchema(testDb);
+testDb.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+`);
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(TEST_USER_ID, "test@test.com");
 testDb
 	.prepare("INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))")

--- a/backend/routes/offers.spec.ts
+++ b/backend/routes/offers.spec.ts
@@ -2,84 +2,7 @@ import { createHmac } from "node:crypto";
 import Database from "better-sqlite3";
 import request from "supertest";
 import { createApp } from "../server.js";
-
-const SCHEMA = `
-  CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS sessions (
-    sid TEXT NOT NULL PRIMARY KEY,
-    sess JSON NOT NULL,
-    expire TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    date_applied TEXT,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    salary TEXT,
-    fit_score TEXT,
-    referred_by TEXT,
-    status TEXT DEFAULT 'not_started',
-    recruiter TEXT,
-    notes TEXT,
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now')),
-    job_description TEXT,
-    ending_substatus TEXT,
-    date_phone_screen TEXT,
-    date_last_onsite TEXT,
-    date_offer_extended TEXT
-  );
-  CREATE TABLE IF NOT EXISTS job_status_history (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id     INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    status     TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE IF NOT EXISTS interviews (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    interview_stage TEXT NOT NULL,
-    interview_dttm TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS interview_questions (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    interview_id INTEGER NOT NULL,
-    question_type TEXT NOT NULL,
-    question_text TEXT NOT NULL,
-    difficulty INTEGER NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS job_tags (
-    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
-    PRIMARY KEY (job_id, tag)
-  );
-  CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
-  CREATE TABLE IF NOT EXISTS offers (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
-    base_pay_amount INTEGER,
-    target_bonus_percent REAL,
-    equity_amount INTEGER,
-    equity_vesting_years INTEGER DEFAULT 4,
-    equity_type TEXT,
-    signing_bonus_amount INTEGER,
-    wellness_stipend_amount INTEGER,
-    other_amount INTEGER,
-    other_label TEXT,
-    other_is_recurring INTEGER DEFAULT 0,
-    k401_match_percent REAL,
-    offer_deadline TEXT,
-    notes TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-`;
+import { applySchema } from "../db.js";
 
 const TEST_USER_ID = 1;
 const OTHER_USER_ID = 2;
@@ -88,7 +11,14 @@ const OTHER_SESSION_ID = "test-session-offers-routes-other";
 const SESSION_SECRET = "dev-secret";
 
 const testDb = new Database(":memory:");
-testDb.exec(SCHEMA);
+applySchema(testDb);
+testDb.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+`);
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(TEST_USER_ID, "test@test.com");
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(OTHER_USER_ID, "other@test.com");
 testDb

--- a/backend/routes/radar.spec.ts
+++ b/backend/routes/radar.spec.ts
@@ -2,89 +2,21 @@ import { createHmac } from "node:crypto";
 import Database from "better-sqlite3";
 import request from "supertest";
 import { createApp } from "../server.js";
-
-const SCHEMA = `
-  CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS sessions (
-    sid TEXT NOT NULL PRIMARY KEY,
-    sess JSON NOT NULL,
-    expire TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS target_companies (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL UNIQUE,
-    tier TEXT NOT NULL DEFAULT 'faang_adjacent',
-    application_cooldown_days INTEGER,
-    phone_screen_cooldown_days INTEGER,
-    onsite_cooldown_days INTEGER,
-    max_apps_per_period INTEGER,
-    apps_period_days INTEGER,
-    policy_summary TEXT,
-    policy_url TEXT,
-    policy_confidence TEXT,
-    policy_updated_at TEXT,
-    user_notes TEXT,
-    hidden INTEGER NOT NULL DEFAULT 0
-  );
-  CREATE TABLE IF NOT EXISTS jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL DEFAULT 'Engineer',
-    link TEXT NOT NULL DEFAULT 'https://example.com',
-    status TEXT NOT NULL DEFAULT 'Not started',
-    ending_substatus TEXT,
-    date_applied TEXT,
-    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE IF NOT EXISTS job_status_history (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    status TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE IF NOT EXISTS interviews (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    interview_dttm TEXT NOT NULL
-  );
-
-  CREATE TABLE IF NOT EXISTS offers (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
-    base_pay_amount INTEGER,
-    target_bonus_percent REAL,
-    equity_amount INTEGER,
-    equity_vesting_years INTEGER DEFAULT 4,
-    equity_type TEXT,
-    signing_bonus_amount INTEGER,
-    wellness_stipend_amount INTEGER,
-    other_amount INTEGER,
-    other_label TEXT,
-    other_is_recurring INTEGER DEFAULT 0,
-    k401_match_percent REAL,
-    offer_deadline TEXT,
-    notes TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-
-  CREATE TABLE IF NOT EXISTS job_tags (
-    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
-    PRIMARY KEY (job_id, tag)
-  );
-`;
+import { applySchema } from "../db.js";
 
 const SESSION_SECRET = "dev-secret";
 const TEST_USER_ID = 1;
 const TEST_SESSION_ID = "test-session-radar-routes";
 
 const testDb = new Database(":memory:");
-testDb.exec(SCHEMA);
+applySchema(testDb);
+testDb.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+`);
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(TEST_USER_ID, "test@test.com");
 testDb
 	.prepare("INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))")
@@ -117,7 +49,7 @@ function insertJob(overrides: { company?: string; status?: string; date_applied?
 		.run(
 			TEST_USER_ID,
 			overrides.company ?? "Acme",
-			overrides.status ?? "Applied",
+			overrides.status ?? "applied",
 			overrides.date_applied ?? null,
 		) as { lastInsertRowid: number };
 	return Number(result.lastInsertRowid);
@@ -139,7 +71,7 @@ describe("gET /api/radar", () => {
 
 	it("returns a radar response with entries and generated_at", async () => {
 		const id = insertCompany({ name: "Acme" });
-		insertJob({ company: "Acme", status: "Applied", date_applied: daysAgo(5) });
+		insertJob({ company: "Acme", status: "applied", date_applied: daysAgo(5) });
 		const res = await req("get", "/api/radar");
 		expect(res.status).toBe(200);
 		expect(res.body.generated_at).toBeTruthy();
@@ -150,7 +82,7 @@ describe("gET /api/radar", () => {
 
 	it("excludes hidden companies by default", async () => {
 		insertCompany({ name: "Acme", hidden: 1 });
-		insertJob({ company: "Acme", status: "Applied" });
+		insertJob({ company: "Acme", status: "applied" });
 		const res = await req("get", "/api/radar");
 		expect(res.status).toBe(200);
 		expect(res.body.entries).toHaveLength(0);
@@ -158,7 +90,7 @@ describe("gET /api/radar", () => {
 
 	it("includes hidden companies when includeHidden=true", async () => {
 		insertCompany({ name: "Acme", hidden: 1 });
-		insertJob({ company: "Acme", status: "Applied" });
+		insertJob({ company: "Acme", status: "applied" });
 		const res = await req("get", "/api/radar?includeHidden=true");
 		expect(res.status).toBe(200);
 		expect(res.body.entries).toHaveLength(1);

--- a/backend/routes/stats.spec.ts
+++ b/backend/routes/stats.spec.ts
@@ -2,98 +2,21 @@ import { createHmac } from "node:crypto";
 import Database from "better-sqlite3";
 import request from "supertest";
 import { createApp } from "../server.js";
-
-const SCHEMA = `
-  CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS sessions (
-    sid TEXT NOT NULL PRIMARY KEY,
-    sess JSON NOT NULL,
-    expire TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    date_applied TEXT,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    salary TEXT,
-    fit_score TEXT,
-    referred_by TEXT,
-    status TEXT DEFAULT 'not_started',
-    recruiter TEXT,
-    notes TEXT,
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now')),
-    job_description TEXT,
-    ending_substatus TEXT,
-    date_phone_screen TEXT,
-    date_last_onsite TEXT,
-    date_offer_extended TEXT
-  );
-  CREATE TABLE IF NOT EXISTS job_status_history (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id     INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    status     TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-  CREATE TABLE IF NOT EXISTS interviews (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    interview_stage TEXT NOT NULL,
-    interview_dttm TEXT NOT NULL,
-    interview_interviewers TEXT,
-    interview_type TEXT,
-    interview_vibe TEXT,
-    interview_notes TEXT
-  );
-  CREATE TABLE IF NOT EXISTS interview_questions (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    interview_id INTEGER NOT NULL,
-    question_type TEXT NOT NULL,
-    question_text TEXT NOT NULL,
-    question_notes TEXT,
-    difficulty INTEGER NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS job_tags (
-    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
-    PRIMARY KEY (job_id, tag)
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
-
-  CREATE TABLE IF NOT EXISTS offers (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
-    base_pay_amount INTEGER,
-    target_bonus_percent REAL,
-    equity_amount INTEGER,
-    equity_vesting_years INTEGER DEFAULT 4,
-    equity_type TEXT,
-    signing_bonus_amount INTEGER,
-    wellness_stipend_amount INTEGER,
-    other_amount INTEGER,
-    other_label TEXT,
-    other_is_recurring INTEGER DEFAULT 0,
-    k401_match_percent REAL,
-    offer_deadline TEXT,
-    notes TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-`;
+import { applySchema } from "../db.js";
 
 const TEST_USER_ID = 1;
 const TEST_SESSION_ID = "test-session-stats-routes";
 const SESSION_SECRET = "dev-secret";
 
 const testDb = new Database(":memory:");
-testDb.exec(SCHEMA);
+applySchema(testDb);
+testDb.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+`);
 testDb
 	.prepare("INSERT INTO users (id, email) VALUES (?, ?)")
 	.run(TEST_USER_ID, "test@test.com");

--- a/backend/server.spec.ts
+++ b/backend/server.spec.ts
@@ -2,99 +2,21 @@ import { createHmac } from "node:crypto";
 import Database from "better-sqlite3";
 import request from "supertest";
 import { createApp } from "./server.js";
-
-const SCHEMA = `
-  CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS sessions (
-    sid TEXT NOT NULL PRIMARY KEY,
-    sess JSON NOT NULL,
-    expire TEXT NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER,
-    company TEXT NOT NULL,
-    role TEXT NOT NULL,
-    link TEXT NOT NULL,
-    status TEXT DEFAULT 'not_started',
-    favorite INTEGER DEFAULT 0,
-    created_at TEXT DEFAULT (datetime('now'))
-  );
-  CREATE TABLE IF NOT EXISTS interviews (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    interview_stage TEXT NOT NULL,
-    interview_dttm TEXT NOT NULL,
-    interview_type TEXT
-  );
-  CREATE TABLE IF NOT EXISTS interview_questions (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    interview_id INTEGER NOT NULL,
-    question_type TEXT NOT NULL,
-    question_text TEXT NOT NULL,
-    difficulty INTEGER NOT NULL
-  );
-  CREATE TABLE IF NOT EXISTS job_tags (
-    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-    tag    TEXT NOT NULL,
-    PRIMARY KEY (job_id, tag)
-  );
-
-  CREATE TABLE IF NOT EXISTS target_companies (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL UNIQUE,
-    tier TEXT NOT NULL DEFAULT 'faang_adjacent',
-    application_cooldown_days INTEGER,
-    phone_screen_cooldown_days INTEGER,
-    onsite_cooldown_days INTEGER,
-    max_apps_per_period INTEGER,
-    apps_period_days INTEGER,
-    policy_summary TEXT,
-    policy_url TEXT,
-    policy_confidence TEXT,
-    policy_updated_at TEXT,
-    user_notes TEXT,
-    hidden INTEGER NOT NULL DEFAULT 0
-  );
-  CREATE TABLE IF NOT EXISTS job_status_history (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL,
-    status TEXT NOT NULL,
-    entered_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_job_tags_tag ON job_tags(tag);
-
-  CREATE TABLE IF NOT EXISTS offers (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id INTEGER NOT NULL UNIQUE REFERENCES jobs(id) ON DELETE CASCADE,
-    base_pay_amount INTEGER,
-    target_bonus_percent REAL,
-    equity_amount INTEGER,
-    equity_vesting_years INTEGER DEFAULT 4,
-    equity_type TEXT,
-    signing_bonus_amount INTEGER,
-    wellness_stipend_amount INTEGER,
-    other_amount INTEGER,
-    other_label TEXT,
-    other_is_recurring INTEGER DEFAULT 0,
-    k401_match_percent REAL,
-    offer_deadline TEXT,
-    notes TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
-  );
-`;
+import { applySchema } from "./db.js";
 
 const TEST_USER_ID = 1;
 const TEST_SESSION_ID = "test-session-server";
 const SESSION_SECRET = "dev-secret";
 
 const testDb = new Database(":memory:");
-testDb.exec(SCHEMA);
+applySchema(testDb);
+testDb.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+`);
 testDb
 	.prepare("INSERT INTO users (id, email) VALUES (?, ?)")
 	.run(TEST_USER_ID, "test@test.com");


### PR DESCRIPTION
## Summary

- Exports `applySchema(db: Database.Database)` from `backend/db.ts` — the production DDL now lives in exactly one place
- Removes `const SCHEMA = \`...\`` and inline `CREATE TABLE` DDL from all 16 backend spec files; each now calls `applySchema(db)` instead
- Route-level specs still create the `sessions` table inline (it's managed by `better-sqlite3-session-store`, not by `db.ts`, so it can't drift)
- Fixes test data that violated production constraints once the real schema was applied: `interview_dttm` values trimmed to ≤16 chars; `status` enum values lowercased (`"Interviewing"` → `"interviewing"`, `"Applied"` → `"applied"`); missing `NOT NULL` column `interview_stage` added to radar interview inserts; `users` parent rows added where `better-sqlite3` v12's default FK enforcement required them

## Test plan

- [x] All 478 backend tests pass (`npx vitest run`)
- [x] All 631 frontend tests pass
- [x] `npm run lint:fix` — no issues
- [x] `npm run format:fix` — no changes needed
- [x] `npm run tsc` — no errors

Closes #129

🤖 Generated with [Claude Code](https://claude.ai/claude-code)