### PR TITLE
feat(offers): frontend — LeaveOfferDialog and drag/status-change guard

### DIFF
--- a/frontend/src/components/jobs/JobDialog.spec.tsx
+++ b/frontend/src/components/jobs/JobDialog.spec.tsx
@@ -1140,4 +1140,99 @@ describe("jobDialog", () => {
 			expect(DEFAULT_PROPS.onSave).toHaveBeenCalledWith(expect.any(Object));
 		});
 	});
+
+	describe("leaving the Offer column", () => {
+		const OFFER_JOB: Job = {
+			...BASE_JOB,
+			status: "offer",
+			ending_substatus: "Offer accepted",
+			has_offer: true,
+			date_offer_extended: "2024-04-01",
+		};
+
+		function clickSave() {
+			fireEvent.click(screen.getByRole("button", { name: "Save" }));
+		}
+
+		it("shows LeaveOfferDialog when status changes away from Offer and the job had an offer", async () => {
+			vi.mocked(api.getJob).mockResolvedValue(OFFER_JOB);
+			await renderEditMode(OFFER_JOB);
+
+			changeSelect("Status", "Applied");
+			clickSave();
+
+			expect(screen.getByText("Remove offer details?")).toBeInTheDocument();
+			expect(DEFAULT_PROPS.onSave).not.toHaveBeenCalled();
+		});
+
+		it("does not show LeaveOfferDialog when the job had no offer", async () => {
+			const job: Job = { ...OFFER_JOB, has_offer: false };
+			vi.mocked(api.getJob).mockResolvedValue(job);
+			await renderEditMode(job);
+
+			changeSelect("Status", "Applied");
+			clickSave();
+
+			expect(
+				screen.queryByText("Remove offer details?"),
+			).not.toBeInTheDocument();
+			expect(DEFAULT_PROPS.onSave).toHaveBeenCalledWith(
+				expect.objectContaining({ status: "applied" }),
+			);
+		});
+
+		it("does not show LeaveOfferDialog when status is left as Offer", async () => {
+			vi.mocked(api.getJob).mockResolvedValue(OFFER_JOB);
+			await renderEditMode(OFFER_JOB);
+
+			fireEvent.change(screen.getByLabelText(/Company/), {
+				target: { value: "Updated Corp" },
+			});
+			clickSave();
+
+			expect(
+				screen.queryByText("Remove offer details?"),
+			).not.toBeInTheDocument();
+			expect(DEFAULT_PROPS.onSave).toHaveBeenCalledWith(
+				expect.objectContaining({ company: "Updated Corp", status: "offer" }),
+			);
+		});
+
+		it("proceeds with the save when the dialog is confirmed", async () => {
+			vi.mocked(api.getJob).mockResolvedValue(OFFER_JOB);
+			await renderEditMode(OFFER_JOB);
+
+			changeSelect("Status", "Applied");
+			clickSave();
+			fireEvent.click(
+				screen.getByRole("button", { name: "Remove & Continue" }),
+			);
+
+			expect(DEFAULT_PROPS.onSave).toHaveBeenCalledWith(
+				expect.objectContaining({ status: "applied" }),
+			);
+		});
+
+		it("leaves the form in its pre-save state when the dialog is cancelled", async () => {
+			vi.mocked(api.getJob).mockResolvedValue(OFFER_JOB);
+			await renderEditMode(OFFER_JOB);
+
+			changeSelect("Status", "Applied");
+			clickSave();
+
+			const leaveOfferDialog = screen
+				.getByText("Remove offer details?")
+				.closest('[role="dialog"]') as HTMLElement;
+			fireEvent.click(
+				within(leaveOfferDialog).getByRole("button", { name: "Cancel" }),
+			);
+
+			expect(DEFAULT_PROPS.onSave).not.toHaveBeenCalled();
+			await waitFor(() => {
+				expect(
+					screen.getByRole("combobox", { name: "Status" }),
+				).toHaveTextContent("Applied");
+			});
+		});
+	});
 });

--- a/frontend/src/components/jobs/JobDialog.tsx
+++ b/frontend/src/components/jobs/JobDialog.tsx
@@ -22,6 +22,7 @@ import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import InterviewsTab from "./interviews/InterviewsTab";
 import OfferTab from "./OfferTab";
+import LeaveOfferDialog from "./LeaveOfferDialog";
 import EditIcon from "@mui/icons-material/Edit";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import CloseIcon from "@mui/icons-material/Close";
@@ -105,8 +106,11 @@ export default function JobDialog({
 	const [viewingQuestionsFor, setViewingQuestionsFor] =
 		useState<Interview | null>(null);
 	const [offerData, setOfferData] = useState<Offer | null>(null);
+	const [confirmLeaveOffer, setConfirmLeaveOffer] = useState(false);
 	const abortRef = useRef<AbortController | null>(null);
 	const dialogContentRef = useRef<HTMLDivElement>(null);
+	const originalStatusRef = useRef<JobStatus | null>(null);
+	const originalHasOfferRef = useRef(false);
 
 	// Force a scroll to the top of the question panel. Without this, the vertical scroll will be
 	// "inherited" from the prior, `Interviews` card content.
@@ -130,7 +134,10 @@ export default function JobDialog({
 		setInterviewCount(null);
 		setViewingQuestionsFor(null);
 		setOfferData(null);
+		setConfirmLeaveOffer(false);
 		setLoadError(null);
+		originalStatusRef.current = null;
+		originalHasOfferRef.current = false;
 
 		if (jobId === null) {
 			setLoadingJob(false);
@@ -149,6 +156,8 @@ export default function JobDialog({
 					return;
 				}
 				setForm({ ...EMPTY, ...job });
+				originalStatusRef.current = job.status;
+				originalHasOfferRef.current = job.has_offer;
 
 				if (job.status === "offer") {
 					try {
@@ -247,6 +256,14 @@ export default function JobDialog({
 
 	function handleSave() {
 		if (!validate()) {
+			return;
+		}
+		if (
+			form.status !== "offer" &&
+			originalStatusRef.current === "offer" &&
+			originalHasOfferRef.current
+		) {
+			setConfirmLeaveOffer(true);
 			return;
 		}
 		onSave(form);
@@ -810,6 +827,16 @@ export default function JobDialog({
 			</Dialog>
 
 			{confirmDialog}
+
+			<LeaveOfferDialog
+				open={confirmLeaveOffer}
+				company={form.company}
+				onConfirm={() => {
+					setConfirmLeaveOffer(false);
+					onSave(form);
+				}}
+				onCancel={() => setConfirmLeaveOffer(false)}
+			/>
 		</>
 	);
 }

--- a/frontend/src/components/jobs/KanbanBoard.spec.tsx
+++ b/frontend/src/components/jobs/KanbanBoard.spec.tsx
@@ -1,17 +1,35 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import KanbanBoard from "./KanbanBoard";
 import type { Job } from "../../types";
 import { STATUSES, STATUS_LABELS } from "../../constants";
 import { makeJob } from "../../testUtils";
 
+let capturedOnDragEnd: ((event: unknown) => void) | null = null;
+
+function dragJobTo(job: Job, overId: string) {
+	act(() => {
+		capturedOnDragEnd!({
+			active: { data: { current: { job } } },
+			over: { id: overId },
+		});
+	});
+}
+
 vi.mock(
 	import("@dnd-kit/core"),
 	() =>
 		({
-			DndContext: ({ children }: { children: React.ReactNode }) => (
-				<>{children}</>
-			),
+			DndContext: ({
+				children,
+				onDragEnd,
+			}: {
+				children: React.ReactNode;
+				onDragEnd: (event: unknown) => void;
+			}) => {
+				capturedOnDragEnd = onDragEnd;
+				return <>{children}</>;
+			},
 			DragOverlay: () => null,
 			pointerWithin: () => [],
 			useDraggable: () => ({
@@ -79,5 +97,85 @@ describe("kanbanBoard", () => {
 	it("shows no cards when jobs array is empty", () => {
 		render(<KanbanBoard {...DEFAULT_PROPS} jobs={[]} />);
 		expect(screen.queryByText("Acme")).not.toBeInTheDocument();
+	});
+
+	describe("leaving the Offer column", () => {
+		beforeEach(() => vi.clearAllMocks());
+
+		it("shows the LeaveOfferDialog when dragging a job with an offer out of the Offer column", () => {
+			const job = makeJob({
+				company: "Acme",
+				has_offer: true,
+				status: "offer",
+			});
+			render(<KanbanBoard {...DEFAULT_PROPS} jobs={[job]} />);
+
+			dragJobTo(job, "applied");
+
+			expect(screen.getByText("Remove offer details?")).toBeInTheDocument();
+			expect(DEFAULT_PROPS.onStatusChange).not.toHaveBeenCalled();
+		});
+
+		it("proceeds immediately when dragging a job without an offer out of the Offer column", () => {
+			const job = makeJob({
+				company: "Acme",
+				has_offer: false,
+				status: "offer",
+			});
+			render(<KanbanBoard {...DEFAULT_PROPS} jobs={[job]} />);
+
+			dragJobTo(job, "applied");
+
+			expect(
+				screen.queryByText("Remove offer details?"),
+			).not.toBeInTheDocument();
+			expect(DEFAULT_PROPS.onStatusChange).toHaveBeenCalledWith(job, "applied");
+		});
+
+		it("never shows the dialog when dragging a job into the Offer column", () => {
+			const job = makeJob({
+				company: "Acme",
+				has_offer: false,
+				status: "applied",
+			});
+			render(<KanbanBoard {...DEFAULT_PROPS} jobs={[job]} />);
+
+			dragJobTo(job, "offer");
+
+			expect(
+				screen.queryByText("Remove offer details?"),
+			).not.toBeInTheDocument();
+			expect(DEFAULT_PROPS.onStatusChange).toHaveBeenCalledWith(job, "offer");
+		});
+
+		it("completes the status change when the dialog is confirmed", () => {
+			const job = makeJob({
+				company: "Acme",
+				has_offer: true,
+				status: "offer",
+			});
+			render(<KanbanBoard {...DEFAULT_PROPS} jobs={[job]} />);
+
+			dragJobTo(job, "applied");
+			fireEvent.click(
+				screen.getByRole("button", { name: "Remove & Continue" }),
+			);
+
+			expect(DEFAULT_PROPS.onStatusChange).toHaveBeenCalledWith(job, "applied");
+		});
+
+		it("leaves the job unchanged when the dialog is cancelled", () => {
+			const job = makeJob({
+				company: "Acme",
+				has_offer: true,
+				status: "offer",
+			});
+			render(<KanbanBoard {...DEFAULT_PROPS} jobs={[job]} />);
+
+			dragJobTo(job, "applied");
+			fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+			expect(DEFAULT_PROPS.onStatusChange).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/frontend/src/components/jobs/KanbanBoard.tsx
+++ b/frontend/src/components/jobs/KanbanBoard.tsx
@@ -11,6 +11,7 @@ import { STATUSES } from "../../constants";
 import type { Job, JobStatus } from "../../types";
 import KanbanColumn from "./KanbanColumn";
 import JobCard from "./JobCard";
+import LeaveOfferDialog from "./LeaveOfferDialog";
 
 interface Props {
 	jobs: Job[];
@@ -22,6 +23,10 @@ interface Props {
 export default memo(
 	({ jobs, onStatusChange, onCardClick, onToggleFavorite }: Props) => {
 		const [activeJob, setActiveJob] = useState<Job | null>(null);
+		const [pendingStatusChange, setPendingStatusChange] = useState<{
+			job: Job;
+			newStatus: JobStatus;
+		} | null>(null);
 
 		const byStatus = useMemo(
 			() =>
@@ -54,6 +59,20 @@ export default memo(
 			if (newStatus === job.status) {
 				return;
 			}
+
+			if (job.status === "offer" && job.has_offer) {
+				setPendingStatusChange({ job, newStatus });
+				return;
+			}
+			onStatusChange(job, newStatus);
+		}
+
+		function handleConfirmLeaveOffer() {
+			if (!pendingStatusChange) {
+				return;
+			}
+			const { job, newStatus } = pendingStatusChange;
+			setPendingStatusChange(null);
 			onStatusChange(job, newStatus);
 		}
 
@@ -94,6 +113,13 @@ export default memo(
 						/>
 					) : null}
 				</DragOverlay>
+
+				<LeaveOfferDialog
+					open={pendingStatusChange !== null}
+					company={pendingStatusChange?.job.company ?? null}
+					onConfirm={handleConfirmLeaveOffer}
+					onCancel={() => setPendingStatusChange(null)}
+				/>
 			</DndContext>
 		);
 	},

--- a/frontend/src/components/jobs/LeaveOfferDialog.spec.tsx
+++ b/frontend/src/components/jobs/LeaveOfferDialog.spec.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import LeaveOfferDialog from "./LeaveOfferDialog";
+
+const DEFAULT_PROPS = {
+	company: "Acme Corp",
+	onCancel: vi.fn(),
+	onConfirm: vi.fn(),
+	open: true,
+};
+
+describe("leaveOfferDialog", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("renders the title and confirmation copy with the company name", () => {
+		render(<LeaveOfferDialog {...DEFAULT_PROPS} />);
+		expect(screen.getByText("Remove offer details?")).toBeInTheDocument();
+		expect(screen.getByText(/Acme Corp/)).toBeInTheDocument();
+		expect(
+			screen.getByText(/permanently delete the compensation details/),
+		).toBeInTheDocument();
+	});
+
+	it("calls onConfirm when Remove & Continue is clicked", () => {
+		render(<LeaveOfferDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Remove & Continue" }));
+		expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith(expect.anything());
+		expect(DEFAULT_PROPS.onCancel).not.toHaveBeenCalled();
+	});
+
+	it("calls onCancel when Cancel is clicked", () => {
+		render(<LeaveOfferDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(DEFAULT_PROPS.onCancel).toHaveBeenCalledWith(expect.anything());
+		expect(DEFAULT_PROPS.onConfirm).not.toHaveBeenCalled();
+	});
+
+	it("renders nothing meaningful when open=false", () => {
+		render(<LeaveOfferDialog {...DEFAULT_PROPS} open={false} />);
+		expect(screen.queryByText("Remove offer details?")).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/jobs/LeaveOfferDialog.tsx
+++ b/frontend/src/components/jobs/LeaveOfferDialog.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import {
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Typography,
+} from "@mui/material";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+
+interface Props {
+	open: boolean;
+	company: string | null;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export default function LeaveOfferDialog({
+	open,
+	company,
+	onConfirm,
+	onCancel,
+}: Props) {
+	return (
+		<Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
+			<DialogTitle sx={{ alignItems: "center", display: "flex", gap: 1 }}>
+				<WarningAmberIcon color="warning" />
+				Remove offer details?
+			</DialogTitle>
+			<DialogContent>
+				<Typography>
+					Moving <strong>{company}</strong> out of the Offer column will
+					permanently delete the compensation details you recorded.
+				</Typography>
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onCancel}>Cancel</Button>
+				<Button color="error" variant="contained" onClick={onConfirm}>
+					Remove & Continue
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
## Summary

Adds the confirmation dialog that fires when a user tries to move a job out of the Offer column — either via drag-and-drop on the Kanban board, or via the status dropdown in the Job Dialog — warning that the recorded compensation details will be permanently deleted.

Closes #126

## Details

- New `LeaveOfferDialog` component (`components/jobs/LeaveOfferDialog.tsx`) — single dialog rendered as two independent instances, one in `KanbanBoard` and one in `JobDialog`, each managing its own open/pending state locally
- `KanbanBoard.handleDragEnd` now intercepts drags from the Offer column to any other column when `job.has_offer` is true, deferring the status change until the user confirms
- `JobDialog` captures the loaded job's `status` and `has_offer` in refs on open, and intercepts Save when the user changes status away from `offer` and the job previously had an offer
- Confirming proceeds with the change/save (the backend cascade deletes the offer); cancelling leaves the job/form untouched
- Unit tests for `LeaveOfferDialog`, and for the new guard logic in `KanbanBoard` and `JobDialog`

## Test plan

- [x] `npm test` — all suites pass
- [x] `npm run lint` / `npm run format` / `npm run tsc` — clean
- [ ] Manually verify: dragging an offer-bearing job out of the Offer column shows the dialog; confirming completes the move and deletes the offer; cancelling leaves the job in place
- [ ] Manually verify: changing status away from Offer in the Job Dialog and saving shows the dialog with the same confirm/cancel behavior

🤖 Generated with [Claude Code](https://claude.ai/claude-code)