### PR TITLE
feat(offers): frontend — Offer Comparator page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import LoginPage from "./components/LoginPage";
 import PageSpinner from "./components/shared/PageSpinner";
 import AppShell from "./components/shared/AppShell";
 import InsightsPage from "./components/insights/InsightsPage";
+import OfferComparatorPage from "./components/offers/OfferComparatorPage";
 import JobManagementPage from "./components/jobs/JobManagementPage";
 import InterviewsPage from "./components/calendar/InterviewsPage";
 import RadarPage from "./components/radar/RadarPage";
@@ -63,6 +64,7 @@ export default function App() {
 						<Route path="/stats" element={<StatsPage />} />
 						<Route path="/insights" element={<InsightsPage />} />
 						<Route path="/radar" element={<RadarPage />} />
+						<Route path="/offers" element={<OfferComparatorPage />} />
 						<Route path="*" element={<Navigate to="/jobs" replace />} />
 					</Route>
 				</Routes>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,6 +9,7 @@ import type {
 	JobFormData,
 	LinkJob,
 	Offer,
+	OfferComparisonEntry,
 	OfferFormData,
 	RadarPatch,
 	RadarResponse,
@@ -170,4 +171,5 @@ export const api = {
 		}),
 	deleteOffer: (jobId: number) =>
 		request<void>(`/jobs/${jobId}/offer`, { method: "DELETE" }),
+	getOffersComparison: () => request<OfferComparisonEntry[]>("/offers"),
 };

--- a/frontend/src/components/jobs/OfferTab.tsx
+++ b/frontend/src/components/jobs/OfferTab.tsx
@@ -4,6 +4,7 @@ import {
 	Button,
 	FormControlLabel,
 	Grid,
+	InputAdornment,
 	MenuItem,
 	Switch,
 	TextField,
@@ -159,26 +160,32 @@ export default function OfferTab({ jobId, offerData, onOfferChange }: Props) {
 
 				{/* Row 2: equity */}
 				<Grid size={{ sm: 4, xs: 12 }}>
-					<Box sx={{ alignItems: "center", display: "flex", gap: 0.5 }}>
-						<TextField
-							label="Equity Amount ($)"
-							type="number"
-							value={form.equity_amount ?? ""}
-							onChange={(e) =>
-								setField("equity_amount", parseAmount(e.target.value))
-							}
-							fullWidth
-							size="small"
-							slotProps={{ htmlInput: { min: 0 } }}
-						/>
-						<Tooltip title="Enter total grant value at current fair market value">
-							<InfoOutlinedIcon
-								aria-label="Enter total grant value at current fair market value"
-								fontSize="small"
-								sx={{ color: "text.secondary", flexShrink: 0 }}
-							/>
-						</Tooltip>
-					</Box>
+					<TextField
+						label="Equity Amount ($)"
+						type="number"
+						value={form.equity_amount ?? ""}
+						onChange={(e) =>
+							setField("equity_amount", parseAmount(e.target.value))
+						}
+						fullWidth
+						size="small"
+						slotProps={{
+							htmlInput: { min: 0 },
+							input: {
+								endAdornment: (
+									<InputAdornment position="end">
+										<Tooltip title="Enter total grant value at current fair market value">
+											<InfoOutlinedIcon
+												aria-label="Enter total grant value at current fair market value"
+												fontSize="small"
+												sx={{ color: "text.secondary" }}
+											/>
+										</Tooltip>
+									</InputAdornment>
+								),
+							},
+						}}
+					/>
 				</Grid>
 
 				<Grid size={{ sm: 4, xs: 12 }}>

--- a/frontend/src/components/offers/OfferBreakdownChart.spec.tsx
+++ b/frontend/src/components/offers/OfferBreakdownChart.spec.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import OfferBreakdownChart from "./OfferBreakdownChart";
+import { makeJob } from "../../testUtils";
+import type { Offer, OfferComparisonEntry } from "../../types";
+
+vi.mock(
+	import("recharts"),
+	() =>
+		({
+			Bar: ({ dataKey }: { dataKey: string }) => (
+				<div data-testid={`bar-${dataKey}`} />
+			),
+			BarChart: ({ children }: { children: React.ReactNode }) => (
+				<div data-testid="bar-chart">{children}</div>
+			),
+			CartesianGrid: () => null,
+			Legend: () => null,
+			ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+				<div data-testid="recharts-container">{children}</div>
+			),
+			Tooltip: () => null,
+			XAxis: () => null,
+			YAxis: () => null,
+		}) as any,
+);
+
+const BASE_OFFER: Offer = {
+	id: 1,
+	job_id: 1,
+	base_pay_amount: 150_000,
+	target_bonus_percent: 10,
+	equity_amount: 200_000,
+	equity_vesting_years: 4,
+	equity_type: "rsus",
+	signing_bonus_amount: 20_000,
+	wellness_stipend_amount: 1200,
+	other_amount: 5000,
+	other_label: "Car allowance",
+	other_is_recurring: true,
+	k401_match_percent: 4,
+	offer_deadline: "2026-07-01",
+	notes: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+function makeOffer(overrides: Partial<Offer> = {}): Offer {
+	return { ...BASE_OFFER, ...overrides };
+}
+
+function makeEntry(
+	overrides: Partial<OfferComparisonEntry> = {},
+): OfferComparisonEntry {
+	return { job: makeJob(), offer: makeOffer(), ...overrides };
+}
+
+describe("offerBreakdownChart", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("shows an empty state when no entries have offer data", () => {
+		render(<OfferBreakdownChart entries={[makeEntry({ offer: null })]} />);
+		expect(screen.getByText(/No offer data yet/)).toBeInTheDocument();
+		expect(screen.queryByTestId("recharts-container")).not.toBeInTheDocument();
+	});
+
+	it("renders the chart when at least one entry has offer data", () => {
+		render(
+			<OfferBreakdownChart
+				entries={[
+					makeEntry(),
+					makeEntry({ job: makeJob({ id: 2 }), offer: null }),
+				]}
+			/>,
+		);
+		expect(screen.getByTestId("recharts-container")).toBeInTheDocument();
+	});
+
+	it("renders a Bar segment for each compensation component", () => {
+		render(<OfferBreakdownChart entries={[makeEntry()]} />);
+		expect(screen.getByTestId("bar-base")).toBeInTheDocument();
+		expect(screen.getByTestId("bar-bonus")).toBeInTheDocument();
+		expect(screen.getByTestId("bar-equity")).toBeInTheDocument();
+		expect(screen.getByTestId("bar-signingBonus")).toBeInTheDocument();
+		expect(screen.getByTestId("bar-stipend")).toBeInTheDocument();
+		expect(screen.getByTestId("bar-other")).toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/offers/OfferBreakdownChart.tsx
+++ b/frontend/src/components/offers/OfferBreakdownChart.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Legend,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Box, Typography } from "@mui/material";
+import type { OfferComparisonEntry } from "../../types";
+import { annualBonus, equityPerYear, formatCurrency } from "../../offerUtils";
+
+type SegmentKey =
+	| "base"
+	| "bonus"
+	| "equity"
+	| "signingBonus"
+	| "stipend"
+	| "other";
+
+const SEGMENT_LABELS: Record<SegmentKey, string> = {
+	base: "Base",
+	bonus: "Bonus",
+	equity: "Equity/yr",
+	other: "Other",
+	signingBonus: "Signing Bonus",
+	stipend: "Stipend",
+};
+
+const SEGMENT_COLORS: Record<SegmentKey, string> = {
+	base: "#1e88e5",
+	bonus: "#26a69a",
+	equity: "#7e57c2",
+	other: "#bdbdbd",
+	signingBonus: "#ffa726",
+	stipend: "#66bb6a",
+};
+
+const SEGMENT_KEYS: SegmentKey[] = [
+	"base",
+	"bonus",
+	"equity",
+	"signingBonus",
+	"stipend",
+	"other",
+];
+
+type DataPoint = { company: string } & Record<SegmentKey, number>;
+
+function toDataPoint({ job, offer }: OfferComparisonEntry): DataPoint | null {
+	if (offer === null) {
+		return null;
+	}
+	return {
+		base: offer.base_pay_amount ?? 0,
+		bonus: annualBonus(offer),
+		company: job.company,
+		equity: equityPerYear(offer),
+		other: offer.other_amount ?? 0,
+		signingBonus: offer.signing_bonus_amount ?? 0,
+		stipend: offer.wellness_stipend_amount ?? 0,
+	};
+}
+
+interface Props {
+	entries: OfferComparisonEntry[];
+}
+
+export default function OfferBreakdownChart({ entries }: Props) {
+	const data = entries
+		.map(toDataPoint)
+		.filter((d): d is DataPoint => d !== null);
+
+	if (data.length === 0) {
+		return (
+			<Box
+				sx={{
+					alignItems: "center",
+					display: "flex",
+					height: 200,
+					justifyContent: "center",
+				}}
+			>
+				<Typography color="text.secondary" variant="body2">
+					No offer data yet — record offer details to see a pay breakdown
+				</Typography>
+			</Box>
+		);
+	}
+
+	const height = Math.max(200, data.length * 70 + 60);
+
+	return (
+		<ResponsiveContainer width="100%" height={height}>
+			<BarChart
+				data={data}
+				layout="vertical"
+				margin={{ bottom: 4, left: 8, right: 24, top: 4 }}
+			>
+				<CartesianGrid strokeDasharray="3 3" horizontal={false} />
+				<XAxis
+					type="number"
+					tickFormatter={(v) => formatCurrency(Number(v))}
+					tick={{ fontSize: 11 }}
+				/>
+				<YAxis
+					type="category"
+					dataKey="company"
+					width={120}
+					tick={{ fontSize: 12 }}
+				/>
+				<Tooltip
+					formatter={(value, name) => [formatCurrency(Number(value)), name]}
+					contentStyle={{ fontSize: 12 }}
+				/>
+				<Legend wrapperStyle={{ fontSize: 11 }} />
+				{SEGMENT_KEYS.map((key) => (
+					<Bar
+						key={key}
+						dataKey={key}
+						name={SEGMENT_LABELS[key]}
+						stackId="tc"
+						fill={SEGMENT_COLORS[key]}
+					/>
+				))}
+			</BarChart>
+		</ResponsiveContainer>
+	);
+}

--- a/frontend/src/components/offers/OfferComparatorPage.spec.tsx
+++ b/frontend/src/components/offers/OfferComparatorPage.spec.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import OfferComparatorPage from "./OfferComparatorPage";
+import { api } from "../../api";
+import { makeJob } from "../../testUtils";
+import type { Offer, OfferComparisonEntry } from "../../types";
+
+const mockNavigate = vi.fn();
+vi.mock(import("react-router-dom"), async (importOriginal) => {
+	const actual = await importOriginal();
+	return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock(
+	import("../../api"),
+	() => ({ api: { getOffersComparison: vi.fn() } }) as any,
+);
+
+vi.mock(
+	import("../../useCompanyLogo"),
+	() => ({ useCompanyLogo: vi.fn(() => null) }) as any,
+);
+
+vi.mock(
+	import("./OfferBreakdownChart"),
+	() => ({ default: () => <div data-testid="offer-breakdown-chart" /> }) as any,
+);
+
+const mockGetOffersComparison = vi.mocked(api.getOffersComparison);
+
+const BASE_OFFER: Offer = {
+	id: 1,
+	job_id: 1,
+	base_pay_amount: 150_000,
+	target_bonus_percent: 10,
+	equity_amount: 200_000,
+	equity_vesting_years: 4,
+	equity_type: "rsus",
+	signing_bonus_amount: 20_000,
+	wellness_stipend_amount: 1200,
+	other_amount: null,
+	other_label: null,
+	other_is_recurring: false,
+	k401_match_percent: 4,
+	offer_deadline: "2026-07-01",
+	notes: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+function makeEntry(
+	overrides: Partial<OfferComparisonEntry> = {},
+): OfferComparisonEntry {
+	return { job: makeJob(), offer: BASE_OFFER, ...overrides };
+}
+
+function renderPage() {
+	return render(
+		<MemoryRouter>
+			<OfferComparatorPage />
+		</MemoryRouter>,
+	);
+}
+
+describe("offerComparatorPage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("shows a loading spinner while fetching offers", () => {
+		mockGetOffersComparison.mockReturnValue(new Promise(() => {}));
+		renderPage();
+		expect(screen.getByRole("progressbar")).toBeInTheDocument();
+	});
+
+	it("shows an error message when the fetch fails", async () => {
+		mockGetOffersComparison.mockRejectedValue(new Error("Network error"));
+		renderPage();
+		await waitFor(() =>
+			expect(screen.getByText(/Failed to load offers/)).toBeInTheDocument(),
+		);
+	});
+
+	it("shows the empty state and links to the Kanban board when there are no offer-status jobs", async () => {
+		mockGetOffersComparison.mockResolvedValue([]);
+		renderPage();
+		await waitFor(() =>
+			expect(
+				screen.getByText(/don't have any jobs in the Offer column/),
+			).toBeInTheDocument(),
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Go to Kanban Board" }));
+		expect(mockNavigate).toHaveBeenCalledWith("/jobs");
+	});
+
+	it("renders summary cards, comparison table, and breakdown chart when offer-status jobs exist", async () => {
+		mockGetOffersComparison.mockResolvedValue([
+			makeEntry({ job: makeJob({ id: 1, company: "Acme Corp" }) }),
+			makeEntry({ job: makeJob({ id: 2, company: "Globex" }), offer: null }),
+		]);
+		renderPage();
+
+		await waitFor(() =>
+			expect(screen.getAllByText("Acme Corp")).not.toHaveLength(0),
+		);
+		expect(screen.getAllByText("Globex").length).toBeGreaterThan(0);
+		expect(screen.getByText("No offer recorded")).toBeInTheDocument();
+		expect(screen.getByText("Compensation Comparison")).toBeInTheDocument();
+		expect(screen.getByTestId("offer-breakdown-chart")).toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/offers/OfferComparatorPage.tsx
+++ b/frontend/src/components/offers/OfferComparatorPage.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import { Box, Button, Typography } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import { api } from "../../api";
+import type { OfferComparisonEntry } from "../../types";
+import ChartCard from "../shared/ChartCard";
+import PageSpinner from "../shared/PageSpinner";
+import OfferSummaryCard from "./OfferSummaryCard";
+import OfferComparisonTable from "./OfferComparisonTable";
+import OfferBreakdownChart from "./OfferBreakdownChart";
+
+export default function OfferComparatorPage() {
+	const navigate = useNavigate();
+	const [entries, setEntries] = useState<OfferComparisonEntry[] | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(false);
+
+	useEffect(() => {
+		setLoading(true);
+		setError(false);
+		api
+			.getOffersComparison()
+			.then(setEntries)
+			.catch(() => setError(true))
+			.finally(() => setLoading(false));
+	}, []);
+
+	return (
+		<Box sx={{ maxWidth: 1100, mx: "auto", px: 3, py: 4 }}>
+			<Typography variant="h5" sx={{ fontWeight: 700, mb: 3 }}>
+				Offer Comparator
+			</Typography>
+
+			{error && (
+				<Typography color="error" sx={{ mb: 2 }}>
+					Failed to load offers. Please try again.
+				</Typography>
+			)}
+
+			{loading ? <PageSpinner /> : null}
+
+			{!loading && entries && entries.length === 0 && (
+				<Box
+					sx={{
+						alignItems: "center",
+						display: "flex",
+						flexDirection: "column",
+						gap: 1.5,
+						py: 8,
+						textAlign: "center",
+					}}
+				>
+					<Typography variant="body1" color="text.secondary">
+						You don't have any jobs in the Offer column yet.
+					</Typography>
+					<Typography variant="body2" color="text.secondary">
+						Move a job to "Offer!" on the Kanban board to start comparing
+						offers.
+					</Typography>
+					<Button variant="contained" onClick={() => navigate("/jobs")}>
+						Go to Kanban Board
+					</Button>
+				</Box>
+			)}
+
+			{!loading && entries && entries.length > 0 && (
+				<Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+					<Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+						{entries.map(({ job, offer }) => (
+							<OfferSummaryCard key={job.id} job={job} offer={offer} />
+						))}
+					</Box>
+
+					<ChartCard title="Compensation Comparison">
+						<OfferComparisonTable entries={entries} />
+					</ChartCard>
+
+					<ChartCard title="TC Breakdown">
+						<OfferBreakdownChart entries={entries} />
+					</ChartCard>
+				</Box>
+			)}
+		</Box>
+	);
+}

--- a/frontend/src/components/offers/OfferComparisonTable.spec.tsx
+++ b/frontend/src/components/offers/OfferComparisonTable.spec.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import OfferComparisonTable from "./OfferComparisonTable";
+import { makeJob } from "../../testUtils";
+import type { Offer, OfferComparisonEntry } from "../../types";
+
+const BASE_OFFER: Offer = {
+	id: 1,
+	job_id: 1,
+	base_pay_amount: 150_000,
+	target_bonus_percent: 10,
+	equity_amount: 200_000,
+	equity_vesting_years: 4,
+	equity_type: "rsus",
+	signing_bonus_amount: 20_000,
+	wellness_stipend_amount: 1200,
+	other_amount: 5000,
+	other_label: "Car allowance",
+	other_is_recurring: true,
+	k401_match_percent: 4,
+	offer_deadline: "2026-07-01",
+	notes: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+function makeOffer(overrides: Partial<Offer> = {}): Offer {
+	return { ...BASE_OFFER, ...overrides };
+}
+
+function makeEntry(
+	overrides: Partial<OfferComparisonEntry> = {},
+): OfferComparisonEntry {
+	return { job: makeJob(), offer: makeOffer(), ...overrides };
+}
+
+describe("offerComparisonTable", () => {
+	it("renders a column header for each company", () => {
+		render(
+			<OfferComparisonTable
+				entries={[
+					makeEntry({ job: makeJob({ id: 1, company: "Acme Corp" }) }),
+					makeEntry({ job: makeJob({ id: 2, company: "Globex" }) }),
+				]}
+			/>,
+		);
+		expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+		expect(screen.getByText("Globex")).toBeInTheDocument();
+	});
+
+	it("renders formatted values for compensation fields", () => {
+		render(<OfferComparisonTable entries={[makeEntry()]} />);
+		expect(screen.getByText("$150,000/yr")).toBeInTheDocument();
+		expect(screen.getByText("10%")).toBeInTheDocument();
+		expect(screen.getByText("$20,000")).toBeInTheDocument();
+		expect(screen.getByText(/Car allowance/)).toBeInTheDocument();
+	});
+
+	it("shows dashes for missing fields and missing offers", () => {
+		render(
+			<OfferComparisonTable
+				entries={[
+					makeEntry({
+						job: makeJob({ id: 1 }),
+						offer: makeOffer({ signing_bonus_amount: null }),
+					}),
+					makeEntry({ job: makeJob({ id: 2 }), offer: null }),
+				]}
+			/>,
+		);
+		const dashes = screen.getAllByText("—");
+		// At least one for the null signing_bonus_amount and a full row of dashes for the null offer.
+		expect(dashes.length).toBeGreaterThan(1);
+	});
+
+	it("renders a Total Comp footer row with correct Year 1 and Ongoing values", () => {
+		render(<OfferComparisonTable entries={[makeEntry()]} />);
+
+		// Year 1: 150,000 + 15,000 + 50,000 + 20,000 + 1,200 + 5,000 = 241,200
+		const year1Row = screen.getByText("Total Comp (Year 1)").closest("tr");
+		expect(year1Row).not.toBeNull();
+		expect(
+			within(year1Row as HTMLElement).getByText("$241,200"),
+		).toBeInTheDocument();
+
+		// Ongoing: 150,000 + 15,000 + 50,000 + 1,200 + 5,000 (recurring) = 221,200
+		const ongoingRow = screen.getByText("Total Comp (Ongoing)").closest("tr");
+		expect(ongoingRow).not.toBeNull();
+		expect(
+			within(ongoingRow as HTMLElement).getByText("$221,200"),
+		).toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/offers/OfferComparisonTable.tsx
+++ b/frontend/src/components/offers/OfferComparisonTable.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableFooter,
+	TableHead,
+	TableRow,
+	Typography,
+} from "@mui/material";
+import type { EquityType, Offer, OfferComparisonEntry } from "../../types";
+import {
+	computeOngoingTC,
+	computeYear1TC,
+	formatCompactCurrency,
+	formatCurrency,
+} from "../../offerUtils";
+
+const EQUITY_TYPE_LABELS: Record<EquityType, string> = {
+	isos: "ISOs",
+	nsos: "NSOs",
+	phantom: "Phantom",
+	profit_sharing: "Profit Sharing",
+	rsus: "RSUs",
+};
+
+const DASH = "—";
+
+function formatEquity(offer: Offer): string {
+	if (offer.equity_amount === null) {
+		return DASH;
+	}
+	const years = offer.equity_vesting_years || 4;
+	const perYear = offer.equity_amount / years;
+	const type = offer.equity_type
+		? ` ${EQUITY_TYPE_LABELS[offer.equity_type]}`
+		: "";
+	return `${formatCompactCurrency(offer.equity_amount)}${type} over ${years} yrs ≈ ${formatCompactCurrency(perYear)}/yr`;
+}
+
+function formatOther(offer: Offer): string {
+	if (offer.other_amount === null) {
+		return DASH;
+	}
+	const cadence = offer.other_is_recurring ? "/yr" : " one-time";
+	const label = offer.other_label ? ` (${offer.other_label})` : "";
+	return `${formatCurrency(offer.other_amount)}${cadence}${label}`;
+}
+
+interface Row {
+	key: string;
+	label: string;
+	format: (offer: Offer) => string;
+}
+
+const ROWS: Row[] = [
+	{
+		format: (o) =>
+			o.base_pay_amount === null
+				? DASH
+				: `${formatCurrency(o.base_pay_amount)}/yr`,
+		key: "base_pay",
+		label: "Base Pay",
+	},
+	{
+		format: (o) =>
+			o.target_bonus_percent === null ? DASH : `${o.target_bonus_percent}%`,
+		key: "target_bonus",
+		label: "Target Bonus",
+	},
+	{ format: formatEquity, key: "equity", label: "Equity" },
+	{
+		format: (o) =>
+			o.signing_bonus_amount === null
+				? DASH
+				: formatCurrency(o.signing_bonus_amount),
+		key: "signing_bonus",
+		label: "Signing Bonus",
+	},
+	{
+		format: (o) =>
+			o.wellness_stipend_amount === null
+				? DASH
+				: `${formatCurrency(o.wellness_stipend_amount)}/yr`,
+		key: "wellness_stipend",
+		label: "Wellness Stipend",
+	},
+	{ format: formatOther, key: "other", label: "Other" },
+	{
+		format: (o) =>
+			o.k401_match_percent === null ? DASH : `${o.k401_match_percent}%`,
+		key: "k401_match",
+		label: "401k Match",
+	},
+];
+
+interface Props {
+	entries: OfferComparisonEntry[];
+}
+
+export default function OfferComparisonTable({ entries }: Props) {
+	return (
+		<TableContainer>
+			<Table size="small">
+				<TableHead>
+					<TableRow>
+						<TableCell />
+						{entries.map(({ job }) => (
+							<TableCell key={job.id} sx={{ fontWeight: 700 }}>
+								{job.company}
+							</TableCell>
+						))}
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					{ROWS.map((row) => (
+						<TableRow key={row.key}>
+							<TableCell sx={{ color: "text.secondary" }}>
+								{row.label}
+							</TableCell>
+							{entries.map(({ job, offer }) => (
+								<TableCell key={job.id}>
+									{offer === null ? DASH : row.format(offer)}
+								</TableCell>
+							))}
+						</TableRow>
+					))}
+				</TableBody>
+				<TableFooter>
+					<TableRow>
+						<TableCell sx={{ fontWeight: 700 }}>
+							<Typography variant="body2" sx={{ fontWeight: 700 }}>
+								Total Comp (Year 1)
+							</Typography>
+						</TableCell>
+						{entries.map(({ job, offer }) => (
+							<TableCell key={job.id} sx={{ fontWeight: 700 }}>
+								{offer === null ? DASH : formatCurrency(computeYear1TC(offer))}
+							</TableCell>
+						))}
+					</TableRow>
+					<TableRow>
+						<TableCell sx={{ fontWeight: 700 }}>
+							<Typography variant="body2" sx={{ fontWeight: 700 }}>
+								Total Comp (Ongoing)
+							</Typography>
+						</TableCell>
+						{entries.map(({ job, offer }) => (
+							<TableCell key={job.id} sx={{ fontWeight: 700 }}>
+								{offer === null
+									? DASH
+									: formatCurrency(computeOngoingTC(offer))}
+							</TableCell>
+						))}
+					</TableRow>
+				</TableFooter>
+			</Table>
+		</TableContainer>
+	);
+}

--- a/frontend/src/components/offers/OfferSummaryCard.spec.tsx
+++ b/frontend/src/components/offers/OfferSummaryCard.spec.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import OfferSummaryCard from "./OfferSummaryCard";
+import { makeJob } from "../../testUtils";
+import type { Offer } from "../../types";
+
+vi.mock(
+	import("../../useCompanyLogo"),
+	() => ({ useCompanyLogo: vi.fn(() => null) }) as any,
+);
+
+const BASE_OFFER: Offer = {
+	id: 1,
+	job_id: 1,
+	base_pay_amount: 150_000,
+	target_bonus_percent: 10,
+	equity_amount: 200_000,
+	equity_vesting_years: 4,
+	equity_type: "rsus",
+	signing_bonus_amount: 20_000,
+	wellness_stipend_amount: 1200,
+	other_amount: null,
+	other_label: null,
+	other_is_recurring: false,
+	k401_match_percent: 4,
+	offer_deadline: "2026-07-01",
+	notes: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+function makeOffer(overrides: Partial<Offer> = {}): Offer {
+	return { ...BASE_OFFER, ...overrides };
+}
+
+describe("offerSummaryCard", () => {
+	it("renders the company name and role", () => {
+		render(
+			<OfferSummaryCard
+				job={makeJob({ company: "Acme Corp", role: "Staff Engineer" })}
+				offer={makeOffer()}
+			/>,
+		);
+		expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+		expect(screen.getByText("Staff Engineer")).toBeInTheDocument();
+	});
+
+	it("shows Year 1 and Ongoing TC when an offer is recorded", () => {
+		render(<OfferSummaryCard job={makeJob()} offer={makeOffer()} />);
+
+		// Year 1: 150,000 + 15,000 (bonus) + 50,000 (equity/yr) + 20,000 (signing) + 1,200 (stipend) = 236,200
+		expect(screen.getByText("$236,200")).toBeInTheDocument();
+		// Ongoing: 150,000 + 15,000 + 50,000 + 1,200 = 216,200
+		expect(screen.getByText("$216,200")).toBeInTheDocument();
+	});
+
+	it("shows the 'No offer recorded' indicator when offer is null", () => {
+		render(<OfferSummaryCard job={makeJob()} offer={null} />);
+		expect(screen.getByText("No offer recorded")).toBeInTheDocument();
+		expect(screen.queryByText("Year 1 TC")).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/offers/OfferSummaryCard.tsx
+++ b/frontend/src/components/offers/OfferSummaryCard.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Box, Card, CardContent, Typography } from "@mui/material";
+import type { Job, Offer } from "../../types";
+import {
+	computeOngoingTC,
+	computeYear1TC,
+	formatCurrency,
+} from "../../offerUtils";
+import CompanyLogo from "../shared/CompanyLogo";
+
+interface Props {
+	job: Job;
+	offer: Offer | null;
+}
+
+export default function OfferSummaryCard({ job, offer }: Props) {
+	return (
+		<Card sx={{ flex: "1 1 220px", maxWidth: 280 }}>
+			<CardContent>
+				<Box sx={{ alignItems: "center", display: "flex", gap: 1, mb: 1.5 }}>
+					<CompanyLogo company={job.company} size={28} />
+					<Box sx={{ minWidth: 0 }}>
+						<Typography variant="subtitle2" noWrap sx={{ fontWeight: 700 }}>
+							{job.company}
+						</Typography>
+						<Typography variant="caption" color="text.secondary" noWrap>
+							{job.role}
+						</Typography>
+					</Box>
+				</Box>
+
+				{offer === null ? (
+					<Typography
+						variant="body2"
+						color="text.secondary"
+						sx={{ fontStyle: "italic" }}
+					>
+						No offer recorded
+					</Typography>
+				) : (
+					<Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+						<Box sx={{ alignItems: "baseline", display: "flex", gap: 1 }}>
+							<Typography variant="caption" color="text.secondary">
+								Year 1 TC
+							</Typography>
+							<Typography variant="h6" sx={{ fontWeight: 700 }}>
+								{formatCurrency(computeYear1TC(offer))}
+							</Typography>
+						</Box>
+						<Box sx={{ alignItems: "baseline", display: "flex", gap: 1 }}>
+							<Typography variant="caption" color="text.secondary">
+								Ongoing TC
+							</Typography>
+							<Typography variant="body1" sx={{ fontWeight: 600 }}>
+								{formatCurrency(computeOngoingTC(offer))}
+							</Typography>
+						</Box>
+					</Box>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/components/offers/OfferSummaryCard.tsx
+++ b/frontend/src/components/offers/OfferSummaryCard.tsx
@@ -25,8 +25,7 @@ export default function OfferSummaryCard({ job, offer }: Props) {
 						</Typography>
 						<Typography
 							variant="caption"
-							color="text.secondary"
-							sx={{ minHeight: "3.32em" }}
+							sx={{ display: "block", lineHeight: 1.2, minHeight: "2.5em" }}
 						>
 							{job.role}
 						</Typography>

--- a/frontend/src/components/offers/OfferSummaryCard.tsx
+++ b/frontend/src/components/offers/OfferSummaryCard.tsx
@@ -23,7 +23,11 @@ export default function OfferSummaryCard({ job, offer }: Props) {
 						<Typography variant="subtitle2" noWrap sx={{ fontWeight: 700 }}>
 							{job.company}
 						</Typography>
-						<Typography variant="caption" color="text.secondary" noWrap>
+						<Typography
+							variant="caption"
+							color="text.secondary"
+							sx={{ minHeight: "3.32em" }}
+						>
 							{job.role}
 						</Typography>
 					</Box>

--- a/frontend/src/components/shared/AppShell.tsx
+++ b/frontend/src/components/shared/AppShell.tsx
@@ -15,6 +15,7 @@ import AccountCircleOutlinedIcon from "@mui/icons-material/AccountCircleOutlined
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
 import CalendarMonthOutlinedIcon from "@mui/icons-material/CalendarMonthOutlined";
+import CompareArrowsIcon from "@mui/icons-material/CompareArrows";
 import InsightsIcon from "@mui/icons-material/Insights";
 import PsychologyOutlinedIcon from "@mui/icons-material/PsychologyOutlined";
 import RadarIcon from "@mui/icons-material/Radar";
@@ -38,6 +39,7 @@ const NAV_ITEMS = [
 		path: "/insights",
 	},
 	{ icon: <RadarIcon />, label: "Radar", path: "/radar" },
+	{ icon: <CompareArrowsIcon />, label: "Offers", path: "/offers" },
 ] as const;
 
 interface Props {

--- a/frontend/src/offerUtils.ts
+++ b/frontend/src/offerUtils.ts
@@ -1,0 +1,55 @@
+import type { Offer } from "./types";
+
+function n(value: number | null): number {
+	return value ?? 0;
+}
+
+function vestingYears(offer: Offer): number {
+	return offer.equity_vesting_years || 4;
+}
+
+export function equityPerYear(offer: Offer): number {
+	return n(offer.equity_amount) / vestingYears(offer);
+}
+
+export function annualBonus(offer: Offer): number {
+	return n(offer.base_pay_amount) * (n(offer.target_bonus_percent) / 100);
+}
+
+export function computeYear1TC(offer: Offer): number {
+	return (
+		n(offer.base_pay_amount) +
+		annualBonus(offer) +
+		equityPerYear(offer) +
+		n(offer.signing_bonus_amount) +
+		n(offer.wellness_stipend_amount) +
+		n(offer.other_amount)
+	);
+}
+
+export function computeOngoingTC(offer: Offer): number {
+	return (
+		n(offer.base_pay_amount) +
+		annualBonus(offer) +
+		equityPerYear(offer) +
+		n(offer.wellness_stipend_amount) +
+		(offer.other_is_recurring ? n(offer.other_amount) : 0)
+	);
+}
+
+export function formatCurrency(amount: number): string {
+	return amount.toLocaleString("en-US", {
+		currency: "USD",
+		maximumFractionDigits: 0,
+		style: "currency",
+	});
+}
+
+export function formatCompactCurrency(amount: number): string {
+	return amount.toLocaleString("en-US", {
+		currency: "USD",
+		maximumFractionDigits: 1,
+		notation: "compact",
+		style: "currency",
+	});
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -112,6 +112,11 @@ export type OfferFormData = Omit<
 	"id" | "job_id" | "created_at" | "updated_at"
 >;
 
+export interface OfferComparisonEntry {
+	job: Job;
+	offer: Offer | null;
+}
+
 export type InterviewStage = "phone_screen" | "onsite";
 export type InterviewType =
 	| "recruiter_call"


### PR DESCRIPTION
## Summary
- Adds a new top-level `/offers` page (`OfferComparatorPage`) for comparing all jobs in the Offer column side by side
- Adds an "Offers" nav item (CompareArrowsIcon) to the left sidebar
- `OfferSummaryCard`: per-job card with company logo, role, computed Year 1 / Ongoing TC, or a "No offer recorded" indicator
- `OfferComparisonTable`: rows = compensation fields, columns = companies, with a Total Comp footer row for both Year 1 and Ongoing
- `OfferBreakdownChart`: stacked horizontal Recharts bar chart showing pay composition per company (base, bonus, equity/yr, signing bonus, stipend, other)
- Adds `getOffersComparison()` to `api.ts` and `OfferComparisonEntry` to `types.ts`
- Adds `offerUtils.ts` with shared TC calculation (Year 1 / Ongoing, per the PRD formula, treating null fields as 0 and guarding against `equity_vesting_years === 0`) and currency formatting helpers
- Empty state with a friendly message and a button linking back to the Kanban board when no jobs are in `offer` status
- Moves the equity amount info icon into the field as an `InputAdornment` (MUI OOTB pattern) instead of an external icon adjacent to the field

Closes #127

## Test plan
- [x] `npm run lint:fix`, `npm run format:fix`, `npm run tsc`, `npm run test` all pass
- [x] Unit tests for `OfferComparatorPage`, `OfferSummaryCard`, `OfferComparisonTable`, `OfferBreakdownChart` (loading/error/empty/loaded states, formatting, TC math, chart segments)
- [x] Manually verified in the browser: nav item routes to `/offers`; empty state renders with working "Go to Kanban Board" link; summary cards, comparison table (with correct formatting and Total Comp footer), and TC breakdown chart all render correctly with real offer data entered via the Offer tab

🤖 Generated with [Claude Code](https://claude.ai/claude-code)