### PR TITLE
refactor(snackbar): lift toast into shared SnackbarContext; add OfferTab success feedback

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import theme from "./theme";
 import { api, setUnauthorizedHandler } from "./api";
 import type { User } from "./types";
+import { SnackbarProvider } from "./useSnackbar";
 import LoginPage from "./components/LoginPage";
 import PageSpinner from "./components/shared/PageSpinner";
 import AppShell from "./components/shared/AppShell";
@@ -50,25 +51,27 @@ export default function App() {
 		content = <LoginPage />;
 	} else {
 		content = (
-			<BrowserRouter>
-				<Routes>
-					<Route
-						element={
-							<AppShell currentUser={currentUser} onLogout={handleLogout} />
-						}
-					>
-						<Route path="/" element={<Navigate to="/jobs" replace />} />
-						<Route path="/jobs" element={<JobManagementPage />} />
-						<Route path="/jobs/:jobId" element={<JobManagementPage />} />
-						<Route path="/calendar" element={<InterviewsPage />} />
-						<Route path="/stats" element={<StatsPage />} />
-						<Route path="/insights" element={<InsightsPage />} />
-						<Route path="/radar" element={<RadarPage />} />
-						<Route path="/offers" element={<OfferComparatorPage />} />
-						<Route path="*" element={<Navigate to="/jobs" replace />} />
-					</Route>
-				</Routes>
-			</BrowserRouter>
+			<SnackbarProvider>
+				<BrowserRouter>
+					<Routes>
+						<Route
+							element={
+								<AppShell currentUser={currentUser} onLogout={handleLogout} />
+							}
+						>
+							<Route path="/" element={<Navigate to="/jobs" replace />} />
+							<Route path="/jobs" element={<JobManagementPage />} />
+							<Route path="/jobs/:jobId" element={<JobManagementPage />} />
+							<Route path="/calendar" element={<InterviewsPage />} />
+							<Route path="/stats" element={<StatsPage />} />
+							<Route path="/insights" element={<InsightsPage />} />
+							<Route path="/radar" element={<RadarPage />} />
+							<Route path="/offers" element={<OfferComparatorPage />} />
+							<Route path="*" element={<Navigate to="/jobs" replace />} />
+						</Route>
+					</Routes>
+				</BrowserRouter>
+			</SnackbarProvider>
 		);
 	}
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -39,6 +39,9 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 	if (!res.ok) {
 		throw new Error(`API error ${res.status}`);
 	}
+	if (res.status === 204) {
+		return undefined as T;
+	}
 	return res.json() as Promise<T>;
 }
 

--- a/frontend/src/components/calendar/InterviewsPage.spec.tsx
+++ b/frontend/src/components/calendar/InterviewsPage.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import InterviewsPage, { getDefaultDateRange } from "./InterviewsPage";
 import { api } from "../../api";
+import { SnackbarProvider } from "../../useSnackbar";
 import type { EnrichedInterview } from "../../types";
 
 vi.mock(
@@ -61,9 +62,11 @@ function makeInterview(
 
 function renderPage() {
 	return render(
-		<MemoryRouter>
-			<InterviewsPage />
-		</MemoryRouter>,
+		<SnackbarProvider>
+			<MemoryRouter>
+				<InterviewsPage />
+			</MemoryRouter>
+		</SnackbarProvider>,
 	);
 }
 

--- a/frontend/src/components/calendar/InterviewsPage.tsx
+++ b/frontend/src/components/calendar/InterviewsPage.tsx
@@ -15,7 +15,7 @@ import PhoneIcon from "@mui/icons-material/Phone";
 import { useNavigate } from "react-router-dom";
 import { api } from "../../api";
 import { INTERVIEW_STAGE_LABELS, INTERVIEW_TYPE_LABELS } from "../../constants";
-import { useSnackbar } from "../../useSnackbar";
+import { useNotify } from "../../useSnackbar";
 import { formatTime } from "../../jobUtils";
 import MarkdownSnippet from "../shared/MarkdownSnippet";
 import CompanyLogo from "../shared/CompanyLogo";
@@ -160,7 +160,7 @@ export default function InterviewsPage() {
 	const [error, setError] = useState(false);
 	const [loadingMore, setLoadingMore] = useState(false);
 	const [reachedEnd, setReachedEnd] = useState(false);
-	const [notify, snackbarNode] = useSnackbar();
+	const notify = useNotify();
 	const [from, setFrom] = useState(() => getDefaultDateRange().from);
 	const [to, setTo] = useState(() => getDefaultDateRange().to);
 
@@ -374,8 +374,6 @@ export default function InterviewsPage() {
 					</Box>
 				)}
 			</Box>
-
-			{snackbarNode}
 		</>
 	);
 }

--- a/frontend/src/components/jobs/JobManagementPage.spec.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.spec.tsx
@@ -13,6 +13,7 @@ import JobManagementPage from "./JobManagementPage";
 import StatsPage from "../stats/StatsPage";
 import KanbanBoard from "./KanbanBoard";
 import { api } from "../../api";
+import { SnackbarProvider } from "../../useSnackbar";
 import type { Job, User } from "../../types";
 import { makeJob } from "../../testUtils";
 
@@ -99,17 +100,19 @@ const MOCK_ON_LOGOUT = vi.fn();
 /** Renders JobManagementPage inside AppShell with the same route structure as App.tsx. */
 function renderPage(initialPath = "/jobs", onLogout = MOCK_ON_LOGOUT) {
 	return render(
-		<MemoryRouter initialEntries={[initialPath]}>
-			<Routes>
-				<Route
-					element={<AppShell currentUser={MOCK_USER} onLogout={onLogout} />}
-				>
-					<Route path="/jobs" element={<JobManagementPage />} />
-					<Route path="/jobs/:jobId" element={<JobManagementPage />} />
-					<Route path="/stats" element={<StatsPage />} />
-				</Route>
-			</Routes>
-		</MemoryRouter>,
+		<SnackbarProvider>
+			<MemoryRouter initialEntries={[initialPath]}>
+				<Routes>
+					<Route
+						element={<AppShell currentUser={MOCK_USER} onLogout={onLogout} />}
+					>
+						<Route path="/jobs" element={<JobManagementPage />} />
+						<Route path="/jobs/:jobId" element={<JobManagementPage />} />
+						<Route path="/stats" element={<StatsPage />} />
+					</Route>
+				</Routes>
+			</MemoryRouter>
+		</SnackbarProvider>,
 	);
 }
 

--- a/frontend/src/components/jobs/JobManagementPage.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.tsx
@@ -31,7 +31,7 @@ import StarBorderIcon from "@mui/icons-material/StarBorder";
 import TuneIcon from "@mui/icons-material/Tune";
 import { useNavigate, useParams } from "react-router-dom";
 import { api } from "../../api";
-import { useSnackbar } from "../../useSnackbar";
+import { useNotify } from "../../useSnackbar";
 import type {
 	EndingSubstatus,
 	FitScore,
@@ -90,7 +90,7 @@ export default function JobManagementPage() {
 		newStatus: JobStatus;
 	} | null>(null);
 	const searchRef = useRef<HTMLInputElement>(null);
-	const [notify, snackbarNode] = useSnackbar();
+	const notify = useNotify();
 
 	const loadJobs = useCallback(async () => {
 		try {
@@ -576,8 +576,6 @@ export default function JobManagementPage() {
 				onConfirm={handleTerminalConfirm}
 				onCancel={() => setPendingTerminalChange(null)}
 			/>
-
-			{snackbarNode}
 		</>
 	);
 }

--- a/frontend/src/components/jobs/OfferTab.spec.tsx
+++ b/frontend/src/components/jobs/OfferTab.spec.tsx
@@ -1,8 +1,15 @@
 import React from "react";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 
 import OfferTab from "./OfferTab";
 import { api } from "../../api";
+import { SnackbarProvider } from "../../useSnackbar";
 import type { Offer } from "../../types";
 
 vi.mock(import("../../api"));
@@ -33,12 +40,20 @@ const DEFAULT_PROPS = {
 	onOfferChange: vi.fn(),
 };
 
+function renderTab(props = DEFAULT_PROPS) {
+	return render(
+		<SnackbarProvider>
+			<OfferTab {...props} />
+		</SnackbarProvider>,
+	);
+}
+
 describe("offerTab", () => {
 	beforeEach(() => vi.clearAllMocks());
 
 	describe("rendering with no existing offer", () => {
 		it("renders pay and equity fields", () => {
-			render(<OfferTab {...DEFAULT_PROPS} />);
+			renderTab();
 			expect(screen.getByLabelText(/Base Pay/i)).toBeInTheDocument();
 			expect(screen.getByLabelText(/Target Bonus %/i)).toBeInTheDocument();
 			expect(screen.getByLabelText(/Equity Amount/i)).toBeInTheDocument();
@@ -50,7 +65,7 @@ describe("offerTab", () => {
 		});
 
 		it("renders other, deadline, and notes fields", () => {
-			render(<OfferTab {...DEFAULT_PROPS} />);
+			renderTab();
 			expect(screen.getByLabelText(/Other Amount/i)).toBeInTheDocument();
 			expect(screen.getByLabelText(/Other Label/i)).toBeInTheDocument();
 			expect(
@@ -61,26 +76,26 @@ describe("offerTab", () => {
 		});
 
 		it("renders a Save Offer button", () => {
-			render(<OfferTab {...DEFAULT_PROPS} />);
+			renderTab();
 			expect(
 				screen.getByRole("button", { name: "Save Offer" }),
 			).toBeInTheDocument();
 		});
 
 		it("does not render a Clear button when offerData is null", () => {
-			render(<OfferTab {...DEFAULT_PROPS} />);
+			renderTab();
 			expect(
 				screen.queryByRole("button", { name: "Clear" }),
 			).not.toBeInTheDocument();
 		});
 
 		it("initializes equity vesting years to 4", () => {
-			render(<OfferTab {...DEFAULT_PROPS} />);
+			renderTab();
 			expect(screen.getByLabelText(/Equity Vesting/i)).toHaveValue(4);
 		});
 
 		it("shows the FMV info icon on the equity amount field", () => {
-			render(<OfferTab {...DEFAULT_PROPS} />);
+			renderTab();
 			expect(
 				screen.getByLabelText(
 					"Enter total grant value at current fair market value",
@@ -91,7 +106,7 @@ describe("offerTab", () => {
 
 	describe("rendering with an existing offer", () => {
 		it("pre-fills fields from offerData", () => {
-			render(<OfferTab {...DEFAULT_PROPS} offerData={BASE_OFFER} />);
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER });
 			expect(screen.getByLabelText(/Base Pay/i)).toHaveValue(150_000);
 			expect(screen.getByLabelText(/Target Bonus %/i)).toHaveValue(15);
 			expect(screen.getByLabelText(/Equity Amount/i)).toHaveValue(200_000);
@@ -103,7 +118,7 @@ describe("offerTab", () => {
 		});
 
 		it("renders a Clear button when offerData is set", () => {
-			render(<OfferTab {...DEFAULT_PROPS} offerData={BASE_OFFER} />);
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER });
 			expect(screen.getByRole("button", { name: "Clear" })).toBeInTheDocument();
 		});
 	});
@@ -111,7 +126,7 @@ describe("offerTab", () => {
 	describe("save Offer — POST on first save", () => {
 		it("calls createOffer when offerData is null and save is clicked", async () => {
 			vi.mocked(api.createOffer).mockResolvedValue(BASE_OFFER);
-			render(<OfferTab {...DEFAULT_PROPS} offerData={null} />);
+			renderTab();
 
 			fireEvent.change(screen.getByLabelText(/Base Pay/i), {
 				target: { value: "150000" },
@@ -128,7 +143,7 @@ describe("offerTab", () => {
 
 		it("calls onOfferChange with the saved offer after POST", async () => {
 			vi.mocked(api.createOffer).mockResolvedValue(BASE_OFFER);
-			render(<OfferTab {...DEFAULT_PROPS} offerData={null} />);
+			renderTab();
 
 			await act(async () => {
 				fireEvent.click(screen.getByRole("button", { name: "Save Offer" }));
@@ -139,7 +154,7 @@ describe("offerTab", () => {
 
 		it("does not call updateOffer on first save", async () => {
 			vi.mocked(api.createOffer).mockResolvedValue(BASE_OFFER);
-			render(<OfferTab {...DEFAULT_PROPS} offerData={null} />);
+			renderTab();
 
 			await act(async () => {
 				fireEvent.click(screen.getByRole("button", { name: "Save Offer" }));
@@ -147,12 +162,25 @@ describe("offerTab", () => {
 
 			expect(vi.mocked(api.updateOffer)).not.toHaveBeenCalled();
 		});
+
+		it("shows a success snackbar after saving", async () => {
+			vi.mocked(api.createOffer).mockResolvedValue(BASE_OFFER);
+			renderTab();
+
+			await act(async () => {
+				fireEvent.click(screen.getByRole("button", { name: "Save Offer" }));
+			});
+
+			await waitFor(() => {
+				expect(screen.getByText("Offer saved")).toBeInTheDocument();
+			});
+		});
 	});
 
 	describe("save Offer — PUT on subsequent save", () => {
 		it("calls updateOffer when offerData is set and save is clicked", async () => {
 			vi.mocked(api.updateOffer).mockResolvedValue(BASE_OFFER);
-			render(<OfferTab {...DEFAULT_PROPS} offerData={BASE_OFFER} />);
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER });
 
 			await act(async () => {
 				fireEvent.click(screen.getByRole("button", { name: "Save Offer" }));
@@ -166,7 +194,7 @@ describe("offerTab", () => {
 
 		it("does not call createOffer on subsequent save", async () => {
 			vi.mocked(api.updateOffer).mockResolvedValue(BASE_OFFER);
-			render(<OfferTab {...DEFAULT_PROPS} offerData={BASE_OFFER} />);
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER });
 
 			await act(async () => {
 				fireEvent.click(screen.getByRole("button", { name: "Save Offer" }));
@@ -179,7 +207,7 @@ describe("offerTab", () => {
 	describe("clear", () => {
 		it("calls deleteOffer and resets form when Clear is clicked", async () => {
 			vi.mocked(api.deleteOffer).mockResolvedValue(undefined);
-			render(<OfferTab {...DEFAULT_PROPS} offerData={BASE_OFFER} />);
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER });
 
 			await act(async () => {
 				fireEvent.click(screen.getByRole("button", { name: "Clear" }));
@@ -191,7 +219,7 @@ describe("offerTab", () => {
 
 		it("clears the base pay field after Clear", async () => {
 			vi.mocked(api.deleteOffer).mockResolvedValue(undefined);
-			render(<OfferTab {...DEFAULT_PROPS} offerData={BASE_OFFER} />);
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER });
 
 			await act(async () => {
 				fireEvent.click(screen.getByRole("button", { name: "Clear" }));
@@ -199,45 +227,62 @@ describe("offerTab", () => {
 
 			expect(screen.getByLabelText(/Base Pay/i)).toHaveValue(null);
 		});
-	});
 
-	describe("error handling", () => {
-		it("shows an error message when save fails", async () => {
-			vi.mocked(api.createOffer).mockRejectedValue(new Error("Network error"));
-			render(<OfferTab {...DEFAULT_PROPS} offerData={null} />);
-
-			await act(async () => {
-				fireEvent.click(screen.getByRole("button", { name: "Save Offer" }));
-			});
-
-			expect(
-				screen.getByText("Failed to save offer. Please try again."),
-			).toBeInTheDocument();
-		});
-
-		it("shows an error message when clear fails", async () => {
-			vi.mocked(api.deleteOffer).mockRejectedValue(new Error("Network error"));
-			render(<OfferTab {...DEFAULT_PROPS} offerData={BASE_OFFER} />);
+		it("shows a success snackbar after clearing", async () => {
+			vi.mocked(api.deleteOffer).mockResolvedValue(undefined);
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER });
 
 			await act(async () => {
 				fireEvent.click(screen.getByRole("button", { name: "Clear" }));
 			});
 
-			expect(
-				screen.getByText("Failed to clear offer. Please try again."),
-			).toBeInTheDocument();
+			await waitFor(() => {
+				expect(screen.getByText("Offer cleared")).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("error handling", () => {
+		it("shows an error snackbar when save fails", async () => {
+			vi.mocked(api.createOffer).mockRejectedValue(new Error("Network error"));
+			renderTab();
+
+			await act(async () => {
+				fireEvent.click(screen.getByRole("button", { name: "Save Offer" }));
+			});
+
+			await waitFor(() => {
+				expect(
+					screen.getByText("Failed to save offer. Please try again."),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("shows an error snackbar when clear fails", async () => {
+			vi.mocked(api.deleteOffer).mockRejectedValue(new Error("Network error"));
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER });
+
+			await act(async () => {
+				fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+			});
+
+			await waitFor(() => {
+				expect(
+					screen.getByText("Failed to clear offer. Please try again."),
+				).toBeInTheDocument();
+			});
 		});
 	});
 
 	describe("equity type select", () => {
 		it("renders RSUs as an option", () => {
-			render(<OfferTab {...DEFAULT_PROPS} />);
+			renderTab();
 			fireEvent.mouseDown(screen.getByLabelText(/Equity Type/i));
 			expect(screen.getByRole("option", { name: "RSUs" })).toBeInTheDocument();
 		});
 
 		it("renders all equity type options", () => {
-			render(<OfferTab {...DEFAULT_PROPS} />);
+			renderTab();
 			fireEvent.mouseDown(screen.getByLabelText(/Equity Type/i));
 			expect(screen.getByRole("option", { name: "RSUs" })).toBeInTheDocument();
 			expect(screen.getByRole("option", { name: "ISOs" })).toBeInTheDocument();
@@ -253,7 +298,7 @@ describe("offerTab", () => {
 
 	describe("other_is_recurring toggle", () => {
 		it("is unchecked by default", () => {
-			const { container } = render(<OfferTab {...DEFAULT_PROPS} />);
+			const { container } = renderTab();
 			const toggle = container.querySelector(
 				'input[type="checkbox"]',
 			) as HTMLInputElement;
@@ -261,7 +306,7 @@ describe("offerTab", () => {
 		});
 
 		it("can be toggled on", () => {
-			const { container } = render(<OfferTab {...DEFAULT_PROPS} />);
+			const { container } = renderTab();
 			const toggle = container.querySelector(
 				'input[type="checkbox"]',
 			) as HTMLInputElement;
@@ -273,7 +318,7 @@ describe("offerTab", () => {
 	describe("save payload", () => {
 		it("includes other_is_recurring as false by default", async () => {
 			vi.mocked(api.createOffer).mockResolvedValue(BASE_OFFER);
-			render(<OfferTab {...DEFAULT_PROPS} offerData={null} />);
+			renderTab();
 
 			await act(async () => {
 				fireEvent.click(screen.getByRole("button", { name: "Save Offer" }));
@@ -287,7 +332,7 @@ describe("offerTab", () => {
 
 		it("includes equity_vesting_years default of 4", async () => {
 			vi.mocked(api.createOffer).mockResolvedValue(BASE_OFFER);
-			render(<OfferTab {...DEFAULT_PROPS} offerData={null} />);
+			renderTab();
 
 			await act(async () => {
 				fireEvent.click(screen.getByRole("button", { name: "Save Offer" }));

--- a/frontend/src/components/jobs/OfferTab.tsx
+++ b/frontend/src/components/jobs/OfferTab.tsx
@@ -9,10 +9,10 @@ import {
 	Switch,
 	TextField,
 	Tooltip,
-	Typography,
 } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { api } from "../../api";
+import { useNotify } from "../../useSnackbar";
 import type { EquityType, Offer, OfferFormData } from "../../types";
 
 const EQUITY_TYPE_LABELS: Record<EquityType, string> = {
@@ -72,11 +72,11 @@ interface Props {
 }
 
 export default function OfferTab({ jobId, offerData, onOfferChange }: Props) {
+	const notify = useNotify();
 	const [form, setForm] = useState<OfferFormData>(
 		offerData ? offerToForm(offerData) : EMPTY_FORM,
 	);
 	const [saving, setSaving] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 
 	function setField<K extends keyof OfferFormData>(
 		field: K,
@@ -97,7 +97,6 @@ export default function OfferTab({ jobId, offerData, onOfferChange }: Props) {
 
 	async function handleSave() {
 		setSaving(true);
-		setError(null);
 		try {
 			const saved =
 				offerData === null
@@ -105,8 +104,9 @@ export default function OfferTab({ jobId, offerData, onOfferChange }: Props) {
 					: await api.updateOffer(jobId, form);
 			onOfferChange(saved);
 			setForm(offerToForm(saved));
+			notify("Offer saved");
 		} catch {
-			setError("Failed to save offer. Please try again.");
+			notify("Failed to save offer. Please try again.", "error");
 		} finally {
 			setSaving(false);
 		}
@@ -114,13 +114,13 @@ export default function OfferTab({ jobId, offerData, onOfferChange }: Props) {
 
 	async function handleClear() {
 		setSaving(true);
-		setError(null);
 		try {
 			await api.deleteOffer(jobId);
 			onOfferChange(null);
 			setForm(EMPTY_FORM);
+			notify("Offer cleared");
 		} catch {
-			setError("Failed to clear offer. Please try again.");
+			notify("Failed to clear offer. Please try again.", "error");
 		} finally {
 			setSaving(false);
 		}
@@ -340,12 +340,6 @@ export default function OfferTab({ jobId, offerData, onOfferChange }: Props) {
 					/>
 				</Grid>
 			</Grid>
-
-			{error && (
-				<Typography color="error" variant="body2" sx={{ mt: 1 }}>
-					{error}
-				</Typography>
-			)}
 
 			<Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end", mt: 2 }}>
 				{offerData !== null && (

--- a/frontend/src/useSnackbar.tsx
+++ b/frontend/src/useSnackbar.tsx
@@ -1,7 +1,9 @@
-import React, { useCallback, useState } from "react";
+import React, { createContext, useCallback, useContext, useState } from "react";
 import { Alert, Snackbar } from "@mui/material";
 
 type Severity = "error" | "info" | "success" | "warning";
+
+export type NotifyFn = (message: string, severity?: Severity) => void;
 
 interface SnackState {
 	message: string;
@@ -11,36 +13,45 @@ interface SnackState {
 
 const INITIAL: SnackState = { message: "", open: false, severity: "success" };
 
-export function useSnackbar(): [
-	notify: (message: string, severity?: Severity) => void,
-	snackbarNode: React.ReactNode,
-] {
+const SnackbarContext = createContext<NotifyFn | null>(null);
+
+export function SnackbarProvider({ children }: { children: React.ReactNode }) {
 	const [snack, setSnack] = useState<SnackState>(INITIAL);
 
-	const notify = useCallback(
-		(message: string, severity: Severity = "success") => {
-			setSnack({ message, open: true, severity });
-		},
-		[],
-	);
+	const notify = useCallback<NotifyFn>((message, severity = "success") => {
+		setSnack({ message, open: true, severity });
+	}, []);
 
-	const snackbarNode = (
-		<Snackbar
-			open={snack.open}
-			autoHideDuration={3000}
-			onClose={() => setSnack((s) => ({ ...s, open: false }))}
-			anchorOrigin={{ horizontal: "center", vertical: "bottom" }}
-		>
-			<Alert severity={snack.severity} variant="filled" sx={{ width: "100%" }}>
-				{snack.message.includes("\n")
-					? snack.message
-							.split("\n")
-							// eslint-disable-next-line react/no-array-index-key
-							.map((line, i) => <div key={i}>{line}</div>)
-					: snack.message}
-			</Alert>
-		</Snackbar>
+	return (
+		<SnackbarContext.Provider value={notify}>
+			{children}
+			<Snackbar
+				open={snack.open}
+				autoHideDuration={3000}
+				onClose={() => setSnack((s) => ({ ...s, open: false }))}
+				anchorOrigin={{ horizontal: "center", vertical: "bottom" }}
+			>
+				<Alert
+					severity={snack.severity}
+					variant="filled"
+					sx={{ width: "100%" }}
+				>
+					{snack.message.includes("\n")
+						? snack.message
+								.split("\n")
+								// eslint-disable-next-line react/no-array-index-key
+								.map((line, i) => <div key={i}>{line}</div>)
+						: snack.message}
+				</Alert>
+			</Snackbar>
+		</SnackbarContext.Provider>
 	);
+}
 
-	return [notify, snackbarNode];
+export function useNotify(): NotifyFn {
+	const notify = useContext(SnackbarContext);
+	if (!notify) {
+		throw new Error("useNotify must be used within SnackbarProvider");
+	}
+	return notify;
 }


### PR DESCRIPTION
## Summary

Replaces the per-component `useSnackbar()` hook pattern with a single `SnackbarProvider` / `useNotify()` React Context so any component in the tree can trigger toasts without prop-drilling or duplicating snackbar state. Fixes #133 by adding save/clear success feedback to `OfferTab`.

## Details

- **`useSnackbar.tsx`** — exports `SnackbarProvider` (renders one `<Snackbar>` at app level) and `useNotify()` hook; removes the old `useSnackbar()` tuple API
- **`App.tsx`** — wraps authenticated routes in `SnackbarProvider` so a single snackbar instance is shared across all pages
- **`JobManagementPage`**, **`InterviewsPage`** — switched to `useNotify()`; removed local `snackbarNode` renders (those are now handled by the provider)
- **`OfferTab`** — uses `useNotify()` for success (`"Offer saved"` / `"Offer cleared"`) and error feedback; removes the inline `error` state + `Typography` error display in favour of consistent snackbar toasts

## Test plan

- [x] Open a Job with status "Offer!" and navigate to the Offer tab
- [x] Fill in some fields and click **Save Offer** — verify a green "Offer saved" toast appears
- [x] Click **Clear** — verify a green "Offer cleared" toast appears
- [x] Simulate a network failure (DevTools → Offline) and click **Save Offer** — verify a red error toast appears
- [x] Confirm existing snackbar behaviour is unchanged on the Kanban board (drag a card, toggle a favourite, save/delete a job)
- [x] Confirm existing snackbar behaviour is unchanged on the Interviews page (Load More)

Closes #133

🤖 Generated with [Claude Code](https://claude.ai/claude-code)