### PR TITLE
feat(offers): bold row-max values and green-highlight best-offer column

### DIFF
--- a/frontend/src/components/offers/OfferComparisonTable.spec.tsx
+++ b/frontend/src/components/offers/OfferComparisonTable.spec.tsx
@@ -34,6 +34,9 @@ function makeEntry(
 	return { job: makeJob(), offer: makeOffer(), ...overrides };
 }
 
+// BASE_OFFER ongoing TC: 150k + 15k + 50k + 1.2k + 5k = 221,200
+// Higher offer (base 180k) ongoing TC: 180k + 18k + 50k + 1.2k + 5k = 254,200
+
 describe("offerComparisonTable", () => {
 	it("renders a column header for each company", () => {
 		render(
@@ -71,6 +74,184 @@ describe("offerComparisonTable", () => {
 		const dashes = screen.getAllByText("—");
 		// At least one for the null signing_bonus_amount and a full row of dashes for the null offer.
 		expect(dashes.length).toBeGreaterThan(1);
+	});
+
+	describe("row-max bolding", () => {
+		it("marks the max-valued cell in each body row with data-row-max", () => {
+			// Entry 2 has higher base pay; entry 1 has all other fields identical.
+			render(
+				<OfferComparisonTable
+					entries={[
+						makeEntry({ job: makeJob({ id: 1, company: "Acme Corp" }) }),
+						makeEntry({
+							job: makeJob({ id: 2, company: "Globex" }),
+							offer: makeOffer({ base_pay_amount: 180_000 }),
+						}),
+					]}
+				/>,
+			);
+
+			const basePay = screen.getByText("Base Pay").closest("tr");
+			expect(basePay).not.toBeNull();
+			const cells = within(basePay as HTMLElement).getAllByRole("cell");
+			// Cells[0] is the label; cells[1] is Acme (150k), cells[2] is Globex (180k)
+			expect(cells[1]).not.toHaveAttribute("data-row-max");
+			expect(cells[2]).toHaveAttribute("data-row-max", "true");
+		});
+
+		it("marks all tied max cells with data-row-max", () => {
+			// Both offers have identical base pay — both should be marked.
+			render(
+				<OfferComparisonTable
+					entries={[
+						makeEntry({ job: makeJob({ id: 1 }) }),
+						makeEntry({ job: makeJob({ id: 2 }) }),
+					]}
+				/>,
+			);
+
+			const basePay = screen.getByText("Base Pay").closest("tr");
+			const cells = within(basePay as HTMLElement).getAllByRole("cell");
+			expect(cells[1]).toHaveAttribute("data-row-max", "true");
+			expect(cells[2]).toHaveAttribute("data-row-max", "true");
+		});
+
+		it("does not mark a null-offer cell as data-row-max", () => {
+			render(
+				<OfferComparisonTable
+					entries={[
+						makeEntry({ job: makeJob({ id: 1 }) }),
+						makeEntry({ job: makeJob({ id: 2 }), offer: null }),
+					]}
+				/>,
+			);
+
+			const basePay = screen.getByText("Base Pay").closest("tr");
+			const cells = within(basePay as HTMLElement).getAllByRole("cell");
+			expect(cells[1]).toHaveAttribute("data-row-max", "true");
+			expect(cells[2]).not.toHaveAttribute("data-row-max");
+		});
+	});
+
+	describe("best-offer column highlighting", () => {
+		it("marks all cells in the highest ongoing-TC column with data-best-offer", () => {
+			// Entry 2 has higher base pay → higher ongoing TC → best column.
+			render(
+				<OfferComparisonTable
+					entries={[
+						makeEntry({ job: makeJob({ id: 1, company: "Acme Corp" }) }),
+						makeEntry({
+							job: makeJob({ id: 2, company: "Globex" }),
+							offer: makeOffer({ base_pay_amount: 180_000 }),
+						}),
+					]}
+				/>,
+			);
+
+			// Header
+			expect(screen.getByText("Globex")).toHaveAttribute(
+				"data-best-offer",
+				"true",
+			);
+			expect(screen.getByText("Acme Corp")).not.toHaveAttribute(
+				"data-best-offer",
+			);
+
+			// Body rows: check Base Pay cells (representative)
+			const basePay = screen.getByText("Base Pay").closest("tr");
+			const basePayCells = within(basePay as HTMLElement).getAllByRole("cell");
+			expect(basePayCells[1]).not.toHaveAttribute("data-best-offer");
+			expect(basePayCells[2]).toHaveAttribute("data-best-offer", "true");
+
+			// Footer: check Total Comp (Ongoing) row
+			const ongoingRow = screen.getByText("Total Comp (Ongoing)").closest("tr");
+			const ongoingCells = within(ongoingRow as HTMLElement).getAllByRole(
+				"cell",
+			);
+			expect(ongoingCells[1]).not.toHaveAttribute("data-best-offer");
+			expect(ongoingCells[2]).toHaveAttribute("data-best-offer", "true");
+		});
+
+		it("marks all tied best-offer columns when ongoing TC is equal", () => {
+			render(
+				<OfferComparisonTable
+					entries={[
+						makeEntry({ job: makeJob({ id: 1, company: "Acme Corp" }) }),
+						makeEntry({ job: makeJob({ id: 2, company: "Globex" }) }),
+					]}
+				/>,
+			);
+
+			expect(screen.getByText("Acme Corp")).toHaveAttribute(
+				"data-best-offer",
+				"true",
+			);
+			expect(screen.getByText("Globex")).toHaveAttribute(
+				"data-best-offer",
+				"true",
+			);
+		});
+
+		it("does not mark a null-offer column as best offer", () => {
+			render(
+				<OfferComparisonTable
+					entries={[
+						makeEntry({ job: makeJob({ id: 1, company: "Acme Corp" }) }),
+						makeEntry({
+							job: makeJob({ id: 2, company: "Globex" }),
+							offer: null,
+						}),
+					]}
+				/>,
+			);
+
+			expect(screen.getByText("Acme Corp")).toHaveAttribute(
+				"data-best-offer",
+				"true",
+			);
+			expect(screen.getByText("Globex")).not.toHaveAttribute("data-best-offer");
+		});
+	});
+
+	it("shows % of min offer footer row: 100% for lowest, proportional % for others", () => {
+		// BASE_OFFER ongoing TC: 150k + 15k + 50k + 1.2k + 5k = 221,200
+		// Higher offer (base 180k) ongoing TC: 180k + 18k + 50k + 1.2k + 5k = 254,200
+		// 254,200 / 221,200 ≈ 115%
+		render(
+			<OfferComparisonTable
+				entries={[
+					makeEntry({ job: makeJob({ id: 1, company: "Acme Corp" }) }),
+					makeEntry({
+						job: makeJob({ id: 2, company: "Globex" }),
+						offer: makeOffer({ base_pay_amount: 180_000 }),
+					}),
+				]}
+			/>,
+		);
+
+		const pctRow = screen.getByText("% of min offer").closest("tr");
+		expect(pctRow).not.toBeNull();
+		const cells = within(pctRow as HTMLElement).getAllByRole("cell");
+		// Cells[0] is the label cell
+		expect(cells[1]).toHaveTextContent("100%");
+		expect(cells[2]).toHaveTextContent("115%");
+	});
+
+	it("shows dash for % of min offer when an entry has no offer", () => {
+		render(
+			<OfferComparisonTable
+				entries={[
+					makeEntry({ job: makeJob({ id: 1 }) }),
+					makeEntry({ job: makeJob({ id: 2 }), offer: null }),
+				]}
+			/>,
+		);
+
+		const pctRow = screen.getByText("% of min offer").closest("tr");
+		expect(pctRow).not.toBeNull();
+		const cells = within(pctRow as HTMLElement).getAllByRole("cell");
+		expect(cells[1]).toHaveTextContent("100%");
+		expect(cells[2]).toHaveTextContent("—");
 	});
 
 	it("renders a Total Comp footer row with correct Year 1 and Ongoing values", () => {

--- a/frontend/src/components/offers/OfferComparisonTable.tsx
+++ b/frontend/src/components/offers/OfferComparisonTable.tsx
@@ -13,6 +13,7 @@ import type { EquityType, Offer, OfferComparisonEntry } from "../../types";
 import {
 	computeOngoingTC,
 	computeYear1TC,
+	equityPerYear,
 	formatCompactCurrency,
 	formatCurrency,
 } from "../../offerUtils";
@@ -48,10 +49,26 @@ function formatOther(offer: Offer): string {
 	return `${formatCurrency(offer.other_amount)}${cadence}${label}`;
 }
 
+function maxIndices(values: (number | null)[]): Set<number> {
+	const nonNull = values.filter((v): v is number => v !== null);
+	if (nonNull.length === 0) {
+		return new Set();
+	}
+	const max = Math.max(...nonNull);
+	const indices = new Set<number>();
+	for (let i = 0; i < values.length; i++) {
+		if (values[i] === max) {
+			indices.add(i);
+		}
+	}
+	return indices;
+}
+
 interface Row {
 	key: string;
 	label: string;
 	format: (offer: Offer) => string;
+	value?: (offer: Offer) => number | null;
 }
 
 const ROWS: Row[] = [
@@ -62,14 +79,21 @@ const ROWS: Row[] = [
 				: `${formatCurrency(o.base_pay_amount)}/yr`,
 		key: "base_pay",
 		label: "Base Pay",
+		value: (o) => o.base_pay_amount,
 	},
 	{
 		format: (o) =>
 			o.target_bonus_percent === null ? DASH : `${o.target_bonus_percent}%`,
 		key: "target_bonus",
 		label: "Target Bonus",
+		value: (o) => o.target_bonus_percent,
 	},
-	{ format: formatEquity, key: "equity", label: "Equity" },
+	{
+		format: formatEquity,
+		key: "equity",
+		label: "Equity",
+		value: (o) => (o.equity_amount === null ? null : equityPerYear(o)),
+	},
 	{
 		format: (o) =>
 			o.signing_bonus_amount === null
@@ -77,6 +101,7 @@ const ROWS: Row[] = [
 				: formatCurrency(o.signing_bonus_amount),
 		key: "signing_bonus",
 		label: "Signing Bonus",
+		value: (o) => o.signing_bonus_amount,
 	},
 	{
 		format: (o) =>
@@ -85,13 +110,20 @@ const ROWS: Row[] = [
 				: `${formatCurrency(o.wellness_stipend_amount)}/yr`,
 		key: "wellness_stipend",
 		label: "Wellness Stipend",
+		value: (o) => o.wellness_stipend_amount,
 	},
-	{ format: formatOther, key: "other", label: "Other" },
+	{
+		format: formatOther,
+		key: "other",
+		label: "Other",
+		value: (o) => o.other_amount,
+	},
 	{
 		format: (o) =>
 			o.k401_match_percent === null ? DASH : `${o.k401_match_percent}%`,
 		key: "k401_match",
 		label: "401k Match",
+		value: (o) => o.k401_match_percent,
 	},
 ];
 
@@ -100,60 +132,159 @@ interface Props {
 }
 
 export default function OfferComparisonTable({ entries }: Props) {
+	const ongoingTCs = entries.map(({ offer }) =>
+		offer === null ? null : computeOngoingTC(offer),
+	);
+	const year1TCs = entries.map(({ offer }) =>
+		offer === null ? null : computeYear1TC(offer),
+	);
+	const nonNullTCs = ongoingTCs.filter((tc): tc is number => tc !== null);
+	const minOngoingTC = nonNullTCs.length > 0 ? Math.min(...nonNullTCs) : null;
+	const maxOngoingTC = nonNullTCs.length > 0 ? Math.max(...nonNullTCs) : null;
+	const bestColIndices = maxIndices(ongoingTCs);
+
+	const pctOfMinValues = ongoingTCs.map((tc) =>
+		tc === null || minOngoingTC === null
+			? null
+			: Math.round((tc / minOngoingTC) * 100),
+	);
+
+	const isBestCol = (i: number) =>
+		maxOngoingTC !== null && bestColIndices.has(i);
+
 	return (
 		<TableContainer>
 			<Table size="small">
 				<TableHead>
 					<TableRow>
 						<TableCell />
-						{entries.map(({ job }) => (
-							<TableCell key={job.id} sx={{ fontWeight: 700 }}>
+						{entries.map(({ job }, i) => (
+							<TableCell
+								key={job.id}
+								data-best-offer={isBestCol(i) ? "true" : undefined}
+								sx={{
+									color: isBestCol(i) ? "success.main" : undefined,
+									fontWeight: 700,
+								}}
+							>
 								{job.company}
 							</TableCell>
 						))}
 					</TableRow>
 				</TableHead>
 				<TableBody>
-					{ROWS.map((row) => (
-						<TableRow key={row.key}>
-							<TableCell sx={{ color: "text.secondary" }}>
-								{row.label}
-							</TableCell>
-							{entries.map(({ job, offer }) => (
-								<TableCell key={job.id}>
-									{offer === null ? DASH : row.format(offer)}
+					{ROWS.map((row) => {
+						const rowValues = entries.map(({ offer }) =>
+							offer === null || !row.value ? null : row.value(offer),
+						);
+						const boldCols = row.value
+							? maxIndices(rowValues)
+							: new Set<number>();
+						return (
+							<TableRow key={row.key}>
+								<TableCell sx={{ color: "text.secondary" }}>
+									{row.label}
 								</TableCell>
-							))}
-						</TableRow>
-					))}
+								{entries.map(({ job, offer }, i) => (
+									<TableCell
+										key={job.id}
+										data-row-max={boldCols.has(i) ? "true" : undefined}
+										data-best-offer={isBestCol(i) ? "true" : undefined}
+										sx={{
+											color: isBestCol(i) ? "success.main" : undefined,
+											fontWeight: boldCols.has(i) ? 700 : undefined,
+										}}
+									>
+										{offer === null ? DASH : row.format(offer)}
+									</TableCell>
+								))}
+							</TableRow>
+						);
+					})}
 				</TableBody>
 				<TableFooter>
-					<TableRow>
-						<TableCell sx={{ fontWeight: 700 }}>
-							<Typography variant="body2" sx={{ fontWeight: 700 }}>
-								Total Comp (Year 1)
-							</Typography>
-						</TableCell>
-						{entries.map(({ job, offer }) => (
-							<TableCell key={job.id} sx={{ fontWeight: 700 }}>
-								{offer === null ? DASH : formatCurrency(computeYear1TC(offer))}
-							</TableCell>
-						))}
-					</TableRow>
-					<TableRow>
-						<TableCell sx={{ fontWeight: 700 }}>
-							<Typography variant="body2" sx={{ fontWeight: 700 }}>
-								Total Comp (Ongoing)
-							</Typography>
-						</TableCell>
-						{entries.map(({ job, offer }) => (
-							<TableCell key={job.id} sx={{ fontWeight: 700 }}>
-								{offer === null
-									? DASH
-									: formatCurrency(computeOngoingTC(offer))}
-							</TableCell>
-						))}
-					</TableRow>
+					{(() => {
+						const boldCols = maxIndices(year1TCs);
+						return (
+							<TableRow>
+								<TableCell sx={{ fontWeight: 700 }}>
+									<Typography variant="body2" sx={{ fontWeight: 700 }}>
+										Total Comp (Year 1)
+									</Typography>
+								</TableCell>
+								{entries.map(({ job, offer }, i) => (
+									<TableCell
+										key={job.id}
+										data-row-max={boldCols.has(i) ? "true" : undefined}
+										data-best-offer={isBestCol(i) ? "true" : undefined}
+										sx={{
+											color: isBestCol(i) ? "success.main" : undefined,
+											fontWeight: 700,
+										}}
+									>
+										{offer === null
+											? DASH
+											: formatCurrency(computeYear1TC(offer))}
+									</TableCell>
+								))}
+							</TableRow>
+						);
+					})()}
+					{(() => {
+						const boldCols = maxIndices(ongoingTCs);
+						return (
+							<TableRow>
+								<TableCell sx={{ fontWeight: 700 }}>
+									<Typography variant="body2" sx={{ fontWeight: 700 }}>
+										Total Comp (Ongoing)
+									</Typography>
+								</TableCell>
+								{entries.map(({ job, offer }, i) => (
+									<TableCell
+										key={job.id}
+										data-row-max={boldCols.has(i) ? "true" : undefined}
+										data-best-offer={isBestCol(i) ? "true" : undefined}
+										sx={{
+											color: isBestCol(i) ? "success.main" : undefined,
+											fontWeight: 700,
+										}}
+									>
+										{offer === null
+											? DASH
+											: formatCurrency(computeOngoingTC(offer))}
+									</TableCell>
+								))}
+							</TableRow>
+						);
+					})()}
+					{(() => {
+						const boldCols = maxIndices(pctOfMinValues);
+						return (
+							<TableRow>
+								<TableCell sx={{ fontWeight: 700 }}>
+									<Typography variant="body2" sx={{ fontWeight: 700 }}>
+										% of min offer
+									</Typography>
+								</TableCell>
+								{entries.map(({ job }, i) => {
+									const pct = pctOfMinValues[i];
+									return (
+										<TableCell
+											key={job.id}
+											data-row-max={boldCols.has(i) ? "true" : undefined}
+											data-best-offer={isBestCol(i) ? "true" : undefined}
+											sx={{
+												color: isBestCol(i) ? "success.main" : undefined,
+												fontWeight: 700,
+											}}
+										>
+											{pct === null ? DASH : `${pct}%`}
+										</TableCell>
+									);
+								})}
+							</TableRow>
+						);
+					})()}
 				</TableFooter>
 			</Table>
 		</TableContainer>


### PR DESCRIPTION
## Summary

Enhances the Compensation Comparison table in the Offers tab with two visual improvements that make it easier to identify the best offer at a glance.

## Details

- **Row-max bolding**: the highest-valued cell in each row is bolded; ties bold all tied values. Applies to every body row (Base Pay, Bonus %, Equity/yr, Signing Bonus, Wellness Stipend, Other, 401k Match) and every footer row.
- **Best-offer column**: the column belonging to the offer with the highest ongoing total comp is rendered in green (`success.main`) across the header, all body cells, and all footer cells.
- Adds `maxIndices()` helper to find all indices sharing a row's numeric maximum, handling nulls (missing fields / missing offers) gracefully.
- Adds a `value?: (offer) => number | null` extractor to each `Row` descriptor so the component can compare fields numerically without duplicating format logic.
- Uses `data-row-max` / `data-best-offer` attributes on cells to make styling behaviour testable in jsdom, where MUI emotion class names are not queryable via `getComputedStyle`.

## Test plan

- [x] Open the Offer Comparator with two or more offers and verify the highest-value cell in each row is bold.
- [x] Verify tied rows (e.g. identical signing bonus) bold both cells.
- [x] Verify the entire column of the highest ongoing-TC offer is green (header, body rows, footer rows).
- [x] Verify that a null offer column is neither bolded as max nor greened as best.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)