### PR TITLE
feat(jobs): scope job listing and creation to the active search round

### DIFF
--- a/backend/db/jobSearches.ts
+++ b/backend/db/jobSearches.ts
@@ -49,6 +49,18 @@ export function getActiveSearch(
 		.get(userId) as JobSearchRow | undefined;
 }
 
+/** Returns the user's active round, opening a first one if they don't have one yet. */
+export function getOrCreateActiveSearch(
+	db: Database.Database,
+	userId: number,
+): JobSearchRow {
+	const active = getActiveSearch(db, userId);
+	if (active) {
+		return active;
+	}
+	return startNewSearch(db, userId, "Search 1", null);
+}
+
 /** Jobs in the given round that aren't in a terminal status — these block closing the round. */
 export function listBlockingJobs(
 	db: Database.Database,

--- a/backend/db/jobs.ts
+++ b/backend/db/jobs.ts
@@ -23,6 +23,7 @@ interface JobDbRow {
 	created_at: string;
 	updated_at: string;
 	tags_csv: string | null;
+	search_id: number | null;
 }
 
 // SQLite stores booleans as 0/1 — convert for the client
@@ -63,6 +64,8 @@ export interface JobCreateData {
 	date_offer_extended: string | null;
 	favorite: boolean;
 	tags: string[];
+	/** Job search round this job belongs to; omitted/null files it outside any round. */
+	search_id?: number | null;
 }
 
 /**
@@ -90,10 +93,17 @@ function setTags(db: Database.Database, jobId: number | bigint, tags: string[]):
 	}
 }
 
-export function listJobs(db: Database.Database, userId: number, view: JobView = "summary"): Job[] {
+export function listJobs(
+	db: Database.Database,
+	userId: number,
+	view: JobView = "summary",
+	searchId?: number,
+): Job[] {
+	const searchFilter = searchId === undefined ? "" : "AND j.search_id = ?";
+	const params = searchId === undefined ? [userId] : [userId, searchId];
 	const rows = db
-		.prepare(`${JOBS_WITH_TAGS_SQL} WHERE j.user_id = ? GROUP BY j.id ORDER BY j.created_at DESC`)
-		.all(userId)
+		.prepare(`${JOBS_WITH_TAGS_SQL} WHERE j.user_id = ? ${searchFilter} GROUP BY j.id ORDER BY j.created_at DESC`)
+		.all(...params)
 		.map(toClient);
 	if (view === "summary") {
 		return rows.map(({ notes: _n, job_description: _jd, ...rest }) => rest);
@@ -134,8 +144,8 @@ export function createJob(
 			.prepare(
 				`INSERT INTO jobs (user_id, date_applied, company, role, link, salary, fit_score,
           referred_by, status, recruiter, notes, job_description, ending_substatus,
-          date_phone_screen, date_last_onsite, date_offer_extended, favorite)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          date_phone_screen, date_last_onsite, date_offer_extended, favorite, search_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			)
 			.run(
 				data.user_id,
@@ -155,6 +165,7 @@ export function createJob(
 				data.date_last_onsite,
 				data.date_offer_extended,
 				data.favorite ? 1 : 0,
+				data.search_id ?? null,
 			);
 		db.prepare(
 			"INSERT INTO job_status_history (job_id, status) VALUES (?, ?)",

--- a/backend/routes/jobs.ts
+++ b/backend/routes/jobs.ts
@@ -2,6 +2,7 @@ import type Database from "better-sqlite3";
 import { Router } from "express";
 import * as JobsDb from "../db/jobs.js";
 import type { JobView } from "../db/jobs.js";
+import * as JobSearchesDb from "../db/jobSearches.js";
 import { validateEndingSubstatus, validateJobFields, validateOfferDate } from "../validators.js";
 import * as OffersDb from "../db/offers.js";
 
@@ -10,7 +11,9 @@ export function createJobsRouter(db: Database.Database) {
 
 	router.get("/", (req, res) => {
 		const view: JobView = req.query.view === "full" ? "full" : "summary";
-		res.json(JobsDb.listJobs(db, req.session.userId!, view));
+		const userId = req.session.userId!;
+		const active = JobSearchesDb.getActiveSearch(db, userId);
+		res.json(active ? JobsDb.listJobs(db, userId, view, active.id) : []);
 	});
 
 	router.get("/:jobId", (req, res) => {
@@ -42,6 +45,8 @@ export function createJobsRouter(db: Database.Database) {
 			return res.status(409).json({ error: "Job already exists" });
 		}
 
+		const active = JobSearchesDb.getOrCreateActiveSearch(db, userId);
+
 		const job = JobsDb.createJob(db, {
 			company: f.company,
 			date_applied: f.date_applied ?? null,
@@ -58,6 +63,7 @@ export function createJobsRouter(db: Database.Database) {
 			referred_by: f.referred_by ?? null,
 			role: f.role,
 			salary: f.salary ?? null,
+			search_id: active.id,
 			status: f.status ?? "not_started",
 			tags: Array.isArray(f.tags) ? f.tags : [],
 			user_id: userId,

--- a/backend/routes/offers.spec.ts
+++ b/backend/routes/offers.spec.ts
@@ -21,6 +21,10 @@ testDb.exec(`
 `);
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(TEST_USER_ID, "test@test.com");
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(OTHER_USER_ID, "other@test.com");
+const ACTIVE_SEARCH_ID = Number(
+	testDb.prepare("INSERT INTO job_searches (user_id, name) VALUES (?, 'Search 1')").run(TEST_USER_ID)
+		.lastInsertRowid,
+);
 testDb
 	.prepare("INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))")
 	.run(TEST_SESSION_ID, JSON.stringify({ cookie: { originalMaxAge: 604_800_000 }, userId: TEST_USER_ID }));
@@ -63,8 +67,15 @@ const BASE_OFFER = {
 
 function insertJob(overrides: Record<string, unknown> = {}) {
 	const result = testDb
-		.prepare("INSERT INTO jobs (user_id, company, role, link, status) VALUES (?, ?, ?, ?, ?)")
-		.run(TEST_USER_ID, "Acme", "Engineer", "https://example.com/job/1", overrides.status ?? "offer");
+		.prepare("INSERT INTO jobs (user_id, company, role, link, status, search_id) VALUES (?, ?, ?, ?, ?, ?)")
+		.run(
+			TEST_USER_ID,
+			"Acme",
+			"Engineer",
+			"https://example.com/job/1",
+			overrides.status ?? "offer",
+			ACTIVE_SEARCH_ID,
+		);
 	return Number(result.lastInsertRowid);
 }
 


### PR DESCRIPTION
## Summary
- `GET /api/jobs` now filters results to the user's active `job_searches` round instead of returning every job across all rounds.
- `POST /api/jobs` stamps new jobs with the active round's id, auto-opening a "Search 1" round if the user doesn't have one yet (mirrors the migration's backfill behavior).

Third story toward the `JobSearch` entity — builds on #139 (schema) and the job-searches CRUD routes on this branch. Stacked on `feat/job-search-schema-migration` since it depends on `job_searches` and isn't merged to `main` yet.

Stats/radar/insights routes are unaffected — they query the `jobs` table directly rather than through `JobsDb.listJobs`.

## Test plan
- [x] `npx vitest run` in `backend` — 503 passed
- [x] `npm run tsc -w backend` — clean