### PR TITLE
feat(job-searches): add CRUD routes and scope jobs to the active round

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ jobman/
 │   ├── validators.ts        # Request field validators (length, substatus rules)
 │   ├── db/                  # DB query modules (one per domain)
 │   │   ├── jobs.ts
+│   │   ├── jobSearches.ts   # Job search rounds (start/close/list, active round)
 │   │   ├── interviews.ts
 │   │   ├── interviewInsights.ts
 │   │   ├── radar.ts
@@ -22,6 +23,7 @@ jobman/
 │   └── routes/              # Express routers (one per domain)
 │       ├── auth.ts          # Google OAuth + session login/logout
 │       ├── jobs.ts
+│       ├── jobSearches.ts
 │       ├── interviews.ts
 │       ├── interviewInsights.ts
 │       ├── radar.ts
@@ -37,9 +39,11 @@ jobman/
         ├── logoCache.ts             # Company logo URL cache
         ├── useCompanyLogo.ts        # Hook for logo fetch
         └── components/
-            ├── AppShell.tsx         # Nav drawer + top bar
+            ├── AppShell.tsx         # Nav drawer + top bar; owns the New Job Search flow
+            ├── NewSearchRoundDialog.tsx # Step 1: name/notes for a new job search round
+            ├── NewSearchRoundConfirmDialog.tsx # Step 2: confirm closing the active round
             ├── LoginPage.tsx        # Google OAuth login screen
-            ├── JobManagementPage.tsx# Kanban board page
+            ├── JobManagementPage.tsx# Kanban board page; shows active round as a chip
             ├── KanbanBoard.tsx      # DnD context, drag overlay
             ├── KanbanColumn.tsx     # Droppable column
             ├── JobCard.tsx          # Draggable card (drag handle only)
@@ -102,11 +106,15 @@ All routes except `/api/auth/*` require an active session (`requireAuth` middlew
 | GET    | /api/auth/google                   | Initiate Google OAuth              |
 | GET    | /api/auth/google/callback          | OAuth callback                     |
 | POST   | /api/auth/logout                   | Destroy session                    |
-| GET    | /api/jobs                          | List jobs (`?view=summary` or `full`) |
+| GET    | /api/jobs                          | List jobs in the active search round (`?view=summary` or `full`) |
 | GET    | /api/jobs/:id                      | Fetch single job (full view)       |
-| POST   | /api/jobs                          | Create job (201)                   |
+| POST   | /api/jobs                          | Create job in the active round (201); opens one if none exists |
 | PUT    | /api/jobs/:id                      | Update job                         |
 | DELETE | /api/jobs/:id                      | Delete job                         |
+| GET    | /api/job-searches                  | List all search rounds, newest first |
+| GET    | /api/job-searches/active            | Current user's active round, or 404 |
+| POST   | /api/job-searches                  | Close the active round and open a new one (201); 409 with `blockingJobs` if unresolved jobs remain |
+| PATCH  | /api/job-searches/:id              | Rename a round / edit its notes    |
 | GET    | /api/jobs/:jobId/interviews        | List interviews for a job          |
 | POST   | /api/jobs/:jobId/interviews        | Add interview                      |
 | PUT    | /api/jobs/:jobId/interviews/:id    | Update interview                   |
@@ -144,6 +152,17 @@ interface Job {
 }
 ```
 
+```typescript
+interface JobSearch {
+  id: number;
+  user_id: number;
+  name: string;
+  started_at: string;
+  closed_at: string | null;     // null while active; a user has at most one active round
+  notes: string | null;
+}
+```
+
 **JobStatus values:** `"Not started"` | `"Applied"` | `"Phone screen"` | `"Interviewing"` | `"Offer!"` | `"Rejected/Withdrawn"`
 
 **EndingSubstatus:** `"Withdrawn"` | `"Rejected"` | `"Ghosted"` | `"No response"` | `"Job closed"` | `"Not a good fit"` | `"Offer accepted"` | `"Offer declined"`
@@ -157,7 +176,8 @@ interface Job {
 - **Drag handle:** Only the `DragIndicatorIcon` on each card is draggable — not the full card — to avoid conflicts with the click-to-edit behavior.
 - **Search:** Case-insensitive substring match on company or role, applied before passing jobs to KanbanBoard.
 - **Job summary vs full view:** `GET /api/jobs` returns a summary view by default (omits `notes` and `job_description`). Pass `?view=full` or fetch `GET /api/jobs/:id` for the complete record.
-- **Schema:** Defined inline in `db.ts` using `CREATE TABLE IF NOT EXISTS`. No migration files.
+- **Job search rounds:** Every job belongs to a `job_searches` round (`jobs.search_id`); a user has at most one active round at a time (`closed_at IS NULL`, enforced by a unique index). `GET`/`POST /api/jobs` only see/create jobs in the *active* round — closed rounds' jobs stay in the DB but drop off the board. `POST /api/job-searches` closes the active round and opens a new one, but 409s with a `blockingJobs` list if the active round still has non-terminal jobs. The frontend surfaces this as a two-step "New Job Search" flow in the `AppShell` user menu (name/notes entry, then an explicit confirmation) since it's an infrequent, consequential action.
+- **Schema:** Defined inline in `db.ts` using `CREATE TABLE IF NOT EXISTS`. One-off migrations (e.g. `migrateJobSearches`) use idempotent `ALTER TABLE`/backfill logic since better-sqlite3 has no "ADD COLUMN IF NOT EXISTS".
 - **Environment:** Backend reads `.env.development` (or `.env.production`). Required vars: `SESSION_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL`.
 
 ## Frontend Unit Test Conventions

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ There are *several* usability issues in the app, but overall it works, and track
 - **Interview insights** — aggregated analytics across all logged interview questions and difficulty
 - **Pipeline stats** — charts on application volume, conversion rates, and time-in-stage over configurable windows
 - **Company radar** — see which companies you've already applied to before re-applying, with notes and policy tracking
+- **Job search rounds** — close out a finished search and start a fresh board without losing history; old rounds' jobs stay recorded, just off the active board
 - **Google OAuth login** — sign in with your Google account; sessions persisted in SQLite
 
 ## Tech stack

--- a/backend/db.ts
+++ b/backend/db.ts
@@ -47,7 +47,8 @@ export function applySchema(db: Database.Database): void {
     date_phone_screen TEXT     CHECK(length(date_phone_screen) <= 16),
     date_last_onsite  TEXT     CHECK(length(date_last_onsite) <= 16),
     date_offer_extended TEXT   CHECK(length(date_offer_extended) <= 16),
-    updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    search_id          INTEGER REFERENCES job_searches(id)
   );
 
   CREATE TRIGGER IF NOT EXISTS jobs_updated_at

--- a/backend/db.ts
+++ b/backend/db.ts
@@ -127,6 +127,18 @@ export function applySchema(db: Database.Database): void {
     UPDATE offers SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = OLD.id;
   END;
 
+  CREATE TABLE IF NOT EXISTS job_searches (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id),
+    name       TEXT NOT NULL CHECK(length(name) <= 128),
+    started_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    closed_at  TEXT,
+    notes      TEXT     CHECK(length(notes) <= 4096)
+  );
+
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_job_searches_active_per_user
+    ON job_searches(user_id) WHERE closed_at IS NULL;
+
   CREATE TABLE IF NOT EXISTS target_companies (
     id                         INTEGER PRIMARY KEY AUTOINCREMENT,
     name                       TEXT    NOT NULL UNIQUE,
@@ -148,11 +160,56 @@ export function applySchema(db: Database.Database): void {
 `);
 }
 
+/**
+ * Adds jobs.search_id (idempotent — better-sqlite3 has no "ADD COLUMN IF NOT EXISTS")
+ * and backfills every pre-existing job into a new "Search 1" job_searches row per user.
+ * Runs against both fresh and pre-existing databases; a fresh DB simply has no rows to backfill.
+ */
+export function migrateJobSearches(db: Database.Database): void {
+	const columns = db.prepare("PRAGMA table_info(jobs)").all() as {
+		name: string;
+	}[];
+	if (!columns.some((c) => c.name === "search_id")) {
+		db.exec(
+			"ALTER TABLE jobs ADD COLUMN search_id INTEGER REFERENCES job_searches(id)",
+		);
+	}
+
+	const usersNeedingBackfill = db
+		.prepare("SELECT DISTINCT user_id FROM jobs WHERE search_id IS NULL")
+		.all() as { user_id: number }[];
+
+	const earliestJobDate = db.prepare(
+		"SELECT MIN(created_at) AS earliest FROM jobs WHERE user_id = ? AND search_id IS NULL",
+	);
+	const insertSearch = db.prepare(
+		"INSERT INTO job_searches (user_id, name, started_at) VALUES (?, 'Search 1', ?)",
+	);
+	const backfillJobs = db.prepare(
+		"UPDATE jobs SET search_id = ? WHERE user_id = ? AND search_id IS NULL",
+	);
+
+	const backfill = db.transaction(() => {
+		for (const { user_id } of usersNeedingBackfill) {
+			const { earliest } = earliestJobDate.get(user_id) as {
+				earliest: string | null;
+			};
+			const { lastInsertRowid: searchId } = insertSearch.run(
+				user_id,
+				earliest ?? new Date().toISOString(),
+			);
+			backfillJobs.run(searchId, user_id);
+		}
+	});
+	backfill();
+}
+
 const db = new Database(join(import.meta.dirname, "jobman.db"));
 
 // Enable foreign key enforcement
 db.pragma("foreign_keys = ON");
 applySchema(db);
+migrateJobSearches(db);
 
 // Seed target companies (INSERT OR IGNORE — safe to re-run)
 db.exec(`

--- a/backend/db/jobSearches.spec.ts
+++ b/backend/db/jobSearches.spec.ts
@@ -1,0 +1,141 @@
+import Database from "better-sqlite3";
+import { applySchema } from "../db.js";
+import {
+	getActiveSearch,
+	getSearch,
+	listBlockingJobs,
+	listSearches,
+	startNewSearch,
+	updateSearch,
+} from "./jobSearches.js";
+
+function makeDb() {
+	const db = new Database(":memory:");
+	applySchema(db);
+	return db;
+}
+
+function insertJob(
+	db: Database.Database,
+	userId: number,
+	overrides: { status?: string; search_id?: number | null } = {},
+) {
+	const result = db
+		.prepare(
+			"INSERT INTO jobs (user_id, company, role, link, status, search_id) VALUES (?, 'Acme', 'Engineer', 'https://example.com', ?, ?)",
+		)
+		.run(userId, overrides.status ?? "applied", overrides.search_id ?? null);
+	return Number(result.lastInsertRowid);
+}
+
+describe("jobSearches db", () => {
+	let db: Database.Database;
+	const USER_ID = 1;
+	const OTHER_USER_ID = 2;
+
+	beforeEach(() => {
+		db = makeDb();
+		db.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(
+			USER_ID,
+			"user@example.com",
+		);
+		db.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(
+			OTHER_USER_ID,
+			"other@example.com",
+		);
+	});
+
+	describe("startNewSearch", () => {
+		it("creates an active round when the user has none yet", () => {
+			const created = startNewSearch(db, USER_ID, "Search 1", null);
+			expect(created.name).toBe("Search 1");
+			expect(created.closed_at).toBeNull();
+			expect(getActiveSearch(db, USER_ID)?.id).toBe(created.id);
+		});
+
+		it("closes the previous active round when starting a new one", () => {
+			const first = startNewSearch(db, USER_ID, "Search 1", null);
+			const second = startNewSearch(db, USER_ID, "Search 2", "fresh start");
+
+			const closedFirst = getSearch(db, first.id, USER_ID);
+			expect(closedFirst?.closed_at).not.toBeNull();
+
+			const active = getActiveSearch(db, USER_ID);
+			expect(active?.id).toBe(second.id);
+			expect(active?.notes).toBe("fresh start");
+		});
+
+		it("does not affect other users' active rounds", () => {
+			startNewSearch(db, OTHER_USER_ID, "Other's search", null);
+			startNewSearch(db, USER_ID, "My search", null);
+			expect(getActiveSearch(db, OTHER_USER_ID)?.name).toBe("Other's search");
+		});
+	});
+
+	describe("listSearches", () => {
+		it("returns rounds newest first", () => {
+			const first = startNewSearch(db, USER_ID, "Search 1", null);
+			const second = startNewSearch(db, USER_ID, "Search 2", null);
+			const rows = listSearches(db, USER_ID);
+			expect(rows.map((r) => r.id)).toStrictEqual([second.id, first.id]);
+		});
+
+		it("does not return other users' rounds", () => {
+			startNewSearch(db, OTHER_USER_ID, "Other's search", null);
+			expect(listSearches(db, USER_ID)).toStrictEqual([]);
+		});
+	});
+
+	describe("listBlockingJobs", () => {
+		it("returns jobs not in a terminal status", () => {
+			const search = startNewSearch(db, USER_ID, "Search 1", null);
+			insertJob(db, USER_ID, { status: "applied", search_id: search.id });
+			insertJob(db, USER_ID, { status: "offer", search_id: search.id });
+			const blocking = listBlockingJobs(db, search.id);
+			expect(blocking).toHaveLength(1);
+			expect(blocking[0]?.status).toBe("applied");
+		});
+
+		it("returns an empty array when every job is terminal", () => {
+			const search = startNewSearch(db, USER_ID, "Search 1", null);
+			insertJob(db, USER_ID, { status: "offer", search_id: search.id });
+			insertJob(db, USER_ID, {
+				status: "rejected_or_withdrawn",
+				search_id: search.id,
+			});
+			expect(listBlockingJobs(db, search.id)).toStrictEqual([]);
+		});
+
+		it("ignores jobs from other rounds", () => {
+			const search = startNewSearch(db, USER_ID, "Search 1", null);
+			const other = startNewSearch(db, OTHER_USER_ID, "Other's search", null);
+			insertJob(db, OTHER_USER_ID, { status: "applied", search_id: other.id });
+			expect(listBlockingJobs(db, search.id)).toStrictEqual([]);
+		});
+	});
+
+	describe("updateSearch", () => {
+		it("updates name and notes", () => {
+			const search = startNewSearch(db, USER_ID, "Search 1", null);
+			const updated = updateSearch(db, search.id, USER_ID, {
+				name: "Renamed",
+				notes: "updated notes",
+			});
+			expect(updated?.name).toBe("Renamed");
+			expect(updated?.notes).toBe("updated notes");
+		});
+
+		it("returns null when the round belongs to a different user", () => {
+			const search = startNewSearch(db, OTHER_USER_ID, "Other's search", null);
+			expect(
+				updateSearch(db, search.id, USER_ID, { name: "Hijacked", notes: null }),
+			).toBeNull();
+		});
+
+		it("returns null when the round does not exist", () => {
+			expect(
+				updateSearch(db, 9999, USER_ID, { name: "Nope", notes: null }),
+			).toBeNull();
+		});
+	});
+});

--- a/backend/db/jobSearches.ts
+++ b/backend/db/jobSearches.ts
@@ -1,0 +1,109 @@
+import type Database from "better-sqlite3";
+import { TERMINAL_STATUSES } from "../validators.js";
+
+export interface JobSearchRow {
+	id: number;
+	user_id: number;
+	name: string;
+	started_at: string;
+	closed_at: string | null;
+	notes: string | null;
+}
+
+export interface BlockingJob {
+	id: number;
+	company: string;
+	role: string;
+	status: string;
+}
+
+export function listSearches(
+	db: Database.Database,
+	userId: number,
+): JobSearchRow[] {
+	return db
+		.prepare(
+			"SELECT * FROM job_searches WHERE user_id = ? ORDER BY started_at DESC, id DESC",
+		)
+		.all(userId) as JobSearchRow[];
+}
+
+export function getSearch(
+	db: Database.Database,
+	id: number,
+	userId: number,
+): JobSearchRow | undefined {
+	return db
+		.prepare("SELECT * FROM job_searches WHERE id = ? AND user_id = ?")
+		.get(id, userId) as JobSearchRow | undefined;
+}
+
+export function getActiveSearch(
+	db: Database.Database,
+	userId: number,
+): JobSearchRow | undefined {
+	return db
+		.prepare(
+			"SELECT * FROM job_searches WHERE user_id = ? AND closed_at IS NULL",
+		)
+		.get(userId) as JobSearchRow | undefined;
+}
+
+/** Jobs in the given round that aren't in a terminal status — these block closing the round. */
+export function listBlockingJobs(
+	db: Database.Database,
+	searchId: number,
+): BlockingJob[] {
+	const placeholders = [...TERMINAL_STATUSES].map(() => "?").join(", ");
+	return db
+		.prepare(
+			`SELECT id, company, role, status FROM jobs
+       WHERE search_id = ? AND status NOT IN (${placeholders})
+       ORDER BY created_at DESC`,
+		)
+		.all(searchId, ...TERMINAL_STATUSES) as BlockingJob[];
+}
+
+/**
+ * Closes the user's active round and opens a new one in its place. Callers must
+ * verify (via listBlockingJobs) that the active round has no non-terminal jobs first.
+ */
+export function startNewSearch(
+	db: Database.Database,
+	userId: number,
+	name: string,
+	notes: string | null,
+): JobSearchRow {
+	return db.transaction(() => {
+		db.prepare(
+			"UPDATE job_searches SET closed_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE user_id = ? AND closed_at IS NULL",
+		).run(userId);
+		const result = db
+			.prepare(
+				"INSERT INTO job_searches (user_id, name, notes) VALUES (?, ?, ?)",
+			)
+			.run(userId, name, notes);
+		return db
+			.prepare("SELECT * FROM job_searches WHERE id = ?")
+			.get(result.lastInsertRowid) as JobSearchRow;
+	})();
+}
+
+export function updateSearch(
+	db: Database.Database,
+	id: number,
+	userId: number,
+	data: { name: string; notes: string | null },
+): JobSearchRow | null {
+	const info = db
+		.prepare(
+			"UPDATE job_searches SET name = ?, notes = ? WHERE id = ? AND user_id = ?",
+		)
+		.run(data.name, data.notes, id, userId);
+	if (info.changes === 0) {
+		return null;
+	}
+	return db
+		.prepare("SELECT * FROM job_searches WHERE id = ?")
+		.get(id) as JobSearchRow;
+}

--- a/backend/db/jobSearches.ts
+++ b/backend/db/jobSearches.ts
@@ -49,6 +49,18 @@ export function getActiveSearch(
 		.get(userId) as JobSearchRow | undefined;
 }
 
+/** Returns the user's active round, opening a first one if they don't have one yet. */
+export function getOrCreateActiveSearch(
+	db: Database.Database,
+	userId: number,
+): JobSearchRow {
+	const active = getActiveSearch(db, userId);
+	if (active) {
+		return active;
+	}
+	return startNewSearch(db, userId, "Search 1", null);
+}
+
 /** Jobs in the given round that aren't in a terminal status — these block closing the round. */
 export function listBlockingJobs(
 	db: Database.Database,

--- a/backend/db/jobs.ts
+++ b/backend/db/jobs.ts
@@ -23,6 +23,7 @@ interface JobDbRow {
 	created_at: string;
 	updated_at: string;
 	tags_csv: string | null;
+	search_id: number | null;
 }
 
 // SQLite stores booleans as 0/1 — convert for the client
@@ -63,6 +64,8 @@ export interface JobCreateData {
 	date_offer_extended: string | null;
 	favorite: boolean;
 	tags: string[];
+	/** Job search round this job belongs to; omitted/null files it outside any round. */
+	search_id?: number | null;
 }
 
 /**
@@ -90,10 +93,17 @@ function setTags(db: Database.Database, jobId: number | bigint, tags: string[]):
 	}
 }
 
-export function listJobs(db: Database.Database, userId: number, view: JobView = "summary"): Job[] {
+export function listJobs(
+	db: Database.Database,
+	userId: number,
+	view: JobView = "summary",
+	searchId?: number,
+): Job[] {
+	const searchFilter = searchId === undefined ? "" : "AND j.search_id = ?";
+	const params = searchId === undefined ? [userId] : [userId, searchId];
 	const rows = db
-		.prepare(`${JOBS_WITH_TAGS_SQL} WHERE j.user_id = ? GROUP BY j.id ORDER BY j.created_at DESC`)
-		.all(userId)
+		.prepare(`${JOBS_WITH_TAGS_SQL} WHERE j.user_id = ? ${searchFilter} GROUP BY j.id ORDER BY j.created_at DESC`)
+		.all(...params)
 		.map(toClient);
 	if (view === "summary") {
 		return rows.map(({ notes: _n, job_description: _jd, ...rest }) => rest);
@@ -134,8 +144,8 @@ export function createJob(
 			.prepare(
 				`INSERT INTO jobs (user_id, date_applied, company, role, link, salary, fit_score,
           referred_by, status, recruiter, notes, job_description, ending_substatus,
-          date_phone_screen, date_last_onsite, date_offer_extended, favorite)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          date_phone_screen, date_last_onsite, date_offer_extended, favorite, search_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			)
 			.run(
 				data.user_id,
@@ -155,6 +165,7 @@ export function createJob(
 				data.date_last_onsite,
 				data.date_offer_extended,
 				data.favorite ? 1 : 0,
+				data.search_id ?? null,
 			);
 		db.prepare(
 			"INSERT INTO job_status_history (job_id, status) VALUES (?, ?)",

--- a/backend/routes/jobSearches.spec.ts
+++ b/backend/routes/jobSearches.spec.ts
@@ -1,0 +1,199 @@
+import { createHmac } from "node:crypto";
+import Database from "better-sqlite3";
+import request from "supertest";
+import { createApp } from "../server.js";
+import { applySchema } from "../db.js";
+
+const SESSION_SECRET = "dev-secret";
+const TEST_USER_ID = 1;
+const TEST_SESSION_ID = "test-session-job-searches-routes";
+
+const testDb = new Database(":memory:");
+applySchema(testDb);
+testDb.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    sid TEXT NOT NULL PRIMARY KEY,
+    sess JSON NOT NULL,
+    expire TEXT NOT NULL
+  );
+`);
+testDb
+	.prepare("INSERT INTO users (id, email) VALUES (?, ?)")
+	.run(TEST_USER_ID, "test@test.com");
+testDb
+	.prepare(
+		"INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))",
+	)
+	.run(
+		TEST_SESSION_ID,
+		JSON.stringify({
+			cookie: { originalMaxAge: 604_800_000 },
+			userId: TEST_USER_ID,
+		}),
+	);
+
+const sig = createHmac("sha256", SESSION_SECRET)
+	.update(TEST_SESSION_ID)
+	.digest("base64")
+	.replace(/=+$/, "");
+const AUTH_COOKIE = `connect.sid=${encodeURIComponent(`s:${TEST_SESSION_ID}.${sig}`)}`;
+
+const app = createApp(testDb);
+
+function req(method: "get" | "post" | "patch", url: string) {
+	return request(app)[method](url).set("Cookie", AUTH_COOKIE);
+}
+
+function insertJob(
+	overrides: { status?: string; search_id?: number | null } = {},
+) {
+	const result = testDb
+		.prepare(
+			"INSERT INTO jobs (user_id, company, role, link, status, search_id) VALUES (?, 'Acme', 'Engineer', 'https://example.com', ?, ?)",
+		)
+		.run(
+			TEST_USER_ID,
+			overrides.status ?? "applied",
+			overrides.search_id ?? null,
+		) as { lastInsertRowid: number };
+	return Number(result.lastInsertRowid);
+}
+
+afterEach(() => {
+	testDb.exec("DELETE FROM jobs; DELETE FROM job_searches;");
+});
+
+describe("gET /api/job-searches", () => {
+	it("returns 401 when not authenticated", async () => {
+		const res = await request(app).get("/api/job-searches");
+		expect(res.status).toBe(401);
+	});
+
+	it("returns rounds newest first", async () => {
+		await req("post", "/api/job-searches").send({ name: "Search 1" });
+		await req("post", "/api/job-searches").send({ name: "Search 2" });
+		const res = await req("get", "/api/job-searches");
+		expect(res.status).toBe(200);
+		expect(res.body.map((r: { name: string }) => r.name)).toStrictEqual([
+			"Search 2",
+			"Search 1",
+		]);
+	});
+});
+
+describe("gET /api/job-searches/active", () => {
+	it("returns 404 when the user has no active round", async () => {
+		const res = await req("get", "/api/job-searches/active");
+		expect(res.status).toBe(404);
+	});
+
+	it("returns the active round", async () => {
+		await req("post", "/api/job-searches").send({ name: "Search 1" });
+		const res = await req("get", "/api/job-searches/active");
+		expect(res.status).toBe(200);
+		expect(res.body.name).toBe("Search 1");
+	});
+});
+
+describe("pOST /api/job-searches", () => {
+	it("returns 401 when not authenticated", async () => {
+		const res = await request(app)
+			.post("/api/job-searches")
+			.send({ name: "Search 1" });
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 400 when name is missing", async () => {
+		const res = await req("post", "/api/job-searches").send({});
+		expect(res.status).toBe(400);
+	});
+
+	it("creates the first round when the user has none yet", async () => {
+		const res = await req("post", "/api/job-searches").send({
+			name: "Search 1",
+		});
+		expect(res.status).toBe(201);
+		expect(res.body.name).toBe("Search 1");
+		expect(res.body.closed_at).toBeNull();
+	});
+
+	it("closes the active round and opens a new one when all jobs are terminal", async () => {
+		const first = await req("post", "/api/job-searches").send({
+			name: "Search 1",
+		});
+		insertJob({ status: "offer", search_id: first.body.id });
+
+		const res = await req("post", "/api/job-searches").send({
+			name: "Search 2",
+		});
+		expect(res.status).toBe(201);
+		expect(res.body.name).toBe("Search 2");
+
+		const active = await req("get", "/api/job-searches/active");
+		expect(active.body.id).toBe(res.body.id);
+	});
+
+	it("returns 409 with blocking jobs when the active round has non-terminal jobs", async () => {
+		const first = await req("post", "/api/job-searches").send({
+			name: "Search 1",
+		});
+		insertJob({ status: "applied", search_id: first.body.id });
+
+		const res = await req("post", "/api/job-searches").send({
+			name: "Search 2",
+		});
+		expect(res.status).toBe(409);
+		expect(res.body.blockingJobs).toHaveLength(1);
+
+		const active = await req("get", "/api/job-searches/active");
+		expect(active.body.id).toBe(first.body.id);
+	});
+});
+
+describe("pATCH /api/job-searches/:id", () => {
+	it("returns 401 when not authenticated", async () => {
+		const res = await request(app)
+			.patch("/api/job-searches/1")
+			.send({ name: "Renamed" });
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 400 for a non-numeric id", async () => {
+		const res = await req("patch", "/api/job-searches/not-a-number").send({
+			name: "Renamed",
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 400 when name is missing", async () => {
+		const created = await req("post", "/api/job-searches").send({
+			name: "Search 1",
+		});
+		const res = await req("patch", `/api/job-searches/${created.body.id}`).send(
+			{},
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("renames a round and updates notes", async () => {
+		const created = await req("post", "/api/job-searches").send({
+			name: "Search 1",
+		});
+		const res = await req("patch", `/api/job-searches/${created.body.id}`).send(
+			{
+				name: "Renamed",
+				notes: "some notes",
+			},
+		);
+		expect(res.status).toBe(200);
+		expect(res.body.name).toBe("Renamed");
+		expect(res.body.notes).toBe("some notes");
+	});
+
+	it("returns 404 when the round does not exist", async () => {
+		const res = await req("patch", "/api/job-searches/9999").send({
+			name: "Renamed",
+		});
+		expect(res.status).toBe(404);
+	});
+});

--- a/backend/routes/jobSearches.ts
+++ b/backend/routes/jobSearches.ts
@@ -1,0 +1,80 @@
+import type Database from "better-sqlite3";
+import { Router } from "express";
+import * as JobSearchesDb from "../db/jobSearches.js";
+import { validateJobSearchFields } from "../validators.js";
+
+export function createJobSearchesRouter(db: Database.Database) {
+	const router = Router();
+
+	// GET /api/job-searches — all rounds for the user, newest first
+	router.get("/", (req, res) => {
+		const userId = req.session.userId!;
+		res.json(JobSearchesDb.listSearches(db, userId));
+	});
+
+	// GET /api/job-searches/active
+	router.get("/active", (req, res) => {
+		const userId = req.session.userId!;
+		const active = JobSearchesDb.getActiveSearch(db, userId);
+		if (!active) {
+			return res.status(404).json({ error: "No active job search" });
+		}
+		return res.json(active);
+	});
+
+	// POST /api/job-searches — closes the current active round and starts a new one
+	router.post("/", (req, res) => {
+		const userId = req.session.userId!;
+		const f = req.body as Record<string, unknown>;
+
+		const validationError = validateJobSearchFields(f);
+		if (validationError) {
+			return res.status(400).json({ error: validationError });
+		}
+
+		const active = JobSearchesDb.getActiveSearch(db, userId);
+		if (active) {
+			const blocking = JobSearchesDb.listBlockingJobs(db, active.id);
+			if (blocking.length > 0) {
+				return res.status(409).json({
+					error: "Active job search has jobs that aren't resolved yet",
+					blockingJobs: blocking,
+				});
+			}
+		}
+
+		const created = JobSearchesDb.startNewSearch(
+			db,
+			userId,
+			f.name as string,
+			(f.notes as string | null) ?? null,
+		);
+		return res.status(201).json(created);
+	});
+
+	// PATCH /api/job-searches/:id — rename or edit notes (active or closed round)
+	router.patch("/:id", (req, res) => {
+		const userId = req.session.userId!;
+		const id = Number(req.params.id);
+		if (isNaN(id)) {
+			return res.status(400).json({ error: "Invalid id" });
+		}
+		const f = req.body as Record<string, unknown>;
+
+		const validationError = validateJobSearchFields(f);
+		if (validationError) {
+			return res.status(400).json({ error: validationError });
+		}
+
+		const updated = JobSearchesDb.updateSearch(db, id, userId, {
+			name: f.name as string,
+			notes: (f.notes as string | null) ?? null,
+		});
+		if (!updated) {
+			return res.status(404).json({ error: "Job search not found" });
+		}
+		return res.json(updated);
+	});
+
+	return router;
+}

--- a/backend/routes/jobs.ts
+++ b/backend/routes/jobs.ts
@@ -2,6 +2,7 @@ import type Database from "better-sqlite3";
 import { Router } from "express";
 import * as JobsDb from "../db/jobs.js";
 import type { JobView } from "../db/jobs.js";
+import * as JobSearchesDb from "../db/jobSearches.js";
 import { validateEndingSubstatus, validateJobFields, validateOfferDate } from "../validators.js";
 import * as OffersDb from "../db/offers.js";
 
@@ -10,7 +11,9 @@ export function createJobsRouter(db: Database.Database) {
 
 	router.get("/", (req, res) => {
 		const view: JobView = req.query.view === "full" ? "full" : "summary";
-		res.json(JobsDb.listJobs(db, req.session.userId!, view));
+		const userId = req.session.userId!;
+		const active = JobSearchesDb.getActiveSearch(db, userId);
+		res.json(active ? JobsDb.listJobs(db, userId, view, active.id) : []);
 	});
 
 	router.get("/:jobId", (req, res) => {
@@ -42,6 +45,8 @@ export function createJobsRouter(db: Database.Database) {
 			return res.status(409).json({ error: "Job already exists" });
 		}
 
+		const active = JobSearchesDb.getOrCreateActiveSearch(db, userId);
+
 		const job = JobsDb.createJob(db, {
 			company: f.company,
 			date_applied: f.date_applied ?? null,
@@ -58,6 +63,7 @@ export function createJobsRouter(db: Database.Database) {
 			referred_by: f.referred_by ?? null,
 			role: f.role,
 			salary: f.salary ?? null,
+			search_id: active.id,
 			status: f.status ?? "not_started",
 			tags: Array.isArray(f.tags) ? f.tags : [],
 			user_id: userId,

--- a/backend/routes/offers.spec.ts
+++ b/backend/routes/offers.spec.ts
@@ -21,6 +21,10 @@ testDb.exec(`
 `);
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(TEST_USER_ID, "test@test.com");
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(OTHER_USER_ID, "other@test.com");
+const ACTIVE_SEARCH_ID = Number(
+	testDb.prepare("INSERT INTO job_searches (user_id, name) VALUES (?, 'Search 1')").run(TEST_USER_ID)
+		.lastInsertRowid,
+);
 testDb
 	.prepare("INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))")
 	.run(TEST_SESSION_ID, JSON.stringify({ cookie: { originalMaxAge: 604_800_000 }, userId: TEST_USER_ID }));
@@ -63,8 +67,15 @@ const BASE_OFFER = {
 
 function insertJob(overrides: Record<string, unknown> = {}) {
 	const result = testDb
-		.prepare("INSERT INTO jobs (user_id, company, role, link, status) VALUES (?, ?, ?, ?, ?)")
-		.run(TEST_USER_ID, "Acme", "Engineer", "https://example.com/job/1", overrides.status ?? "offer");
+		.prepare("INSERT INTO jobs (user_id, company, role, link, status, search_id) VALUES (?, ?, ?, ?, ?, ?)")
+		.run(
+			TEST_USER_ID,
+			"Acme",
+			"Engineer",
+			"https://example.com/job/1",
+			overrides.status ?? "offer",
+			ACTIVE_SEARCH_ID,
+		);
 	return Number(result.lastInsertRowid);
 }
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -10,6 +10,7 @@ import {
 	createInterviewSearchRouter,
 	createInterviewsRouter,
 } from "./routes/interviews.js";
+import { createJobSearchesRouter } from "./routes/jobSearches.js";
 import { createJobsRouter } from "./routes/jobs.js";
 import { createOffersListRouter, createOffersRouter } from "./routes/offers.js";
 import { createRadarRouter } from "./routes/radar.js";
@@ -66,6 +67,7 @@ export function createApp(db: Database.Database) {
 	app.use("/api/auth", createAuthRouter(db));
 	app.use("/api/interviews", requireAuth, createInterviewSearchRouter(db));
 	app.use("/api/jobs", requireAuth, createJobsRouter(db));
+	app.use("/api/job-searches", requireAuth, createJobSearchesRouter(db));
 	app.use(
 		"/api/jobs/:jobId/interviews",
 		requireAuth,

--- a/backend/validators.ts
+++ b/backend/validators.ts
@@ -21,6 +21,11 @@ export const JOB_MAX_LENGTHS = {
 	salary: 64,
 } as const;
 
+export const JOB_SEARCH_MAX_LENGTHS = {
+	name: 128,
+	notes: 4096,
+} as const;
+
 export const INTERVIEW_MAX_LENGTHS = {
 	interview_interviewers: 128,
 	interview_notes: 4096,
@@ -133,6 +138,21 @@ export function validateOfferDate(
 		}
 	} else if (date_offer_extended != null) {
 		return `date_offer_extended must be null when status is not "${STATUS_LABELS["offer"]}"`;
+	}
+	return null;
+}
+
+export function validateJobSearchFields(
+	body: Record<string, unknown>,
+): string | null {
+	if (!body.name || typeof body.name !== "string") {
+		return "name is required";
+	}
+	for (const [field, max] of Object.entries(JOB_SEARCH_MAX_LENGTHS)) {
+		const err = checkLength(body[field], field, max);
+		if (err) {
+			return err;
+		}
 	}
 	return null;
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -35,6 +35,7 @@ export class ApiError extends Error {
 
 	constructor(status: number, body: unknown) {
 		super(`API error ${status}`);
+		this.name = "ApiError";
 		this.status = status;
 		this.body = body;
 	}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,6 +7,7 @@ import type {
 	InterviewQuestionFormData,
 	Job,
 	JobFormData,
+	JobSearch,
 	LinkJob,
 	Offer,
 	OfferComparisonEntry,
@@ -27,6 +28,18 @@ export function setUnauthorizedHandler(handler: () => void): void {
 	unauthorizedHandler = handler;
 }
 
+/** Thrown on non-2xx responses; carries the parsed JSON body (if any) for callers that need it. */
+export class ApiError extends Error {
+	status: number;
+	body: unknown;
+
+	constructor(status: number, body: unknown) {
+		super(`API error ${status}`);
+		this.status = status;
+		this.body = body;
+	}
+}
+
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 	const res = await fetch(`${BASE}${path}`, {
 		credentials: "include",
@@ -37,7 +50,8 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 		unauthorizedHandler?.();
 	}
 	if (!res.ok) {
-		throw new Error(`API error ${res.status}`);
+		const body = await res.json().catch(() => undefined);
+		throw new ApiError(res.status, body);
 	}
 	if (res.status === 204) {
 		return undefined as T;
@@ -69,6 +83,14 @@ export const api = {
 		request<Job>(`/jobs/${id}`, { body: JSON.stringify(data), method: "PUT" }),
 	deleteJob: (id: number) =>
 		request<{ success: boolean }>(`/jobs/${id}`, { method: "DELETE" }),
+
+	// Job searches (rounds)
+	getActiveSearch: () => request<JobSearch>("/job-searches/active"),
+	startNewSearch: (name: string, notes: string | null) =>
+		request<JobSearch>("/job-searches", {
+			body: JSON.stringify({ name, notes }),
+			method: "POST",
+		}),
 
 	// Radar
 	getRadar: (includeHidden = false) =>

--- a/frontend/src/components/jobs/JobManagementPage.spec.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.spec.tsx
@@ -24,6 +24,7 @@ vi.mock(import("../../api"), () => {
 
 		constructor(status: number, body: unknown) {
 			super(`API error ${status}`);
+			this.name = "MockApiError";
 			this.status = status;
 			this.body = body;
 		}

--- a/frontend/src/components/jobs/JobManagementPage.spec.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.spec.tsx
@@ -12,27 +12,37 @@ import AppShell from "../shared/AppShell";
 import JobManagementPage from "./JobManagementPage";
 import StatsPage from "../stats/StatsPage";
 import KanbanBoard from "./KanbanBoard";
-import { api } from "../../api";
+import { ApiError, api } from "../../api";
 import { SnackbarProvider } from "../../useSnackbar";
 import type { Job, User } from "../../types";
-import { makeJob } from "../../testUtils";
+import { makeJob, makeJobSearch } from "../../testUtils";
 
-vi.mock(
-	import("../../api"),
-	() =>
-		({
-			api: {
-				createJob: vi.fn(),
-				deleteJob: vi.fn(),
-				getInterviews: vi.fn(),
-				getJob: vi.fn(),
-				getJobs: vi.fn(),
-				getQuestions: vi.fn(),
-				getStats: vi.fn(),
-				updateJob: vi.fn(),
-			},
-		}) as any,
-);
+vi.mock(import("../../api"), () => {
+	class MockApiError extends Error {
+		status: number;
+		body: unknown;
+
+		constructor(status: number, body: unknown) {
+			super(`API error ${status}`);
+			this.status = status;
+			this.body = body;
+		}
+	}
+	return {
+		ApiError: MockApiError,
+		api: {
+			createJob: vi.fn(),
+			deleteJob: vi.fn(),
+			getActiveSearch: vi.fn(),
+			getInterviews: vi.fn(),
+			getJob: vi.fn(),
+			getJobs: vi.fn(),
+			getQuestions: vi.fn(),
+			getStats: vi.fn(),
+			updateJob: vi.fn(),
+		},
+	} as any;
+});
 
 vi.mock(import("./KanbanBoard"), () => ({ default: vi.fn() }) as any);
 vi.mock(
@@ -86,6 +96,7 @@ vi.mock(
 
 const mockGetJobs = vi.mocked(api.getJobs);
 const mockGetJob = vi.mocked(api.getJob);
+const mockGetActiveSearch = vi.mocked(api.getActiveSearch);
 const MockKanbanBoard = vi.mocked(KanbanBoard);
 
 const MOCK_USER: User = {
@@ -121,6 +132,9 @@ describe("jobManagementPage", () => {
 		vi.clearAllMocks();
 		vi.mocked(api.getInterviews).mockResolvedValue([]);
 		vi.mocked(api.getQuestions).mockResolvedValue([]);
+		mockGetActiveSearch.mockRejectedValue(
+			new ApiError(404, { error: "No active job search" }),
+		);
 		MockKanbanBoard.mockImplementation(({ jobs }) => (
 			<>
 				{jobs.map((j) => (
@@ -797,6 +811,28 @@ describe("jobManagementPage", () => {
 			// State should not carry notes/job_description — board only needs summary fields
 			expect(boardJobs[0]).not.toHaveProperty("notes");
 			expect(boardJobs[0]).not.toHaveProperty("job_description");
+		});
+	});
+
+	describe("active search round", () => {
+		it("does not show a round chip when the user has no active round yet", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			renderPage();
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+			expect(screen.queryByText("Search 1")).not.toBeInTheDocument();
+		});
+
+		it("shows the active round name as a chip", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetActiveSearch.mockResolvedValue(
+				makeJobSearch({ name: "Search 1" }),
+			);
+			renderPage();
+			await waitFor(() => {
+				expect(screen.getByText("Search 1")).toBeInTheDocument();
+			});
 		});
 	});
 });

--- a/frontend/src/components/jobs/JobManagementPage.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.tsx
@@ -30,13 +30,14 @@ import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import TuneIcon from "@mui/icons-material/Tune";
 import { useNavigate, useParams } from "react-router-dom";
-import { api } from "../../api";
+import { ApiError, api } from "../../api";
 import { useNotify } from "../../useSnackbar";
 import type {
 	EndingSubstatus,
 	FitScore,
 	Job,
 	JobFormData,
+	JobSearch,
 	JobStatus,
 	JobTag,
 } from "../../types";
@@ -80,6 +81,7 @@ export default function JobManagementPage() {
 	const [filterTags, setFilterTags] = useState<JobTag[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
+	const [activeSearch, setActiveSearch] = useState<JobSearch | null>(null);
 
 	// "add" dialog is purely local; "edit" dialog is driven by the URL
 	const [addOpen, setAddOpen] = useState(false);
@@ -103,9 +105,21 @@ export default function JobManagementPage() {
 		}
 	}, [notify]);
 
+	const loadActiveSearch = useCallback(async () => {
+		try {
+			const search = await api.getActiveSearch();
+			setActiveSearch(search);
+		} catch (err) {
+			if (!(err instanceof ApiError && err.status === 404)) {
+				notify("Failed to load active search round", "error");
+			}
+		}
+	}, [notify]);
+
 	useEffect(() => {
 		void loadJobs();
-	}, [loadJobs]);
+		void loadActiveSearch();
+	}, [loadJobs, loadActiveSearch]);
 
 	// Sync the edit dialog with the URL param once jobs are loaded
 	useEffect(() => {
@@ -378,6 +392,19 @@ export default function JobManagementPage() {
 				/>
 
 				<Box sx={{ alignItems: "center", display: "flex", gap: 1, ml: "auto" }}>
+					{activeSearch && (
+						<Tooltip title="Current job search">
+							<Chip
+								label={activeSearch.name}
+								size="small"
+								sx={{
+									bgcolor: "rgba(255,255,255,0.15)",
+									color: "white",
+									fontWeight: 500,
+								}}
+							/>
+						</Tooltip>
+					)}
 					<Tooltip
 						title={favoritesOnly ? "Showing favorites only" : "Favorites only"}
 					>

--- a/frontend/src/components/jobs/JobManagementPage.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.tsx
@@ -107,10 +107,9 @@ export default function JobManagementPage() {
 
 	const loadActiveSearch = useCallback(async () => {
 		try {
-			const search = await api.getActiveSearch();
-			setActiveSearch(search);
-		} catch (err) {
-			if (!(err instanceof ApiError && err.status === 404)) {
+			setActiveSearch(await api.getActiveSearch());
+		} catch (error) {
+			if (!(error instanceof ApiError && error.status === 404)) {
 				notify("Failed to load active search round", "error");
 			}
 		}

--- a/frontend/src/components/shared/AppShell.spec.tsx
+++ b/frontend/src/components/shared/AppShell.spec.tsx
@@ -1,8 +1,11 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import AppShell from "./AppShell";
+import { ApiError, api } from "../../api";
+import { SnackbarProvider } from "../../useSnackbar";
 import type { User } from "../../types";
+import { makeJobSearch } from "../../testUtils";
 
 const mockNavigate = vi.fn();
 
@@ -15,6 +18,29 @@ vi.mock(import("react-router-dom"), async (importOriginal) => {
 		useNavigate: () => mockNavigate,
 	};
 });
+
+vi.mock(import("../../api"), () => {
+	class MockApiError extends Error {
+		status: number;
+		body: unknown;
+
+		constructor(status: number, body: unknown) {
+			super(`API error ${status}`);
+			this.status = status;
+			this.body = body;
+		}
+	}
+	return {
+		ApiError: MockApiError,
+		api: {
+			getActiveSearch: vi.fn(),
+			startNewSearch: vi.fn(),
+		},
+	} as any;
+});
+
+const mockGetActiveSearch = vi.mocked(api.getActiveSearch);
+const mockStartNewSearch = vi.mocked(api.startNewSearch);
 
 const MOCK_USER: User = {
 	avatarUrl: null,
@@ -30,14 +56,25 @@ const DEFAULT_PROPS = {
 
 function renderAppShell(props = DEFAULT_PROPS, initialPath = "/jobs") {
 	return render(
-		<MemoryRouter initialEntries={[initialPath]}>
-			<AppShell {...props} />
-		</MemoryRouter>,
+		<SnackbarProvider>
+			<MemoryRouter initialEntries={[initialPath]}>
+				<AppShell {...props} />
+			</MemoryRouter>
+		</SnackbarProvider>,
 	);
 }
 
+function openUserMenu() {
+	fireEvent.click(screen.getByRole("button", { name: "User menu" }));
+}
+
 describe("appShell", () => {
-	beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetActiveSearch.mockRejectedValue(
+			new ApiError(404, { error: "No active job search" }),
+		);
+	});
 
 	it("renders the logo", () => {
 		renderAppShell();
@@ -125,5 +162,115 @@ describe("appShell", () => {
 		expect(
 			screen.queryByRole("menuitem", { name: /Sign Out/ }),
 		).not.toBeInTheDocument();
+	});
+
+	describe("new job search", () => {
+		it("shows a 'New Job Search' item in the user menu", () => {
+			renderAppShell();
+			openUserMenu();
+			expect(
+				screen.getByRole("menuitem", { name: /New Job Search/ }),
+			).toBeInTheDocument();
+		});
+
+		it("opens the name-entry dialog and closes the user menu when clicked", () => {
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+
+			expect(screen.getByText("Start a New Job Search")).toBeInTheDocument();
+			expect(
+				screen.queryByRole("menuitem", { name: /Sign Out/ }),
+			).not.toBeInTheDocument();
+		});
+
+		it("shows a second confirmation dialog after the name is entered, without calling the API yet", () => {
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+			fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+				target: { value: "Search 2" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+			expect(screen.getByText("Start new job search?")).toBeInTheDocument();
+			expect(mockStartNewSearch).not.toHaveBeenCalled();
+		});
+
+		it("calls the API only after the second confirmation, and updates the round", async () => {
+			mockGetActiveSearch.mockResolvedValue(
+				makeJobSearch({ name: "Search 1" }),
+			);
+			mockStartNewSearch.mockResolvedValue(
+				makeJobSearch({ id: 2, name: "Search 2" }),
+			);
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+			fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+				target: { value: "Search 2" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+			fireEvent.click(screen.getByRole("button", { name: "Start Job Search" }));
+
+			await waitFor(() =>
+				expect(mockStartNewSearch).toHaveBeenCalledWith("Search 2", null),
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByText('Started new job search "Search 2"'),
+				).toBeInTheDocument(),
+			);
+			await waitFor(() =>
+				expect(
+					screen.queryByText("Start new job search?"),
+				).not.toBeInTheDocument(),
+			);
+		});
+
+		it("cancelling the confirmation dialog does not call the API", async () => {
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+			fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+				target: { value: "Search 2" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+			fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+			await waitFor(() =>
+				expect(
+					screen.queryByText("Start new job search?"),
+				).not.toBeInTheDocument(),
+			);
+			expect(mockStartNewSearch).not.toHaveBeenCalled();
+		});
+
+		it("returns to the name-entry dialog with blocking jobs when the round can't be closed", async () => {
+			mockStartNewSearch.mockRejectedValue(
+				new ApiError(409, {
+					blockingJobs: [
+						{ id: 5, company: "Acme", role: "Engineer", status: "applied" },
+					],
+				}),
+			);
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+			fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+				target: { value: "Search 2" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+			fireEvent.click(screen.getByRole("button", { name: "Start Job Search" }));
+
+			await waitFor(() => {
+				expect(screen.getByText(/Acme – Engineer/)).toBeInTheDocument();
+			});
+			await waitFor(() =>
+				expect(
+					screen.queryByText("Start new job search?"),
+				).not.toBeInTheDocument(),
+			);
+		});
 	});
 });

--- a/frontend/src/components/shared/AppShell.spec.tsx
+++ b/frontend/src/components/shared/AppShell.spec.tsx
@@ -26,6 +26,7 @@ vi.mock(import("../../api"), () => {
 
 		constructor(status: number, body: unknown) {
 			super(`API error ${status}`);
+			this.name = "MockApiError";
 			this.status = status;
 			this.body = body;
 		}

--- a/frontend/src/components/shared/AppShell.tsx
+++ b/frontend/src/components/shared/AppShell.tsx
@@ -74,8 +74,8 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 		async function loadActiveSearch() {
 			try {
 				setActiveSearch(await api.getActiveSearch());
-			} catch (err) {
-				if (!(err instanceof ApiError && err.status === 404)) {
+			} catch (error) {
+				if (!(error instanceof ApiError && error.status === 404)) {
 					notify("Failed to load active job search", "error");
 				}
 			}
@@ -115,9 +115,9 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 			setPendingSearch(null);
 			setRoundVersion((v) => v + 1);
 			notify(`Started new job search "${search.name}"`);
-		} catch (err) {
-			if (err instanceof ApiError && err.status === 409) {
-				const body = err.body as { blockingJobs?: BlockingJob[] } | undefined;
+		} catch (error) {
+			if (error instanceof ApiError && error.status === 409) {
+				const body = error.body as { blockingJobs?: BlockingJob[] } | undefined;
 				setBlockingJobs(body?.blockingJobs ?? []);
 				setPendingSearch(null);
 				setNewSearchOpen(true);

--- a/frontend/src/components/shared/AppShell.tsx
+++ b/frontend/src/components/shared/AppShell.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
 	AppBar,
 	Avatar,
@@ -12,6 +12,7 @@ import {
 	Toolbar,
 } from "@mui/material";
 import AccountCircleOutlinedIcon from "@mui/icons-material/AccountCircleOutlined";
+import AutorenewIcon from "@mui/icons-material/Autorenew";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
 import CalendarMonthOutlinedIcon from "@mui/icons-material/CalendarMonthOutlined";
@@ -22,8 +23,12 @@ import RadarIcon from "@mui/icons-material/Radar";
 import ViewKanbanOutlinedIcon from "@mui/icons-material/ViewKanbanOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
-import type { User } from "../../types";
+import { ApiError, api } from "../../api";
+import { useNotify } from "../../useSnackbar";
+import type { BlockingJob, JobSearch, User } from "../../types";
 import Footer from "./Footer";
+import NewSearchRoundDialog from "./NewSearchRoundDialog";
+import NewSearchRoundConfirmDialog from "./NewSearchRoundConfirmDialog";
 
 const NAV_ITEMS = [
 	{ icon: <ViewKanbanOutlinedIcon />, label: "Board", path: "/jobs" },
@@ -50,9 +55,78 @@ interface Props {
 export default function AppShell({ currentUser, onLogout }: Props) {
 	const navigate = useNavigate();
 	const location = useLocation();
+	const notify = useNotify();
 	const [userMenuAnchor, setUserMenuAnchor] = useState<null | HTMLElement>(
 		null,
 	);
+
+	const [activeSearch, setActiveSearch] = useState<JobSearch | null>(null);
+	// Bumped whenever a new job search starts, forcing routed pages to remount and refetch.
+	const [roundVersion, setRoundVersion] = useState(0);
+	const [newSearchOpen, setNewSearchOpen] = useState(false);
+	const [pendingSearch, setPendingSearch] = useState<{
+		name: string;
+		notes: string | null;
+	} | null>(null);
+	const [blockingJobs, setBlockingJobs] = useState<BlockingJob[] | null>(null);
+
+	useEffect(() => {
+		async function loadActiveSearch() {
+			try {
+				setActiveSearch(await api.getActiveSearch());
+			} catch (err) {
+				if (!(err instanceof ApiError && err.status === 404)) {
+					notify("Failed to load active job search", "error");
+				}
+			}
+		}
+		void loadActiveSearch();
+	}, [notify]);
+
+	const openNewSearch = useCallback(() => {
+		setUserMenuAnchor(null);
+		setBlockingJobs(null);
+		setNewSearchOpen(true);
+	}, []);
+
+	const closeNewSearch = useCallback(() => {
+		setNewSearchOpen(false);
+		setBlockingJobs(null);
+	}, []);
+
+	const handleNameEntered = useCallback(
+		(name: string, notes: string | null) => {
+			setPendingSearch({ name, notes });
+			setNewSearchOpen(false);
+		},
+		[],
+	);
+
+	const handleConfirmStart = useCallback(async () => {
+		if (!pendingSearch) {
+			return;
+		}
+		try {
+			const search = await api.startNewSearch(
+				pendingSearch.name,
+				pendingSearch.notes,
+			);
+			setActiveSearch(search);
+			setPendingSearch(null);
+			setRoundVersion((v) => v + 1);
+			notify(`Started new job search "${search.name}"`);
+		} catch (err) {
+			if (err instanceof ApiError && err.status === 409) {
+				const body = err.body as { blockingJobs?: BlockingJob[] } | undefined;
+				setBlockingJobs(body?.blockingJobs ?? []);
+				setPendingSearch(null);
+				setNewSearchOpen(true);
+			} else {
+				notify("Failed to start new job search", "error");
+				setPendingSearch(null);
+			}
+		}
+	}, [pendingSearch, notify]);
 
 	return (
 		<Box
@@ -103,6 +177,13 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 								<SettingsOutlinedIcon fontSize="small" />
 							</ListItemIcon>
 							<ListItemText>Settings</ListItemText>
+						</MenuItem>
+						<Divider />
+						<MenuItem onClick={openNewSearch}>
+							<ListItemIcon>
+								<AutorenewIcon fontSize="small" />
+							</ListItemIcon>
+							<ListItemText>New Job Search</ListItemText>
 						</MenuItem>
 						<Divider />
 						<MenuItem
@@ -182,11 +263,26 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 					}}
 				>
 					<Box sx={{ flex: 1 }}>
-						<Outlet />
+						<Outlet key={roundVersion} />
 					</Box>
 					<Footer />
 				</Box>
 			</Box>
+
+			<NewSearchRoundDialog
+				open={newSearchOpen}
+				blockingJobs={blockingJobs}
+				onConfirm={handleNameEntered}
+				onCancel={closeNewSearch}
+			/>
+
+			<NewSearchRoundConfirmDialog
+				open={pendingSearch !== null}
+				currentSearchName={activeSearch?.name ?? null}
+				newSearchName={pendingSearch?.name ?? ""}
+				onConfirm={handleConfirmStart}
+				onCancel={() => setPendingSearch(null)}
+			/>
 		</Box>
 	);
 }

--- a/frontend/src/components/shared/NewSearchRoundConfirmDialog.spec.tsx
+++ b/frontend/src/components/shared/NewSearchRoundConfirmDialog.spec.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import NewSearchRoundConfirmDialog from "./NewSearchRoundConfirmDialog";
+
+const DEFAULT_PROPS = {
+	currentSearchName: "Search 1",
+	newSearchName: "Search 2",
+	onCancel: vi.fn(),
+	onConfirm: vi.fn(),
+	open: true,
+};
+
+describe("newSearchRoundConfirmDialog", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("renders nothing meaningful when open=false", () => {
+		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} open={false} />);
+		expect(screen.queryByText("Start new job search?")).not.toBeInTheDocument();
+	});
+
+	it("mentions both the current and new job search names", () => {
+		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} />);
+		expect(screen.getByText(/Search 1/)).toBeInTheDocument();
+		expect(screen.getByText(/Search 2/)).toBeInTheDocument();
+	});
+
+	it("omits the current round clause when there is no active round yet", () => {
+		render(
+			<NewSearchRoundConfirmDialog
+				{...DEFAULT_PROPS}
+				currentSearchName={null}
+			/>,
+		);
+		expect(screen.queryByText(/This closes/)).not.toBeInTheDocument();
+		expect(screen.getByText(/This starts/)).toBeInTheDocument();
+	});
+
+	it("calls onConfirm when 'Start Job Search' is clicked", () => {
+		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Start Job Search" }));
+		expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalled();
+	});
+
+	it("calls onCancel when Cancel is clicked", () => {
+		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/components/shared/NewSearchRoundConfirmDialog.spec.tsx
+++ b/frontend/src/components/shared/NewSearchRoundConfirmDialog.spec.tsx
@@ -38,12 +38,12 @@ describe("newSearchRoundConfirmDialog", () => {
 	it("calls onConfirm when 'Start Job Search' is clicked", () => {
 		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} />);
 		fireEvent.click(screen.getByRole("button", { name: "Start Job Search" }));
-		expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalled();
+		expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith(expect.anything());
 	});
 
 	it("calls onCancel when Cancel is clicked", () => {
 		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} />);
 		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-		expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
+		expect(DEFAULT_PROPS.onCancel).toHaveBeenCalledWith(expect.anything());
 	});
 });

--- a/frontend/src/components/shared/NewSearchRoundConfirmDialog.tsx
+++ b/frontend/src/components/shared/NewSearchRoundConfirmDialog.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Typography,
+} from "@mui/material";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+
+interface Props {
+	open: boolean;
+	currentSearchName: string | null;
+	newSearchName: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export default function NewSearchRoundConfirmDialog({
+	open,
+	currentSearchName,
+	newSearchName,
+	onConfirm,
+	onCancel,
+}: Props) {
+	return (
+		<Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
+			<DialogTitle sx={{ alignItems: "center", display: "flex", gap: 1 }}>
+				<WarningAmberIcon color="warning" />
+				Start new job search?
+			</DialogTitle>
+			<DialogContent>
+				<Typography>
+					{currentSearchName ? (
+						<>
+							This closes <strong>{currentSearchName}</strong> and starts{" "}
+							<strong>{newSearchName}</strong> as a fresh board.
+						</>
+					) : (
+						<>
+							This starts <strong>{newSearchName}</strong> as a fresh board.
+						</>
+					)}
+				</Typography>
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onCancel}>Cancel</Button>
+				<Button variant="contained" onClick={onConfirm}>
+					Start Job Search
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}

--- a/frontend/src/components/shared/NewSearchRoundDialog.spec.tsx
+++ b/frontend/src/components/shared/NewSearchRoundDialog.spec.tsx
@@ -68,7 +68,7 @@ describe("newSearchRoundDialog", () => {
 	it("calls onCancel when Cancel is clicked", () => {
 		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
 		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-		expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
+		expect(DEFAULT_PROPS.onCancel).toHaveBeenCalledWith(expect.anything());
 	});
 
 	describe("when blocked by unresolved jobs", () => {
@@ -105,7 +105,7 @@ describe("newSearchRoundDialog", () => {
 				/>,
 			);
 			fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-			expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
+			expect(DEFAULT_PROPS.onCancel).toHaveBeenCalledWith(expect.anything());
 		});
 	});
 

--- a/frontend/src/components/shared/NewSearchRoundDialog.spec.tsx
+++ b/frontend/src/components/shared/NewSearchRoundDialog.spec.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import NewSearchRoundDialog from "./NewSearchRoundDialog";
+import type { BlockingJob } from "../../types";
+
+const BLOCKING_JOBS: BlockingJob[] = [
+	{ id: 1, company: "Acme Corp", role: "Engineer", status: "applied" },
+];
+
+const DEFAULT_PROPS = {
+	blockingJobs: null,
+	onCancel: vi.fn(),
+	onConfirm: vi.fn(),
+	open: true,
+};
+
+describe("newSearchRoundDialog", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("renders nothing meaningful when open=false", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} open={false} />);
+		expect(
+			screen.queryByText("Start a New Job Search"),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows validation error when confirmed without a name", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(screen.getByText("Required")).toBeInTheDocument();
+		expect(DEFAULT_PROPS.onConfirm).not.toHaveBeenCalled();
+	});
+
+	it("calls onConfirm with trimmed name and null notes when notes is blank", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+			target: { value: "  Search 2  " },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith("Search 2", null);
+	});
+
+	it("calls onConfirm with notes when provided", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+			target: { value: "Search 2" },
+		});
+		fireEvent.change(screen.getByLabelText("Notes"), {
+			target: { value: "Fresh start" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith(
+			"Search 2",
+			"Fresh start",
+		);
+	});
+
+	it("clears the validation error after typing a name", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(screen.getByText("Required")).toBeInTheDocument();
+		fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+			target: { value: "Search 2" },
+		});
+		expect(screen.queryByText("Required")).not.toBeInTheDocument();
+	});
+
+	it("calls onCancel when Cancel is clicked", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
+	});
+
+	describe("when blocked by unresolved jobs", () => {
+		it("shows the blocking jobs instead of the form", () => {
+			render(
+				<NewSearchRoundDialog
+					{...DEFAULT_PROPS}
+					blockingJobs={BLOCKING_JOBS}
+				/>,
+			);
+			expect(screen.getByText(/Acme Corp – Engineer/)).toBeInTheDocument();
+			expect(
+				screen.queryByLabelText(/Job Search Name/i),
+			).not.toBeInTheDocument();
+		});
+
+		it("hides the Continue button", () => {
+			render(
+				<NewSearchRoundDialog
+					{...DEFAULT_PROPS}
+					blockingJobs={BLOCKING_JOBS}
+				/>,
+			);
+			expect(
+				screen.queryByRole("button", { name: "Continue" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("still allows Cancel", () => {
+			render(
+				<NewSearchRoundDialog
+					{...DEFAULT_PROPS}
+					blockingJobs={BLOCKING_JOBS}
+				/>,
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+			expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
+		});
+	});
+
+	it("shows the form again when blockingJobs is an empty array", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} blockingJobs={[]} />);
+		expect(screen.getByLabelText(/Job Search Name/i)).toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/shared/NewSearchRoundDialog.tsx
+++ b/frontend/src/components/shared/NewSearchRoundDialog.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from "react";
+import {
+	Alert,
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	List,
+	ListItem,
+	ListItemText,
+	TextField,
+	Typography,
+} from "@mui/material";
+import { STATUS_LABELS } from "../../constants";
+import type { BlockingJob, JobStatus } from "../../types";
+
+interface Props {
+	open: boolean;
+	/** Non-null once a start attempt was blocked by unresolved jobs in the active round. */
+	blockingJobs: BlockingJob[] | null;
+	onConfirm: (name: string, notes: string | null) => void;
+	onCancel: () => void;
+}
+
+export default function NewSearchRoundDialog({
+	open,
+	blockingJobs,
+	onConfirm,
+	onCancel,
+}: Props) {
+	const [name, setName] = useState("");
+	const [notes, setNotes] = useState("");
+	const [error, setError] = useState("");
+
+	useEffect(() => {
+		if (open) {
+			setName("");
+			setNotes("");
+			setError("");
+		}
+	}, [open]);
+
+	function handleConfirm() {
+		if (!name.trim()) {
+			setError("Required");
+			return;
+		}
+		onConfirm(name.trim(), notes || null);
+	}
+
+	const blocked = blockingJobs !== null && blockingJobs.length > 0;
+
+	return (
+		<Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
+			<DialogTitle>Start a New Job Search</DialogTitle>
+			<DialogContent>
+				{blocked ? (
+					<>
+						<Alert severity="warning" sx={{ mb: 2 }}>
+							Resolve these jobs before starting a new job search:
+						</Alert>
+						<List dense disablePadding>
+							{blockingJobs.map((job) => (
+								<ListItem key={job.id} disableGutters>
+									<ListItemText
+										primary={`${job.company} – ${job.role}`}
+										secondary={
+											STATUS_LABELS[job.status as JobStatus] ?? job.status
+										}
+									/>
+								</ListItem>
+							))}
+						</List>
+					</>
+				) : (
+					<>
+						<Typography variant="body2" sx={{ mb: 2 }}>
+							Closes your current job search and starts a fresh board.
+						</Typography>
+						<TextField
+							label="Job Search Name *"
+							value={name}
+							onChange={(e) => {
+								setName(e.target.value);
+								if (error) {
+									setError("");
+								}
+							}}
+							error={Boolean(error)}
+							helperText={error}
+							fullWidth
+							size="small"
+							sx={{ mb: 2 }}
+						/>
+						<TextField
+							label="Notes"
+							value={notes}
+							onChange={(e) => setNotes(e.target.value)}
+							fullWidth
+							size="small"
+							multiline
+							rows={3}
+						/>
+					</>
+				)}
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onCancel}>Cancel</Button>
+				{!blocked && (
+					<Button variant="contained" onClick={handleConfirm}>
+						Continue
+					</Button>
+				)}
+			</DialogActions>
+		</Dialog>
+	);
+}

--- a/frontend/src/testUtils.ts
+++ b/frontend/src/testUtils.ts
@@ -1,4 +1,4 @@
-import type { Job } from "./types";
+import type { Job, JobSearch } from "./types";
 
 export const BASE_JOB: Job = {
 	id: 1,
@@ -26,4 +26,17 @@ export const BASE_JOB: Job = {
 
 export function makeJob(overrides: Partial<Job> = {}): Job {
 	return { ...BASE_JOB, ...overrides };
+}
+
+export const BASE_JOB_SEARCH: JobSearch = {
+	id: 1,
+	user_id: 1,
+	name: "Search 1",
+	started_at: "2024-01-01T00:00:00.000Z",
+	closed_at: null,
+	notes: null,
+};
+
+export function makeJobSearch(overrides: Partial<JobSearch> = {}): JobSearch {
+	return { ...BASE_JOB_SEARCH, ...overrides };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -52,6 +52,22 @@ export interface LinkJob {
 	link: string;
 }
 
+export interface JobSearch {
+	id: number;
+	user_id: number;
+	name: string;
+	started_at: string;
+	closed_at: string | null;
+	notes: string | null;
+}
+
+export interface BlockingJob {
+	id: number;
+	company: string;
+	role: string;
+	status: string;
+}
+
 export interface Job {
 	id: number;
 	date_applied: string | null;


### PR DESCRIPTION
## Summary
- `job_searches` CRUD routes at `/api/job-searches` (list, get active, start a new round, rename) — db/routes layer for managing job search rounds (#job-searches).
- `GET`/`POST /api/jobs` now scope to the user's active round instead of returning/creating across all rounds ever (previously merged as PR #140, now folding into this branch's PR to `main`).

The `job_searches` table + migration itself already merged via #139; this PR is the remainder of that branch's work that never had its own PR into `main`.

## Test plan
- [x] `npm run test` (backend) — all passing
- [x] `npm run tsc`