### PR TITLE
feat(job-searches): add active-round indicator and New Job Search flow

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,6 +7,7 @@ import type {
 	InterviewQuestionFormData,
 	Job,
 	JobFormData,
+	JobSearch,
 	LinkJob,
 	Offer,
 	OfferComparisonEntry,
@@ -27,6 +28,18 @@ export function setUnauthorizedHandler(handler: () => void): void {
 	unauthorizedHandler = handler;
 }
 
+/** Thrown on non-2xx responses; carries the parsed JSON body (if any) for callers that need it. */
+export class ApiError extends Error {
+	status: number;
+	body: unknown;
+
+	constructor(status: number, body: unknown) {
+		super(`API error ${status}`);
+		this.status = status;
+		this.body = body;
+	}
+}
+
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 	const res = await fetch(`${BASE}${path}`, {
 		credentials: "include",
@@ -37,7 +50,8 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 		unauthorizedHandler?.();
 	}
 	if (!res.ok) {
-		throw new Error(`API error ${res.status}`);
+		const body = await res.json().catch(() => undefined);
+		throw new ApiError(res.status, body);
 	}
 	if (res.status === 204) {
 		return undefined as T;
@@ -69,6 +83,14 @@ export const api = {
 		request<Job>(`/jobs/${id}`, { body: JSON.stringify(data), method: "PUT" }),
 	deleteJob: (id: number) =>
 		request<{ success: boolean }>(`/jobs/${id}`, { method: "DELETE" }),
+
+	// Job searches (rounds)
+	getActiveSearch: () => request<JobSearch>("/job-searches/active"),
+	startNewSearch: (name: string, notes: string | null) =>
+		request<JobSearch>("/job-searches", {
+			body: JSON.stringify({ name, notes }),
+			method: "POST",
+		}),
 
 	// Radar
 	getRadar: (includeHidden = false) =>

--- a/frontend/src/components/jobs/JobManagementPage.spec.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.spec.tsx
@@ -12,27 +12,37 @@ import AppShell from "../shared/AppShell";
 import JobManagementPage from "./JobManagementPage";
 import StatsPage from "../stats/StatsPage";
 import KanbanBoard from "./KanbanBoard";
-import { api } from "../../api";
+import { ApiError, api } from "../../api";
 import { SnackbarProvider } from "../../useSnackbar";
 import type { Job, User } from "../../types";
-import { makeJob } from "../../testUtils";
+import { makeJob, makeJobSearch } from "../../testUtils";
 
-vi.mock(
-	import("../../api"),
-	() =>
-		({
-			api: {
-				createJob: vi.fn(),
-				deleteJob: vi.fn(),
-				getInterviews: vi.fn(),
-				getJob: vi.fn(),
-				getJobs: vi.fn(),
-				getQuestions: vi.fn(),
-				getStats: vi.fn(),
-				updateJob: vi.fn(),
-			},
-		}) as any,
-);
+vi.mock(import("../../api"), () => {
+	class MockApiError extends Error {
+		status: number;
+		body: unknown;
+
+		constructor(status: number, body: unknown) {
+			super(`API error ${status}`);
+			this.status = status;
+			this.body = body;
+		}
+	}
+	return {
+		ApiError: MockApiError,
+		api: {
+			createJob: vi.fn(),
+			deleteJob: vi.fn(),
+			getActiveSearch: vi.fn(),
+			getInterviews: vi.fn(),
+			getJob: vi.fn(),
+			getJobs: vi.fn(),
+			getQuestions: vi.fn(),
+			getStats: vi.fn(),
+			updateJob: vi.fn(),
+		},
+	} as any;
+});
 
 vi.mock(import("./KanbanBoard"), () => ({ default: vi.fn() }) as any);
 vi.mock(
@@ -86,6 +96,7 @@ vi.mock(
 
 const mockGetJobs = vi.mocked(api.getJobs);
 const mockGetJob = vi.mocked(api.getJob);
+const mockGetActiveSearch = vi.mocked(api.getActiveSearch);
 const MockKanbanBoard = vi.mocked(KanbanBoard);
 
 const MOCK_USER: User = {
@@ -121,6 +132,9 @@ describe("jobManagementPage", () => {
 		vi.clearAllMocks();
 		vi.mocked(api.getInterviews).mockResolvedValue([]);
 		vi.mocked(api.getQuestions).mockResolvedValue([]);
+		mockGetActiveSearch.mockRejectedValue(
+			new ApiError(404, { error: "No active job search" }),
+		);
 		MockKanbanBoard.mockImplementation(({ jobs }) => (
 			<>
 				{jobs.map((j) => (
@@ -797,6 +811,28 @@ describe("jobManagementPage", () => {
 			// State should not carry notes/job_description — board only needs summary fields
 			expect(boardJobs[0]).not.toHaveProperty("notes");
 			expect(boardJobs[0]).not.toHaveProperty("job_description");
+		});
+	});
+
+	describe("active search round", () => {
+		it("does not show a round chip when the user has no active round yet", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			renderPage();
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+			expect(screen.queryByText("Search 1")).not.toBeInTheDocument();
+		});
+
+		it("shows the active round name as a chip", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetActiveSearch.mockResolvedValue(
+				makeJobSearch({ name: "Search 1" }),
+			);
+			renderPage();
+			await waitFor(() => {
+				expect(screen.getByText("Search 1")).toBeInTheDocument();
+			});
 		});
 	});
 });

--- a/frontend/src/components/jobs/JobManagementPage.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.tsx
@@ -30,13 +30,14 @@ import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
 import TuneIcon from "@mui/icons-material/Tune";
 import { useNavigate, useParams } from "react-router-dom";
-import { api } from "../../api";
+import { ApiError, api } from "../../api";
 import { useNotify } from "../../useSnackbar";
 import type {
 	EndingSubstatus,
 	FitScore,
 	Job,
 	JobFormData,
+	JobSearch,
 	JobStatus,
 	JobTag,
 } from "../../types";
@@ -80,6 +81,7 @@ export default function JobManagementPage() {
 	const [filterTags, setFilterTags] = useState<JobTag[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
+	const [activeSearch, setActiveSearch] = useState<JobSearch | null>(null);
 
 	// "add" dialog is purely local; "edit" dialog is driven by the URL
 	const [addOpen, setAddOpen] = useState(false);
@@ -103,9 +105,21 @@ export default function JobManagementPage() {
 		}
 	}, [notify]);
 
+	const loadActiveSearch = useCallback(async () => {
+		try {
+			const search = await api.getActiveSearch();
+			setActiveSearch(search);
+		} catch (err) {
+			if (!(err instanceof ApiError && err.status === 404)) {
+				notify("Failed to load active search round", "error");
+			}
+		}
+	}, [notify]);
+
 	useEffect(() => {
 		void loadJobs();
-	}, [loadJobs]);
+		void loadActiveSearch();
+	}, [loadJobs, loadActiveSearch]);
 
 	// Sync the edit dialog with the URL param once jobs are loaded
 	useEffect(() => {
@@ -378,6 +392,19 @@ export default function JobManagementPage() {
 				/>
 
 				<Box sx={{ alignItems: "center", display: "flex", gap: 1, ml: "auto" }}>
+					{activeSearch && (
+						<Tooltip title="Current job search">
+							<Chip
+								label={activeSearch.name}
+								size="small"
+								sx={{
+									bgcolor: "rgba(255,255,255,0.15)",
+									color: "white",
+									fontWeight: 500,
+								}}
+							/>
+						</Tooltip>
+					)}
 					<Tooltip
 						title={favoritesOnly ? "Showing favorites only" : "Favorites only"}
 					>

--- a/frontend/src/components/shared/AppShell.spec.tsx
+++ b/frontend/src/components/shared/AppShell.spec.tsx
@@ -1,8 +1,11 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import AppShell from "./AppShell";
+import { ApiError, api } from "../../api";
+import { SnackbarProvider } from "../../useSnackbar";
 import type { User } from "../../types";
+import { makeJobSearch } from "../../testUtils";
 
 const mockNavigate = vi.fn();
 
@@ -15,6 +18,29 @@ vi.mock(import("react-router-dom"), async (importOriginal) => {
 		useNavigate: () => mockNavigate,
 	};
 });
+
+vi.mock(import("../../api"), () => {
+	class MockApiError extends Error {
+		status: number;
+		body: unknown;
+
+		constructor(status: number, body: unknown) {
+			super(`API error ${status}`);
+			this.status = status;
+			this.body = body;
+		}
+	}
+	return {
+		ApiError: MockApiError,
+		api: {
+			getActiveSearch: vi.fn(),
+			startNewSearch: vi.fn(),
+		},
+	} as any;
+});
+
+const mockGetActiveSearch = vi.mocked(api.getActiveSearch);
+const mockStartNewSearch = vi.mocked(api.startNewSearch);
 
 const MOCK_USER: User = {
 	avatarUrl: null,
@@ -30,14 +56,25 @@ const DEFAULT_PROPS = {
 
 function renderAppShell(props = DEFAULT_PROPS, initialPath = "/jobs") {
 	return render(
-		<MemoryRouter initialEntries={[initialPath]}>
-			<AppShell {...props} />
-		</MemoryRouter>,
+		<SnackbarProvider>
+			<MemoryRouter initialEntries={[initialPath]}>
+				<AppShell {...props} />
+			</MemoryRouter>
+		</SnackbarProvider>,
 	);
 }
 
+function openUserMenu() {
+	fireEvent.click(screen.getByRole("button", { name: "User menu" }));
+}
+
 describe("appShell", () => {
-	beforeEach(() => vi.clearAllMocks());
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetActiveSearch.mockRejectedValue(
+			new ApiError(404, { error: "No active job search" }),
+		);
+	});
 
 	it("renders the logo", () => {
 		renderAppShell();
@@ -125,5 +162,115 @@ describe("appShell", () => {
 		expect(
 			screen.queryByRole("menuitem", { name: /Sign Out/ }),
 		).not.toBeInTheDocument();
+	});
+
+	describe("new job search", () => {
+		it("shows a 'New Job Search' item in the user menu", () => {
+			renderAppShell();
+			openUserMenu();
+			expect(
+				screen.getByRole("menuitem", { name: /New Job Search/ }),
+			).toBeInTheDocument();
+		});
+
+		it("opens the name-entry dialog and closes the user menu when clicked", () => {
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+
+			expect(screen.getByText("Start a New Job Search")).toBeInTheDocument();
+			expect(
+				screen.queryByRole("menuitem", { name: /Sign Out/ }),
+			).not.toBeInTheDocument();
+		});
+
+		it("shows a second confirmation dialog after the name is entered, without calling the API yet", () => {
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+			fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+				target: { value: "Search 2" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+			expect(screen.getByText("Start new job search?")).toBeInTheDocument();
+			expect(mockStartNewSearch).not.toHaveBeenCalled();
+		});
+
+		it("calls the API only after the second confirmation, and updates the round", async () => {
+			mockGetActiveSearch.mockResolvedValue(
+				makeJobSearch({ name: "Search 1" }),
+			);
+			mockStartNewSearch.mockResolvedValue(
+				makeJobSearch({ id: 2, name: "Search 2" }),
+			);
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+			fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+				target: { value: "Search 2" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+			fireEvent.click(screen.getByRole("button", { name: "Start Job Search" }));
+
+			await waitFor(() =>
+				expect(mockStartNewSearch).toHaveBeenCalledWith("Search 2", null),
+			);
+			await waitFor(() =>
+				expect(
+					screen.getByText('Started new job search "Search 2"'),
+				).toBeInTheDocument(),
+			);
+			await waitFor(() =>
+				expect(
+					screen.queryByText("Start new job search?"),
+				).not.toBeInTheDocument(),
+			);
+		});
+
+		it("cancelling the confirmation dialog does not call the API", async () => {
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+			fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+				target: { value: "Search 2" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+			fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+			await waitFor(() =>
+				expect(
+					screen.queryByText("Start new job search?"),
+				).not.toBeInTheDocument(),
+			);
+			expect(mockStartNewSearch).not.toHaveBeenCalled();
+		});
+
+		it("returns to the name-entry dialog with blocking jobs when the round can't be closed", async () => {
+			mockStartNewSearch.mockRejectedValue(
+				new ApiError(409, {
+					blockingJobs: [
+						{ id: 5, company: "Acme", role: "Engineer", status: "applied" },
+					],
+				}),
+			);
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(screen.getByRole("menuitem", { name: /New Job Search/ }));
+			fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+				target: { value: "Search 2" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+			fireEvent.click(screen.getByRole("button", { name: "Start Job Search" }));
+
+			await waitFor(() => {
+				expect(screen.getByText(/Acme – Engineer/)).toBeInTheDocument();
+			});
+			await waitFor(() =>
+				expect(
+					screen.queryByText("Start new job search?"),
+				).not.toBeInTheDocument(),
+			);
+		});
 	});
 });

--- a/frontend/src/components/shared/AppShell.tsx
+++ b/frontend/src/components/shared/AppShell.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
 	AppBar,
 	Avatar,
@@ -12,6 +12,7 @@ import {
 	Toolbar,
 } from "@mui/material";
 import AccountCircleOutlinedIcon from "@mui/icons-material/AccountCircleOutlined";
+import AutorenewIcon from "@mui/icons-material/Autorenew";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
 import CalendarMonthOutlinedIcon from "@mui/icons-material/CalendarMonthOutlined";
@@ -22,8 +23,12 @@ import RadarIcon from "@mui/icons-material/Radar";
 import ViewKanbanOutlinedIcon from "@mui/icons-material/ViewKanbanOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
-import type { User } from "../../types";
+import { ApiError, api } from "../../api";
+import { useNotify } from "../../useSnackbar";
+import type { BlockingJob, JobSearch, User } from "../../types";
 import Footer from "./Footer";
+import NewSearchRoundDialog from "./NewSearchRoundDialog";
+import NewSearchRoundConfirmDialog from "./NewSearchRoundConfirmDialog";
 
 const NAV_ITEMS = [
 	{ icon: <ViewKanbanOutlinedIcon />, label: "Board", path: "/jobs" },
@@ -50,9 +55,78 @@ interface Props {
 export default function AppShell({ currentUser, onLogout }: Props) {
 	const navigate = useNavigate();
 	const location = useLocation();
+	const notify = useNotify();
 	const [userMenuAnchor, setUserMenuAnchor] = useState<null | HTMLElement>(
 		null,
 	);
+
+	const [activeSearch, setActiveSearch] = useState<JobSearch | null>(null);
+	// Bumped whenever a new job search starts, forcing routed pages to remount and refetch.
+	const [roundVersion, setRoundVersion] = useState(0);
+	const [newSearchOpen, setNewSearchOpen] = useState(false);
+	const [pendingSearch, setPendingSearch] = useState<{
+		name: string;
+		notes: string | null;
+	} | null>(null);
+	const [blockingJobs, setBlockingJobs] = useState<BlockingJob[] | null>(null);
+
+	useEffect(() => {
+		async function loadActiveSearch() {
+			try {
+				setActiveSearch(await api.getActiveSearch());
+			} catch (err) {
+				if (!(err instanceof ApiError && err.status === 404)) {
+					notify("Failed to load active job search", "error");
+				}
+			}
+		}
+		void loadActiveSearch();
+	}, [notify]);
+
+	const openNewSearch = useCallback(() => {
+		setUserMenuAnchor(null);
+		setBlockingJobs(null);
+		setNewSearchOpen(true);
+	}, []);
+
+	const closeNewSearch = useCallback(() => {
+		setNewSearchOpen(false);
+		setBlockingJobs(null);
+	}, []);
+
+	const handleNameEntered = useCallback(
+		(name: string, notes: string | null) => {
+			setPendingSearch({ name, notes });
+			setNewSearchOpen(false);
+		},
+		[],
+	);
+
+	const handleConfirmStart = useCallback(async () => {
+		if (!pendingSearch) {
+			return;
+		}
+		try {
+			const search = await api.startNewSearch(
+				pendingSearch.name,
+				pendingSearch.notes,
+			);
+			setActiveSearch(search);
+			setPendingSearch(null);
+			setRoundVersion((v) => v + 1);
+			notify(`Started new job search "${search.name}"`);
+		} catch (err) {
+			if (err instanceof ApiError && err.status === 409) {
+				const body = err.body as { blockingJobs?: BlockingJob[] } | undefined;
+				setBlockingJobs(body?.blockingJobs ?? []);
+				setPendingSearch(null);
+				setNewSearchOpen(true);
+			} else {
+				notify("Failed to start new job search", "error");
+				setPendingSearch(null);
+			}
+		}
+	}, [pendingSearch, notify]);
 
 	return (
 		<Box
@@ -103,6 +177,13 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 								<SettingsOutlinedIcon fontSize="small" />
 							</ListItemIcon>
 							<ListItemText>Settings</ListItemText>
+						</MenuItem>
+						<Divider />
+						<MenuItem onClick={openNewSearch}>
+							<ListItemIcon>
+								<AutorenewIcon fontSize="small" />
+							</ListItemIcon>
+							<ListItemText>New Job Search</ListItemText>
 						</MenuItem>
 						<Divider />
 						<MenuItem
@@ -182,11 +263,26 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 					}}
 				>
 					<Box sx={{ flex: 1 }}>
-						<Outlet />
+						<Outlet key={roundVersion} />
 					</Box>
 					<Footer />
 				</Box>
 			</Box>
+
+			<NewSearchRoundDialog
+				open={newSearchOpen}
+				blockingJobs={blockingJobs}
+				onConfirm={handleNameEntered}
+				onCancel={closeNewSearch}
+			/>
+
+			<NewSearchRoundConfirmDialog
+				open={pendingSearch !== null}
+				currentSearchName={activeSearch?.name ?? null}
+				newSearchName={pendingSearch?.name ?? ""}
+				onConfirm={handleConfirmStart}
+				onCancel={() => setPendingSearch(null)}
+			/>
 		</Box>
 	);
 }

--- a/frontend/src/components/shared/NewSearchRoundConfirmDialog.spec.tsx
+++ b/frontend/src/components/shared/NewSearchRoundConfirmDialog.spec.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import NewSearchRoundConfirmDialog from "./NewSearchRoundConfirmDialog";
+
+const DEFAULT_PROPS = {
+	currentSearchName: "Search 1",
+	newSearchName: "Search 2",
+	onCancel: vi.fn(),
+	onConfirm: vi.fn(),
+	open: true,
+};
+
+describe("newSearchRoundConfirmDialog", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("renders nothing meaningful when open=false", () => {
+		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} open={false} />);
+		expect(screen.queryByText("Start new job search?")).not.toBeInTheDocument();
+	});
+
+	it("mentions both the current and new job search names", () => {
+		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} />);
+		expect(screen.getByText(/Search 1/)).toBeInTheDocument();
+		expect(screen.getByText(/Search 2/)).toBeInTheDocument();
+	});
+
+	it("omits the current round clause when there is no active round yet", () => {
+		render(
+			<NewSearchRoundConfirmDialog
+				{...DEFAULT_PROPS}
+				currentSearchName={null}
+			/>,
+		);
+		expect(screen.queryByText(/This closes/)).not.toBeInTheDocument();
+		expect(screen.getByText(/This starts/)).toBeInTheDocument();
+	});
+
+	it("calls onConfirm when 'Start Job Search' is clicked", () => {
+		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Start Job Search" }));
+		expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalled();
+	});
+
+	it("calls onCancel when Cancel is clicked", () => {
+		render(<NewSearchRoundConfirmDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/components/shared/NewSearchRoundConfirmDialog.tsx
+++ b/frontend/src/components/shared/NewSearchRoundConfirmDialog.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Typography,
+} from "@mui/material";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+
+interface Props {
+	open: boolean;
+	currentSearchName: string | null;
+	newSearchName: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export default function NewSearchRoundConfirmDialog({
+	open,
+	currentSearchName,
+	newSearchName,
+	onConfirm,
+	onCancel,
+}: Props) {
+	return (
+		<Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
+			<DialogTitle sx={{ alignItems: "center", display: "flex", gap: 1 }}>
+				<WarningAmberIcon color="warning" />
+				Start new job search?
+			</DialogTitle>
+			<DialogContent>
+				<Typography>
+					{currentSearchName ? (
+						<>
+							This closes <strong>{currentSearchName}</strong> and starts{" "}
+							<strong>{newSearchName}</strong> as a fresh board.
+						</>
+					) : (
+						<>
+							This starts <strong>{newSearchName}</strong> as a fresh board.
+						</>
+					)}
+				</Typography>
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onCancel}>Cancel</Button>
+				<Button variant="contained" onClick={onConfirm}>
+					Start Job Search
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}

--- a/frontend/src/components/shared/NewSearchRoundDialog.spec.tsx
+++ b/frontend/src/components/shared/NewSearchRoundDialog.spec.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import NewSearchRoundDialog from "./NewSearchRoundDialog";
+import type { BlockingJob } from "../../types";
+
+const BLOCKING_JOBS: BlockingJob[] = [
+	{ id: 1, company: "Acme Corp", role: "Engineer", status: "applied" },
+];
+
+const DEFAULT_PROPS = {
+	blockingJobs: null,
+	onCancel: vi.fn(),
+	onConfirm: vi.fn(),
+	open: true,
+};
+
+describe("newSearchRoundDialog", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("renders nothing meaningful when open=false", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} open={false} />);
+		expect(
+			screen.queryByText("Start a New Job Search"),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows validation error when confirmed without a name", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(screen.getByText("Required")).toBeInTheDocument();
+		expect(DEFAULT_PROPS.onConfirm).not.toHaveBeenCalled();
+	});
+
+	it("calls onConfirm with trimmed name and null notes when notes is blank", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+			target: { value: "  Search 2  " },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith("Search 2", null);
+	});
+
+	it("calls onConfirm with notes when provided", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+			target: { value: "Search 2" },
+		});
+		fireEvent.change(screen.getByLabelText("Notes"), {
+			target: { value: "Fresh start" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith(
+			"Search 2",
+			"Fresh start",
+		);
+	});
+
+	it("clears the validation error after typing a name", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(screen.getByText("Required")).toBeInTheDocument();
+		fireEvent.change(screen.getByLabelText(/Job Search Name/i), {
+			target: { value: "Search 2" },
+		});
+		expect(screen.queryByText("Required")).not.toBeInTheDocument();
+	});
+
+	it("calls onCancel when Cancel is clicked", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} />);
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
+	});
+
+	describe("when blocked by unresolved jobs", () => {
+		it("shows the blocking jobs instead of the form", () => {
+			render(
+				<NewSearchRoundDialog
+					{...DEFAULT_PROPS}
+					blockingJobs={BLOCKING_JOBS}
+				/>,
+			);
+			expect(screen.getByText(/Acme Corp – Engineer/)).toBeInTheDocument();
+			expect(
+				screen.queryByLabelText(/Job Search Name/i),
+			).not.toBeInTheDocument();
+		});
+
+		it("hides the Continue button", () => {
+			render(
+				<NewSearchRoundDialog
+					{...DEFAULT_PROPS}
+					blockingJobs={BLOCKING_JOBS}
+				/>,
+			);
+			expect(
+				screen.queryByRole("button", { name: "Continue" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("still allows Cancel", () => {
+			render(
+				<NewSearchRoundDialog
+					{...DEFAULT_PROPS}
+					blockingJobs={BLOCKING_JOBS}
+				/>,
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+			expect(DEFAULT_PROPS.onCancel).toHaveBeenCalled();
+		});
+	});
+
+	it("shows the form again when blockingJobs is an empty array", () => {
+		render(<NewSearchRoundDialog {...DEFAULT_PROPS} blockingJobs={[]} />);
+		expect(screen.getByLabelText(/Job Search Name/i)).toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/shared/NewSearchRoundDialog.tsx
+++ b/frontend/src/components/shared/NewSearchRoundDialog.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from "react";
+import {
+	Alert,
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	List,
+	ListItem,
+	ListItemText,
+	TextField,
+	Typography,
+} from "@mui/material";
+import { STATUS_LABELS } from "../../constants";
+import type { BlockingJob, JobStatus } from "../../types";
+
+interface Props {
+	open: boolean;
+	/** Non-null once a start attempt was blocked by unresolved jobs in the active round. */
+	blockingJobs: BlockingJob[] | null;
+	onConfirm: (name: string, notes: string | null) => void;
+	onCancel: () => void;
+}
+
+export default function NewSearchRoundDialog({
+	open,
+	blockingJobs,
+	onConfirm,
+	onCancel,
+}: Props) {
+	const [name, setName] = useState("");
+	const [notes, setNotes] = useState("");
+	const [error, setError] = useState("");
+
+	useEffect(() => {
+		if (open) {
+			setName("");
+			setNotes("");
+			setError("");
+		}
+	}, [open]);
+
+	function handleConfirm() {
+		if (!name.trim()) {
+			setError("Required");
+			return;
+		}
+		onConfirm(name.trim(), notes || null);
+	}
+
+	const blocked = blockingJobs !== null && blockingJobs.length > 0;
+
+	return (
+		<Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
+			<DialogTitle>Start a New Job Search</DialogTitle>
+			<DialogContent>
+				{blocked ? (
+					<>
+						<Alert severity="warning" sx={{ mb: 2 }}>
+							Resolve these jobs before starting a new job search:
+						</Alert>
+						<List dense disablePadding>
+							{blockingJobs.map((job) => (
+								<ListItem key={job.id} disableGutters>
+									<ListItemText
+										primary={`${job.company} – ${job.role}`}
+										secondary={
+											STATUS_LABELS[job.status as JobStatus] ?? job.status
+										}
+									/>
+								</ListItem>
+							))}
+						</List>
+					</>
+				) : (
+					<>
+						<Typography variant="body2" sx={{ mb: 2 }}>
+							Closes your current job search and starts a fresh board.
+						</Typography>
+						<TextField
+							label="Job Search Name *"
+							value={name}
+							onChange={(e) => {
+								setName(e.target.value);
+								if (error) {
+									setError("");
+								}
+							}}
+							error={Boolean(error)}
+							helperText={error}
+							fullWidth
+							size="small"
+							sx={{ mb: 2 }}
+						/>
+						<TextField
+							label="Notes"
+							value={notes}
+							onChange={(e) => setNotes(e.target.value)}
+							fullWidth
+							size="small"
+							multiline
+							rows={3}
+						/>
+					</>
+				)}
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onCancel}>Cancel</Button>
+				{!blocked && (
+					<Button variant="contained" onClick={handleConfirm}>
+						Continue
+					</Button>
+				)}
+			</DialogActions>
+		</Dialog>
+	);
+}

--- a/frontend/src/testUtils.ts
+++ b/frontend/src/testUtils.ts
@@ -1,4 +1,4 @@
-import type { Job } from "./types";
+import type { Job, JobSearch } from "./types";
 
 export const BASE_JOB: Job = {
 	id: 1,
@@ -26,4 +26,17 @@ export const BASE_JOB: Job = {
 
 export function makeJob(overrides: Partial<Job> = {}): Job {
 	return { ...BASE_JOB, ...overrides };
+}
+
+export const BASE_JOB_SEARCH: JobSearch = {
+	id: 1,
+	user_id: 1,
+	name: "Search 1",
+	started_at: "2024-01-01T00:00:00.000Z",
+	closed_at: null,
+	notes: null,
+};
+
+export function makeJobSearch(overrides: Partial<JobSearch> = {}): JobSearch {
+	return { ...BASE_JOB_SEARCH, ...overrides };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -52,6 +52,22 @@ export interface LinkJob {
 	link: string;
 }
 
+export interface JobSearch {
+	id: number;
+	user_id: number;
+	name: string;
+	started_at: string;
+	closed_at: string | null;
+	notes: string | null;
+}
+
+export interface BlockingJob {
+	id: number;
+	company: string;
+	role: string;
+	status: string;
+}
+
 export interface Job {
 	id: number;
 	date_applied: string | null;


### PR DESCRIPTION
## Summary
- Kanban toolbar chip showing the user's active job search round.
- "New Job Search" action in the user menu (infrequent, so it lives there rather than the toolbar): two-step confirmation — enter a name/notes, then explicitly confirm before the current round closes. A 409 (unresolved jobs) routes back to the name step with the blocking jobs listed.
- `AppShell` owns this flow and bumps a version key on its `Outlet` so the active page remounts and refetches after a round changes.

Stacked on #141 since it depends on `/api/job-searches` and the active-round-scoped `/api/jobs`. Retarget to `main` once #141 merges.

## Test plan
- [x] `npm run test` (frontend) — 715 passing
- [x] `npm run tsc`