### PR TITLE
PR 1: Backend read access to a specific job search round

### DIFF
--- a/backend/routes/jobSearches.spec.ts
+++ b/backend/routes/jobSearches.spec.ts
@@ -6,7 +6,9 @@ import { applySchema } from "../db.js";
 
 const SESSION_SECRET = "dev-secret";
 const TEST_USER_ID = 1;
+const OTHER_USER_ID = 2;
 const TEST_SESSION_ID = "test-session-job-searches-routes";
+const OTHER_SESSION_ID = "test-session-job-searches-routes-other";
 
 const testDb = new Database(":memory:");
 applySchema(testDb);
@@ -21,6 +23,9 @@ testDb
 	.prepare("INSERT INTO users (id, email) VALUES (?, ?)")
 	.run(TEST_USER_ID, "test@test.com");
 testDb
+	.prepare("INSERT INTO users (id, email) VALUES (?, ?)")
+	.run(OTHER_USER_ID, "other@test.com");
+testDb
 	.prepare(
 		"INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))",
 	)
@@ -31,17 +36,32 @@ testDb
 			userId: TEST_USER_ID,
 		}),
 	);
+testDb
+	.prepare(
+		"INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))",
+	)
+	.run(
+		OTHER_SESSION_ID,
+		JSON.stringify({
+			cookie: { originalMaxAge: 604_800_000 },
+			userId: OTHER_USER_ID,
+		}),
+	);
 
-const sig = createHmac("sha256", SESSION_SECRET)
-	.update(TEST_SESSION_ID)
-	.digest("base64")
-	.replace(/=+$/, "");
-const AUTH_COOKIE = `connect.sid=${encodeURIComponent(`s:${TEST_SESSION_ID}.${sig}`)}`;
+function makeCookie(sessionId: string): string {
+	const sig = createHmac("sha256", SESSION_SECRET)
+		.update(sessionId)
+		.digest("base64")
+		.replace(/=+$/, "");
+	return `connect.sid=${encodeURIComponent(`s:${sessionId}.${sig}`)}`;
+}
+const AUTH_COOKIE = makeCookie(TEST_SESSION_ID);
+const OTHER_AUTH_COOKIE = makeCookie(OTHER_SESSION_ID);
 
 const app = createApp(testDb);
 
-function req(method: "get" | "post" | "patch", url: string) {
-	return request(app)[method](url).set("Cookie", AUTH_COOKIE);
+function req(method: "get" | "post" | "patch", url: string, cookie = AUTH_COOKIE) {
+	return request(app)[method](url).set("Cookie", cookie);
 }
 
 function insertJob(
@@ -92,6 +112,48 @@ describe("gET /api/job-searches/active", () => {
 		const res = await req("get", "/api/job-searches/active");
 		expect(res.status).toBe(200);
 		expect(res.body.name).toBe("Search 1");
+	});
+});
+
+describe("gET /api/job-searches/:id", () => {
+	it("returns 401 when not authenticated", async () => {
+		const res = await request(app).get("/api/job-searches/1");
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 400 for a non-numeric id", async () => {
+		const res = await req("get", "/api/job-searches/not-a-number");
+		expect(res.status).toBe(400);
+	});
+
+	it("returns 404 when the round does not exist", async () => {
+		const res = await req("get", "/api/job-searches/9999");
+		expect(res.status).toBe(404);
+	});
+
+	it("returns a closed round by id", async () => {
+		const first = await req("post", "/api/job-searches").send({
+			name: "Search 1",
+		});
+		insertJob({ status: "offer", search_id: first.body.id });
+		await req("post", "/api/job-searches").send({ name: "Search 2" });
+
+		const res = await req("get", `/api/job-searches/${first.body.id}`);
+		expect(res.status).toBe(200);
+		expect(res.body.name).toBe("Search 1");
+		expect(res.body.closed_at).not.toBeNull();
+	});
+
+	it("returns 404 for a round owned by a different user", async () => {
+		const created = await req("post", "/api/job-searches").send({
+			name: "Search 1",
+		});
+		const res = await req(
+			"get",
+			`/api/job-searches/${created.body.id}`,
+			OTHER_AUTH_COOKIE,
+		);
+		expect(res.status).toBe(404);
 	});
 });
 

--- a/backend/routes/jobSearches.ts
+++ b/backend/routes/jobSearches.ts
@@ -22,6 +22,20 @@ export function createJobSearchesRouter(db: Database.Database) {
 		return res.json(active);
 	});
 
+	// GET /api/job-searches/:id — a specific round (active or closed), scoped to the user
+	router.get("/:id", (req, res) => {
+		const userId = req.session.userId!;
+		const id = Number(req.params.id);
+		if (isNaN(id)) {
+			return res.status(400).json({ error: "Invalid id" });
+		}
+		const search = JobSearchesDb.getSearch(db, id, userId);
+		if (!search) {
+			return res.status(404).json({ error: "Job search not found" });
+		}
+		return res.json(search);
+	});
+
 	// POST /api/job-searches — closes the current active round and starts a new one
 	router.post("/", (req, res) => {
 		const userId = req.session.userId!;

--- a/backend/routes/jobs.spec.ts
+++ b/backend/routes/jobs.spec.ts
@@ -11,7 +11,9 @@ import {
 import { applySchema } from "../db.js";
 
 const TEST_USER_ID = 1;
+const OTHER_USER_ID = 2;
 const TEST_SESSION_ID = "test-session-jobs-routes";
+const OTHER_SESSION_ID = "test-session-jobs-routes-other";
 const SESSION_SECRET = "dev-secret";
 
 const testDb = new Database(":memory:");
@@ -24,24 +26,32 @@ testDb.exec(`
   );
 `);
 testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(TEST_USER_ID, "test@test.com");
+testDb.prepare("INSERT INTO users (id, email) VALUES (?, ?)").run(OTHER_USER_ID, "other@test.com");
 testDb
 	.prepare("INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))")
 	.run(TEST_SESSION_ID, JSON.stringify({ cookie: { originalMaxAge: 604_800_000 }, userId: TEST_USER_ID }));
+testDb
+	.prepare("INSERT INTO sessions (sid, sess, expire) VALUES (?, ?, datetime('now', '+7 days'))")
+	.run(OTHER_SESSION_ID, JSON.stringify({ cookie: { originalMaxAge: 604_800_000 }, userId: OTHER_USER_ID }));
 
-const sig = createHmac("sha256", SESSION_SECRET)
-	.update(TEST_SESSION_ID)
-	.digest("base64")
-	.replace(/=+$/, "");
-const AUTH_COOKIE = `connect.sid=${encodeURIComponent(`s:${TEST_SESSION_ID}.${sig}`)}`;
+function makeCookie(sessionId: string): string {
+	const sig = createHmac("sha256", SESSION_SECRET)
+		.update(sessionId)
+		.digest("base64")
+		.replace(/=+$/, "");
+	return `connect.sid=${encodeURIComponent(`s:${sessionId}.${sig}`)}`;
+}
+const AUTH_COOKIE = makeCookie(TEST_SESSION_ID);
+const OTHER_AUTH_COOKIE = makeCookie(OTHER_SESSION_ID);
 
 const app = createApp(testDb);
 
-function req(method: "get" | "post" | "put" | "delete", url: string) {
-	return request(app)[method](url).set("Cookie", AUTH_COOKIE);
+function req(method: "get" | "post" | "put" | "delete", url: string, cookie = AUTH_COOKIE) {
+	return request(app)[method](url).set("Cookie", cookie);
 }
 
 afterEach(() => {
-	testDb.exec("DELETE FROM jobs");
+	testDb.exec("DELETE FROM jobs; DELETE FROM job_searches;");
 });
 
 const BASE_JOB = {
@@ -112,6 +122,51 @@ describe("gET /api/jobs", () => {
 			const res = await req("get", "/api/jobs?view=unknown");
 			expect(res.status).toBe(200);
 			expect(res.body[0]).not.toHaveProperty("notes");
+		});
+	});
+
+	describe("search_id param", () => {
+		it("returns 400 for a non-numeric search_id", async () => {
+			const res = await req("get", "/api/jobs?search_id=not-a-number");
+			expect(res.status).toBe(400);
+		});
+
+		it("returns 404 for a search_id that doesn't exist", async () => {
+			const res = await req("get", "/api/jobs?search_id=9999");
+			expect(res.status).toBe(404);
+		});
+
+		it("returns 404 for a search_id owned by a different user", async () => {
+			const created = await req("post", "/api/job-searches").send({
+				name: "Search 1",
+			});
+			const res = await req(
+				"get",
+				`/api/jobs?search_id=${created.body.id}`,
+				OTHER_AUTH_COOKIE,
+			);
+			expect(res.status).toBe(404);
+		});
+
+		it("returns jobs scoped to a closed round, not the active one", async () => {
+			const firstJob = await req("post", "/api/jobs").send({
+				...BASE_JOB,
+				ending_substatus: "Withdrawn",
+				status: "rejected_or_withdrawn",
+			});
+			const firstSearchId = firstJob.body.search_id;
+
+			await req("post", "/api/job-searches").send({ name: "Search 2" });
+			await req("post", "/api/jobs").send({ ...BASE_JOB, company: "Second Co" });
+
+			const historical = await req("get", `/api/jobs?search_id=${firstSearchId}`);
+			expect(historical.status).toBe(200);
+			expect(historical.body).toHaveLength(1);
+			expect(historical.body[0].company).toBe("Acme Corp");
+
+			const current = await req("get", "/api/jobs");
+			expect(current.body).toHaveLength(1);
+			expect(current.body[0].company).toBe("Second Co");
 		});
 	});
 });

--- a/backend/routes/jobs.ts
+++ b/backend/routes/jobs.ts
@@ -12,8 +12,21 @@ export function createJobsRouter(db: Database.Database) {
 	router.get("/", (req, res) => {
 		const view: JobView = req.query.view === "full" ? "full" : "summary";
 		const userId = req.session.userId!;
+
+		if (req.query.search_id !== undefined) {
+			const searchId = Number(req.query.search_id);
+			if (isNaN(searchId)) {
+				return res.status(400).json({ error: "Invalid search_id" });
+			}
+			const search = JobSearchesDb.getSearch(db, searchId, userId);
+			if (!search) {
+				return res.status(404).json({ error: "Job search not found" });
+			}
+			return res.json(JobsDb.listJobs(db, userId, view, search.id));
+		}
+
 		const active = JobSearchesDb.getActiveSearch(db, userId);
-		res.json(active ? JobsDb.listJobs(db, userId, view, active.id) : []);
+		return res.json(active ? JobsDb.listJobs(db, userId, view, active.id) : []);
 	});
 
 	router.get("/:jobId", (req, res) => {


### PR DESCRIPTION
## Summary
First of six PRs implementing "view past job searches" (see `PAST_JOB_SEARCHES_DESIGN.md`).

- `GET /api/job-searches/:id` — fetch a specific round (active or closed), scoped to the requesting user; 404 if not found/not owned.
- `GET /api/jobs?search_id=<id>` — scope job listing to a specific round instead of always resolving the active one; 404 if the round doesn't exist or isn't owned by the user, 400 for a non-numeric id.
- No frontend changes, no write-path changes — purely additive read API. Existing behavior (no `search_id` param) is unchanged.

Follow-up PRs: write-path guards to enforce read-only on closed rounds, frontend API wrappers + routing, read-only UI plumbing, visual distinction, and the "Past Job Searches" entry point.

## Test plan
- [x] `npm run tsc` passes
- [x] `npm run lint` / `npm run format:fix` clean
- [x] Backend test suite: 512/512 passing, including new cases for `GET /api/job-searches/:id` (401/400/404/cross-user/closed-round) and `GET /api/jobs?search_id=` (400/404/cross-user/scoping)