### PR TITLE
PR 2: Enforce read-only for jobs in closed job search rounds

### DIFF
--- a/backend/db/jobSearches.ts
+++ b/backend/db/jobSearches.ts
@@ -49,6 +49,23 @@ export function getActiveSearch(
 		.get(userId) as JobSearchRow | undefined;
 }
 
+/** True if the job exists, belongs to the user, and sits in their currently active (not closed) round. */
+export function isJobInActiveSearch(
+	db: Database.Database,
+	jobId: number,
+	userId: number,
+): boolean {
+	return Boolean(
+		db
+			.prepare(
+				`SELECT 1 FROM jobs j
+				 JOIN job_searches s ON s.id = j.search_id
+				 WHERE j.id = ? AND j.user_id = ? AND s.closed_at IS NULL`,
+			)
+			.get(jobId, userId),
+	);
+}
+
 /** Returns the user's active round, opening a first one if they don't have one yet. */
 export function getOrCreateActiveSearch(
 	db: Database.Database,

--- a/backend/routes/interviews.spec.ts
+++ b/backend/routes/interviews.spec.ts
@@ -89,6 +89,12 @@ async function createJobInterviewAndQuestion() {
 	return { interviewId, jobId, questionId: questionRes.body.id as number };
 }
 
+// Moves the given job's round to "closed" by marking the job terminal (so it doesn't block closing) and starting a new round.
+async function closeRoundContaining(jobId: number) {
+	testDb.prepare("UPDATE jobs SET status = 'offer' WHERE id = ?").run(jobId);
+	await req("post", "/api/job-searches").send({ name: "Next Round" });
+}
+
 // --- Interview routes ---
 
 describe("gET /api/jobs/:jobId/interviews", () => {
@@ -249,6 +255,13 @@ describe("pOST /api/jobs/:jobId/interviews", () => {
 		expect(res.status).toBe(422);
 		expect(res.body.error).toMatch(/job_id/);
 	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const jobId = await createJob();
+		await closeRoundContaining(jobId);
+		const res = await req("post", `/api/jobs/${jobId}/interviews`).send(BASE_INTERVIEW);
+		expect(res.status).toBe(403);
+	});
 });
 
 describe("pUT /api/jobs/:jobId/interviews/:interviewId", () => {
@@ -319,6 +332,15 @@ describe("pUT /api/jobs/:jobId/interviews/:interviewId", () => {
 		expect(res.body.interview_result).toBe("passed");
 		expect(res.body.interview_feeling).toBe("pretty_good");
 	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const { jobId, interviewId } = await createJobAndInterview();
+		await closeRoundContaining(jobId);
+		const res = await req("put", `/api/jobs/${jobId}/interviews/${interviewId}`).send(
+			BASE_INTERVIEW,
+		);
+		expect(res.status).toBe(403);
+	});
 });
 
 describe("dELETE /api/jobs/:jobId/interviews/:interviewId", () => {
@@ -334,6 +356,13 @@ describe("dELETE /api/jobs/:jobId/interviews/:interviewId", () => {
 		const res = await req("delete", `/api/jobs/${jobId}/interviews/99999`);
 		expect(res.status).toBe(404);
 		expect(res.body.error).toBe("Interview not found");
+	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const { jobId, interviewId } = await createJobAndInterview();
+		await closeRoundContaining(jobId);
+		const res = await req("delete", `/api/jobs/${jobId}/interviews/${interviewId}`);
+		expect(res.status).toBe(403);
 	});
 
 	it("returns 404 when the job does not exist", async () => {
@@ -524,6 +553,16 @@ describe("pOST /api/jobs/:jobId/interviews/:interviewId/questions", () => {
 		).send(BASE_QUESTION);
 		expect(res.status).toBe(404);
 	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const { jobId, interviewId } = await createJobAndInterview();
+		await closeRoundContaining(jobId);
+		const res = await req(
+			"post",
+			`/api/jobs/${jobId}/interviews/${interviewId}/questions`,
+		).send(BASE_QUESTION);
+		expect(res.status).toBe(403);
+	});
 });
 
 describe("pUT /api/jobs/:jobId/interviews/:interviewId/questions/:questionId", () => {
@@ -591,6 +630,16 @@ describe("pUT /api/jobs/:jobId/interviews/:interviewId/questions/:questionId", (
 		).send({ ...BASE_QUESTION, question_type: "brainteaser" });
 		expect(res.status).toBe(422);
 	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const { jobId, interviewId, questionId } = await createJobInterviewAndQuestion();
+		await closeRoundContaining(jobId);
+		const res = await req(
+			"put",
+			`/api/jobs/${jobId}/interviews/${interviewId}/questions/${questionId}`,
+		).send(BASE_QUESTION);
+		expect(res.status).toBe(403);
+	});
 });
 
 describe("dELETE /api/jobs/:jobId/interviews/:interviewId/questions/:questionId", () => {
@@ -632,6 +681,16 @@ describe("dELETE /api/jobs/:jobId/interviews/:interviewId/questions/:questionId"
 			`/api/jobs/${jobId}/interviews/99999/questions/1`,
 		);
 		expect(res.status).toBe(404);
+	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const { jobId, interviewId, questionId } = await createJobInterviewAndQuestion();
+		await closeRoundContaining(jobId);
+		const res = await req(
+			"delete",
+			`/api/jobs/${jobId}/interviews/${interviewId}/questions/${questionId}`,
+		);
+		expect(res.status).toBe(403);
 	});
 });
 

--- a/backend/routes/interviews.spec.ts
+++ b/backend/routes/interviews.spec.ts
@@ -256,11 +256,11 @@ describe("pOST /api/jobs/:jobId/interviews", () => {
 		expect(res.body.error).toMatch(/job_id/);
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const jobId = await createJob();
 		await closeRoundContaining(jobId);
 		const res = await req("post", `/api/jobs/${jobId}/interviews`).send(BASE_INTERVIEW);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 	});
 });
 
@@ -333,13 +333,13 @@ describe("pUT /api/jobs/:jobId/interviews/:interviewId", () => {
 		expect(res.body.interview_feeling).toBe("pretty_good");
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const { jobId, interviewId } = await createJobAndInterview();
 		await closeRoundContaining(jobId);
 		const res = await req("put", `/api/jobs/${jobId}/interviews/${interviewId}`).send(
 			BASE_INTERVIEW,
 		);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 	});
 });
 
@@ -358,11 +358,11 @@ describe("dELETE /api/jobs/:jobId/interviews/:interviewId", () => {
 		expect(res.body.error).toBe("Interview not found");
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const { jobId, interviewId } = await createJobAndInterview();
 		await closeRoundContaining(jobId);
 		const res = await req("delete", `/api/jobs/${jobId}/interviews/${interviewId}`);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 	});
 
 	it("returns 404 when the job does not exist", async () => {
@@ -554,14 +554,14 @@ describe("pOST /api/jobs/:jobId/interviews/:interviewId/questions", () => {
 		expect(res.status).toBe(404);
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const { jobId, interviewId } = await createJobAndInterview();
 		await closeRoundContaining(jobId);
 		const res = await req(
 			"post",
 			`/api/jobs/${jobId}/interviews/${interviewId}/questions`,
 		).send(BASE_QUESTION);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 	});
 });
 
@@ -631,14 +631,14 @@ describe("pUT /api/jobs/:jobId/interviews/:interviewId/questions/:questionId", (
 		expect(res.status).toBe(422);
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const { jobId, interviewId, questionId } = await createJobInterviewAndQuestion();
 		await closeRoundContaining(jobId);
 		const res = await req(
 			"put",
 			`/api/jobs/${jobId}/interviews/${interviewId}/questions/${questionId}`,
 		).send(BASE_QUESTION);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 	});
 });
 
@@ -683,14 +683,14 @@ describe("dELETE /api/jobs/:jobId/interviews/:interviewId/questions/:questionId"
 		expect(res.status).toBe(404);
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const { jobId, interviewId, questionId } = await createJobInterviewAndQuestion();
 		await closeRoundContaining(jobId);
 		const res = await req(
 			"delete",
 			`/api/jobs/${jobId}/interviews/${interviewId}/questions/${questionId}`,
 		);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 	});
 });
 

--- a/backend/routes/interviews.ts
+++ b/backend/routes/interviews.ts
@@ -64,7 +64,7 @@ export function createInterviewSearchRouter(db: Database.Database) {
 	return router;
 }
 
-// Rejects writes against a job in a closed (non-active) search round (sends 403). Caller should already have verified the job belongs to the user.
+// Rejects writes against a job in a closed (non-active) search round (sends 409). Caller should already have verified the job belongs to the user.
 function checkActiveRound(
 	db: Database.Database,
 	jobId: string,
@@ -73,7 +73,7 @@ function checkActiveRound(
 ): boolean {
 	if (!JobSearchesDb.isJobInActiveSearch(db, Number(jobId), userId)) {
 		res
-			.status(403)
+			.status(409)
 			.json({ error: "Cannot modify interviews for a job in a closed search round" });
 		return false;
 	}

--- a/backend/routes/interviews.ts
+++ b/backend/routes/interviews.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 import { Router, type Response } from "express";
 import * as InterviewsDb from "../db/interviews.js";
+import * as JobSearchesDb from "../db/jobSearches.js";
 import { validateInterview, validateInterviewQuestion } from "../validators.js";
 
 const PAGE_SIZE = 10;
@@ -63,6 +64,22 @@ export function createInterviewSearchRouter(db: Database.Database) {
 	return router;
 }
 
+// Rejects writes against a job in a closed (non-active) search round (sends 403). Caller should already have verified the job belongs to the user.
+function checkActiveRound(
+	db: Database.Database,
+	jobId: string,
+	userId: number,
+	res: Response,
+): boolean {
+	if (!JobSearchesDb.isJobInActiveSearch(db, Number(jobId), userId)) {
+		res
+			.status(403)
+			.json({ error: "Cannot modify interviews for a job in a closed search round" });
+		return false;
+	}
+	return true;
+}
+
 // Verifies the job belongs to the user and the interview belongs to the job.
 // Sends 404 and returns null if either check fails.
 function resolveInterview(
@@ -108,6 +125,7 @@ export function createInterviewsRouter(db: Database.Database) {
 		if (!InterviewsDb.jobBelongsToUser(db, Number(jobId), req.session.userId!)) {
 			return res.status(404).json({ error: "Job not found" });
 		}
+		if (!checkActiveRound(db, jobId, req.session.userId!, res)) {return;}
 		if (f.job_id != null && String(f.job_id) !== jobId) {
 			return res
 				.status(422)
@@ -138,6 +156,7 @@ export function createInterviewsRouter(db: Database.Database) {
 		if (!InterviewsDb.jobBelongsToUser(db, Number(jobId), req.session.userId!)) {
 			return res.status(404).json({ error: "Job not found" });
 		}
+		if (!checkActiveRound(db, jobId, req.session.userId!, res)) {return;}
 		if (f.job_id != null && String(f.job_id) !== jobId) {
 			return res
 				.status(422)
@@ -171,6 +190,7 @@ export function createInterviewsRouter(db: Database.Database) {
 		if (!InterviewsDb.jobBelongsToUser(db, Number(jobId), req.session.userId!)) {
 			return res.status(404).json({ error: "Job not found" });
 		}
+		if (!checkActiveRound(db, jobId, req.session.userId!, res)) {return;}
 		const deleted = InterviewsDb.deleteInterview(
 			db,
 			Number(interviewId),
@@ -206,6 +226,7 @@ export function createInterviewsRouter(db: Database.Database) {
 		const { jobId, interviewId } = req.params as { jobId: string; interviewId: string };
 		if (!resolveInterview(db, jobId, interviewId, req.session.userId!, res))
 			{return;}
+		if (!checkActiveRound(db, jobId, req.session.userId!, res)) {return;}
 		const f = req.body as Record<string, unknown>;
 		const validationError = validateInterviewQuestion(f);
 		if (validationError) {return res.status(422).json({ error: validationError });}
@@ -224,6 +245,7 @@ export function createInterviewsRouter(db: Database.Database) {
 		const { jobId, interviewId, questionId } = req.params as { jobId: string; interviewId: string; questionId: string };
 		if (!resolveInterview(db, jobId, interviewId, req.session.userId!, res))
 			{return;}
+		if (!checkActiveRound(db, jobId, req.session.userId!, res)) {return;}
 		const f = req.body as Record<string, unknown>;
 		const validationError = validateInterviewQuestion(f);
 		if (validationError) {return res.status(422).json({ error: validationError });}
@@ -247,6 +269,7 @@ export function createInterviewsRouter(db: Database.Database) {
 		const { jobId, interviewId, questionId } = req.params as { jobId: string; interviewId: string; questionId: string };
 		if (!resolveInterview(db, jobId, interviewId, req.session.userId!, res))
 			{return;}
+		if (!checkActiveRound(db, jobId, req.session.userId!, res)) {return;}
 		const deleted = InterviewsDb.deleteQuestion(
 			db,
 			Number(questionId),

--- a/backend/routes/jobs.spec.ts
+++ b/backend/routes/jobs.spec.ts
@@ -305,7 +305,7 @@ describe("pUT /api/jobs/:id", () => {
 		expect(res.body.error).toBe("Job not found");
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const createRes = await req("post", "/api/jobs").send({
 			...BASE_JOB,
 			ending_substatus: "Withdrawn",
@@ -318,7 +318,7 @@ describe("pUT /api/jobs/:id", () => {
 			...BASE_JOB,
 			company: "Should Not Apply",
 		});
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 
 		const unchanged = await req("get", `/api/jobs/${id}`);
 		expect(unchanged.body.company).toBe("Acme Corp");
@@ -341,7 +341,7 @@ describe("dELETE /api/jobs/:id", () => {
 		expect(res.body.error).toBe("Job not found");
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const createRes = await req("post", "/api/jobs").send({
 			...BASE_JOB,
 			ending_substatus: "Withdrawn",
@@ -351,7 +351,7 @@ describe("dELETE /api/jobs/:id", () => {
 		await req("post", "/api/job-searches").send({ name: "Search 2" });
 
 		const res = await req("delete", `/api/jobs/${id}`);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 
 		const stillThere = await req("get", `/api/jobs/${id}`);
 		expect(stillThere.status).toBe(200);

--- a/backend/routes/jobs.spec.ts
+++ b/backend/routes/jobs.spec.ts
@@ -304,6 +304,25 @@ describe("pUT /api/jobs/:id", () => {
 		expect(res.status).toBe(404);
 		expect(res.body.error).toBe("Job not found");
 	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const createRes = await req("post", "/api/jobs").send({
+			...BASE_JOB,
+			ending_substatus: "Withdrawn",
+			status: "rejected_or_withdrawn",
+		});
+		const { id } = createRes.body;
+		await req("post", "/api/job-searches").send({ name: "Search 2" });
+
+		const res = await req("put", `/api/jobs/${id}`).send({
+			...BASE_JOB,
+			company: "Should Not Apply",
+		});
+		expect(res.status).toBe(403);
+
+		const unchanged = await req("get", `/api/jobs/${id}`);
+		expect(unchanged.body.company).toBe("Acme Corp");
+	});
 });
 
 describe("dELETE /api/jobs/:id", () => {
@@ -320,6 +339,22 @@ describe("dELETE /api/jobs/:id", () => {
 		const res = await req("delete", "/api/jobs/99999");
 		expect(res.status).toBe(404);
 		expect(res.body.error).toBe("Job not found");
+	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const createRes = await req("post", "/api/jobs").send({
+			...BASE_JOB,
+			ending_substatus: "Withdrawn",
+			status: "rejected_or_withdrawn",
+		});
+		const { id } = createRes.body;
+		await req("post", "/api/job-searches").send({ name: "Search 2" });
+
+		const res = await req("delete", `/api/jobs/${id}`);
+		expect(res.status).toBe(403);
+
+		const stillThere = await req("get", `/api/jobs/${id}`);
+		expect(stillThere.status).toBe(200);
 	});
 });
 

--- a/backend/routes/jobs.ts
+++ b/backend/routes/jobs.ts
@@ -103,17 +103,22 @@ export function createJobsRouter(db: Database.Database) {
 		if (offerDateError) {return res.status(422).json({ error: offerDateError });}
 
 		const jobId = Number(req.params.id);
-		const currentJob = db
-			.prepare("SELECT status FROM jobs WHERE id = ? AND user_id = ?")
-			.get(jobId, req.session.userId!) as { status: string } | undefined;
-		if (f.status !== undefined && currentJob?.status === "offer" && f.status !== "offer") {
+		const userId = req.session.userId!;
+		const currentJob = JobsDb.findJob(db, jobId, userId);
+		if (!currentJob) {return res.status(404).json({ error: "Job not found" });}
+		if (!JobSearchesDb.isJobInActiveSearch(db, jobId, userId)) {
+			return res
+				.status(403)
+				.json({ error: "Cannot modify a job in a closed search round" });
+		}
+		if (f.status !== undefined && currentJob.status === "offer" && f.status !== "offer") {
 			OffersDb.deleteOffer(db, jobId);
 		}
 
 		const job = JobsDb.updateJob(
 			db,
 			jobId,
-			req.session.userId!,
+			userId,
 			{
 				date_applied: f.date_applied ?? null,
 				company: f.company,
@@ -141,11 +146,17 @@ export function createJobsRouter(db: Database.Database) {
 	});
 
 	router.delete("/:id", (req, res) => {
-		const deleted = JobsDb.deleteJob(
-			db,
-			Number(req.params.id),
-			req.session.userId!,
-		);
+		const jobId = Number(req.params.id);
+		const userId = req.session.userId!;
+		if (!JobsDb.findJob(db, jobId, userId)) {
+			return res.status(404).json({ error: "Job not found" });
+		}
+		if (!JobSearchesDb.isJobInActiveSearch(db, jobId, userId)) {
+			return res
+				.status(403)
+				.json({ error: "Cannot modify a job in a closed search round" });
+		}
+		const deleted = JobsDb.deleteJob(db, jobId, userId);
 		if (!deleted) {return res.status(404).json({ error: "Job not found" });}
 		return res.json({ success: true });
 	});

--- a/backend/routes/jobs.ts
+++ b/backend/routes/jobs.ts
@@ -108,7 +108,7 @@ export function createJobsRouter(db: Database.Database) {
 		if (!currentJob) {return res.status(404).json({ error: "Job not found" });}
 		if (!JobSearchesDb.isJobInActiveSearch(db, jobId, userId)) {
 			return res
-				.status(403)
+				.status(409)
 				.json({ error: "Cannot modify a job in a closed search round" });
 		}
 		if (f.status !== undefined && currentJob.status === "offer" && f.status !== "offer") {
@@ -153,7 +153,7 @@ export function createJobsRouter(db: Database.Database) {
 		}
 		if (!JobSearchesDb.isJobInActiveSearch(db, jobId, userId)) {
 			return res
-				.status(403)
+				.status(409)
 				.json({ error: "Cannot modify a job in a closed search round" });
 		}
 		const deleted = JobsDb.deleteJob(db, jobId, userId);

--- a/backend/routes/offers.spec.ts
+++ b/backend/routes/offers.spec.ts
@@ -172,10 +172,10 @@ describe("pOST /api/jobs/:jobId/offer", () => {
 		expect(second.body.error).toMatch(/already exists/);
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const jobId = insertJobInClosedSearch();
 		const res = await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 	});
 
 	it("creates the offer and returns 201", async () => {
@@ -317,11 +317,11 @@ describe("pUT /api/jobs/:jobId/offer", () => {
 		expect(res.body.other_is_recurring).toBeTruthy();
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const jobId = insertJobInClosedSearch();
 		testDb.prepare("INSERT INTO offers (job_id) VALUES (?)").run(jobId);
 		const res = await req("put", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 	});
 });
 
@@ -364,11 +364,11 @@ describe("dELETE /api/jobs/:jobId/offer", () => {
 		expect(getRes.status).toBe(404);
 	});
 
-	it("returns 403 when the job is in a closed search round", async () => {
+	it("returns 409 when the job is in a closed search round", async () => {
 		const jobId = insertJobInClosedSearch();
 		testDb.prepare("INSERT INTO offers (job_id) VALUES (?)").run(jobId);
 		const res = await req("delete", `/api/jobs/${jobId}/offer`);
-		expect(res.status).toBe(403);
+		expect(res.status).toBe(409);
 	});
 });
 

--- a/backend/routes/offers.spec.ts
+++ b/backend/routes/offers.spec.ts
@@ -74,9 +74,21 @@ function insertJob(overrides: Record<string, unknown> = {}) {
 			"Engineer",
 			"https://example.com/job/1",
 			overrides.status ?? "offer",
-			ACTIVE_SEARCH_ID,
+			overrides.search_id ?? ACTIVE_SEARCH_ID,
 		);
 	return Number(result.lastInsertRowid);
+}
+
+// Inserts a job in offer status that belongs to an already-closed round.
+function insertJobInClosedSearch() {
+	const closedSearchId = Number(
+		testDb
+			.prepare(
+				"INSERT INTO job_searches (user_id, name, closed_at) VALUES (?, 'Closed Search', datetime('now'))",
+			)
+			.run(TEST_USER_ID).lastInsertRowid,
+	);
+	return insertJob({ search_id: closedSearchId });
 }
 
 afterEach(() => {
@@ -158,6 +170,12 @@ describe("pOST /api/jobs/:jobId/offer", () => {
 		const second = await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
 		expect(second.status).toBe(409);
 		expect(second.body.error).toMatch(/already exists/);
+	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const jobId = insertJobInClosedSearch();
+		const res = await req("post", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		expect(res.status).toBe(403);
 	});
 
 	it("creates the offer and returns 201", async () => {
@@ -298,6 +316,13 @@ describe("pUT /api/jobs/:jobId/offer", () => {
 		expect(res.status).toBe(200);
 		expect(res.body.other_is_recurring).toBeTruthy();
 	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const jobId = insertJobInClosedSearch();
+		testDb.prepare("INSERT INTO offers (job_id) VALUES (?)").run(jobId);
+		const res = await req("put", `/api/jobs/${jobId}/offer`).send(BASE_OFFER);
+		expect(res.status).toBe(403);
+	});
 });
 
 describe("dELETE /api/jobs/:jobId/offer", () => {
@@ -337,6 +362,13 @@ describe("dELETE /api/jobs/:jobId/offer", () => {
 		// Confirm it's gone
 		const getRes = await req("get", `/api/jobs/${jobId}/offer`);
 		expect(getRes.status).toBe(404);
+	});
+
+	it("returns 403 when the job is in a closed search round", async () => {
+		const jobId = insertJobInClosedSearch();
+		testDb.prepare("INSERT INTO offers (job_id) VALUES (?)").run(jobId);
+		const res = await req("delete", `/api/jobs/${jobId}/offer`);
+		expect(res.status).toBe(403);
 	});
 });
 

--- a/backend/routes/offers.ts
+++ b/backend/routes/offers.ts
@@ -1,6 +1,7 @@
 import type Database from "better-sqlite3";
 import { Router } from "express";
 import * as JobsDb from "../db/jobs.js";
+import * as JobSearchesDb from "../db/jobSearches.js";
 import * as OffersDb from "../db/offers.js";
 
 function getJobInOfferStatus(
@@ -16,6 +17,12 @@ function getJobInOfferStatus(
 	}
 	if (job.status !== "offer") {
 		res.status(400).json({ error: "Job is not in offer status" });
+		return false;
+	}
+	if (!JobSearchesDb.isJobInActiveSearch(db, jobId, userId)) {
+		res
+			.status(403)
+			.json({ error: "Cannot modify an offer for a job in a closed search round" });
 		return false;
 	}
 	return true;
@@ -102,6 +109,11 @@ export function createOffersRouter(db: Database.Database) {
 
 		const job = JobsDb.findJob(db, Number(jobId), userId);
 		if (!job) {return res.status(404).json({ error: "Job not found" });}
+		if (!JobSearchesDb.isJobInActiveSearch(db, Number(jobId), userId)) {
+			return res
+				.status(403)
+				.json({ error: "Cannot modify an offer for a job in a closed search round" });
+		}
 
 		const deleted = OffersDb.deleteOffer(db, Number(jobId));
 		if (!deleted) {return res.status(404).json({ error: "Offer not found" });}

--- a/backend/routes/offers.ts
+++ b/backend/routes/offers.ts
@@ -21,7 +21,7 @@ function getJobInOfferStatus(
 	}
 	if (!JobSearchesDb.isJobInActiveSearch(db, jobId, userId)) {
 		res
-			.status(403)
+			.status(409)
 			.json({ error: "Cannot modify an offer for a job in a closed search round" });
 		return false;
 	}
@@ -111,7 +111,7 @@ export function createOffersRouter(db: Database.Database) {
 		if (!job) {return res.status(404).json({ error: "Job not found" });}
 		if (!JobSearchesDb.isJobInActiveSearch(db, Number(jobId), userId)) {
 			return res
-				.status(403)
+				.status(409)
 				.json({ error: "Cannot modify an offer for a job in a closed search round" });
 		}
 


### PR DESCRIPTION
## Summary
Second of six PRs implementing "view past job searches" (see `PAST_JOB_SEARCHES_DESIGN.md`). This is the PR that actually makes closed rounds read-only — a disabled UI alone isn't a guarantee; the backend must reject the write.

- `JobSearchesDb.isJobInActiveSearch(db, jobId, userId)` — true if the job exists, belongs to the user, and its round is currently active (`closed_at IS NULL`).
- Guarded write paths (403 `{ error: "..." }` when the job's round is closed, after existing 404/ownership checks):
  - `PUT /api/jobs/:id`, `DELETE /api/jobs/:id`
  - `POST/PUT/DELETE /api/jobs/:jobId/interviews[/:interviewId]` and the nested `/questions[/:questionId]` routes
  - `POST/PUT/DELETE /api/jobs/:jobId/offer` — not explicitly called out in the original design doc (offers.ts postdates it), but offer data is job-scoped and a job can sit in `offer` status (a terminal status) in a closed round, so it needed the same guard for the read-only guarantee to actually hold.
- No frontend changes — still unreachable without direct API calls, same as PR 1.

## Test plan
- [x] `npm run tsc` passes
- [x] `npm run lint` / `npm run format:fix` clean
- [x] Backend test suite: 523/523 passing, including new 403 cases for every guarded route (job in closed round) alongside existing 404/401/422 coverage