### PR TITLE
PR 3: Frontend API wrappers + history route (no discovery UI yet)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,6 +62,14 @@ export default function App() {
 							<Route path="/" element={<Navigate to="/jobs" replace />} />
 							<Route path="/jobs" element={<JobManagementPage />} />
 							<Route path="/jobs/:jobId" element={<JobManagementPage />} />
+							<Route
+								path="/jobs/history/:searchId"
+								element={<JobManagementPage />}
+							/>
+							<Route
+								path="/jobs/history/:searchId/:jobId"
+								element={<JobManagementPage />}
+							/>
 							<Route path="/calendar" element={<InterviewsPage />} />
 							<Route path="/stats" element={<StatsPage />} />
 							<Route path="/insights" element={<InsightsPage />} />

--- a/frontend/src/api.spec.ts
+++ b/frontend/src/api.spec.ts
@@ -152,6 +152,66 @@ describe("aPI module", () => {
 			);
 			await expect(api.getJobs()).rejects.toThrow("API error 400");
 		});
+
+		it("appends search_id when scoping to a specific round", async () => {
+			mockFetch.mockResolvedValue(makeResponse([MOCK_JOB]));
+			await api.getJobs(7);
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/jobs?view=summary&search_id=7",
+				expect.objectContaining({
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+		});
+	});
+
+	describe("listSearches", () => {
+		it("fetches GET /api/job-searches and returns the parsed JSON", async () => {
+			const MOCK_SEARCH = {
+				closed_at: null,
+				id: 1,
+				name: "Search 1",
+				notes: null,
+				started_at: "2024-01-01T00:00:00.000Z",
+				user_id: 1,
+			};
+			mockFetch.mockResolvedValue(makeResponse([MOCK_SEARCH]));
+			const result = await api.listSearches();
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/job-searches",
+				expect.objectContaining({
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+			expect(result).toStrictEqual([MOCK_SEARCH]);
+		});
+	});
+
+	describe("getSearch", () => {
+		it("fetches GET /api/job-searches/:id and returns the parsed JSON", async () => {
+			const MOCK_SEARCH = {
+				closed_at: "2024-02-01T00:00:00.000Z",
+				id: 3,
+				name: "Old Search",
+				notes: null,
+				started_at: "2024-01-01T00:00:00.000Z",
+				user_id: 1,
+			};
+			mockFetch.mockResolvedValue(makeResponse(MOCK_SEARCH));
+			const result = await api.getSearch(3);
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/job-searches/3",
+				expect.objectContaining({
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+			expect(result).toStrictEqual(MOCK_SEARCH);
+		});
+
+		it("throws when the response is not ok", async () => {
+			mockFetch.mockResolvedValue(makeResponse({ error: "Not found" }, false));
+			await expect(api.getSearch(999)).rejects.toThrow("API error 400");
+		});
 	});
 
 	describe("createJob", () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -76,7 +76,10 @@ export const api = {
 		request<{ success: boolean }>("/auth/logout", { method: "POST" }),
 
 	// Jobs
-	getJobs: () => request<Job[]>("/jobs?view=summary"),
+	getJobs: (searchId?: number) =>
+		request<Job[]>(
+			`/jobs?view=summary${searchId !== undefined ? `&search_id=${searchId}` : ""}`,
+		),
 	getJob: (id: number) => request<Job>(`/jobs/${id}`),
 	createJob: (data: JobFormData) =>
 		request<Job>("/jobs", { body: JSON.stringify(data), method: "POST" }),
@@ -87,6 +90,8 @@ export const api = {
 
 	// Job searches (rounds)
 	getActiveSearch: () => request<JobSearch>("/job-searches/active"),
+	listSearches: () => request<JobSearch[]>("/job-searches"),
+	getSearch: (id: number) => request<JobSearch>(`/job-searches/${id}`),
 	startNewSearch: (name: string, notes: string | null) =>
 		request<JobSearch>("/job-searches", {
 			body: JSON.stringify({ name, notes }),

--- a/frontend/src/components/jobs/JobManagementPage.spec.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.spec.tsx
@@ -39,7 +39,9 @@ vi.mock(import("../../api"), () => {
 			getJob: vi.fn(),
 			getJobs: vi.fn(),
 			getQuestions: vi.fn(),
+			getSearch: vi.fn(),
 			getStats: vi.fn(),
+			listSearches: vi.fn(),
 			updateJob: vi.fn(),
 		},
 	} as any;
@@ -98,6 +100,7 @@ vi.mock(
 const mockGetJobs = vi.mocked(api.getJobs);
 const mockGetJob = vi.mocked(api.getJob);
 const mockGetActiveSearch = vi.mocked(api.getActiveSearch);
+const mockGetSearch = vi.mocked(api.getSearch);
 const MockKanbanBoard = vi.mocked(KanbanBoard);
 
 const MOCK_USER: User = {
@@ -120,6 +123,14 @@ function renderPage(initialPath = "/jobs", onLogout = MOCK_ON_LOGOUT) {
 					>
 						<Route path="/jobs" element={<JobManagementPage />} />
 						<Route path="/jobs/:jobId" element={<JobManagementPage />} />
+						<Route
+							path="/jobs/history/:searchId"
+							element={<JobManagementPage />}
+						/>
+						<Route
+							path="/jobs/history/:searchId/:jobId"
+							element={<JobManagementPage />}
+						/>
 						<Route path="/stats" element={<StatsPage />} />
 					</Route>
 				</Routes>
@@ -834,6 +845,57 @@ describe("jobManagementPage", () => {
 			await waitFor(() => {
 				expect(screen.getByText("Search 1")).toBeInTheDocument();
 			});
+		});
+	});
+
+	describe("historical round route (/jobs/history/:searchId)", () => {
+		it("fetches jobs scoped to the search_id from the URL, not the active round", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetSearch.mockResolvedValue(
+				makeJobSearch({ id: 7, name: "Old Search" }),
+			);
+			renderPage("/jobs/history/7");
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+			expect(mockGetJobs).toHaveBeenCalledWith(7);
+			expect(mockGetSearch).toHaveBeenCalledWith(7);
+		});
+
+		it("loads the round via getSearch and shows its name as the chip", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetSearch.mockResolvedValue(
+				makeJobSearch({ id: 7, name: "Old Search" }),
+			);
+			renderPage("/jobs/history/7");
+			await waitFor(() => {
+				expect(mockGetSearch).toHaveBeenCalledWith(7);
+				expect(screen.getByText("Old Search")).toBeInTheDocument();
+			});
+		});
+
+		it("navigates to the history base path (not /jobs) when opening a job", async () => {
+			const job = makeJob({ company: "Acme", id: 3 });
+			mockGetJobs.mockResolvedValue([job]);
+			mockGetSearch.mockResolvedValue(
+				makeJobSearch({ id: 7, name: "Old Search" }),
+			);
+			mockGetJob.mockResolvedValue(job);
+
+			let onCardClick: ((job: Job) => void) | undefined;
+			MockKanbanBoard.mockImplementation(({ onCardClick: cb }) => {
+				onCardClick = cb;
+				return null;
+			});
+
+			renderPage("/jobs/history/7");
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+
+			await act(async () => onCardClick?.(job));
+
+			await waitFor(() => expect(mockGetJob).toHaveBeenCalledWith(3));
 		});
 	});
 });

--- a/frontend/src/components/jobs/JobManagementPage.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.tsx
@@ -71,7 +71,14 @@ const MIN_FIT_SCORE_OPTIONS: { label: string; value: FitScore | null }[] = [
 
 export default function JobManagementPage() {
 	const navigate = useNavigate();
-	const { jobId } = useParams<{ jobId?: string }>();
+	const { jobId, searchId: searchIdParam } = useParams<{
+		jobId?: string;
+		searchId?: string;
+	}>();
+	const searchId =
+		searchIdParam !== undefined ? Number(searchIdParam) : undefined;
+	const basePath =
+		searchId !== undefined ? `/jobs/history/${searchId}` : "/jobs";
 
 	const [jobs, setJobs] = useState<Job[]>([]);
 	const [search, setSearch] = useState("");
@@ -96,29 +103,34 @@ export default function JobManagementPage() {
 
 	const loadJobs = useCallback(async () => {
 		try {
-			const data = await api.getJobs();
+			const data = await api.getJobs(searchId);
 			setJobs(data);
 		} catch {
 			notify("Failed to load jobs", "error");
 		} finally {
 			setLoading(false);
 		}
-	}, [notify]);
+	}, [notify, searchId]);
 
-	const loadActiveSearch = useCallback(async () => {
+	// Loads the active round, or the specific historical round named by the URL
+	const loadSearchRound = useCallback(async () => {
 		try {
-			setActiveSearch(await api.getActiveSearch());
+			setActiveSearch(
+				searchId !== undefined
+					? await api.getSearch(searchId)
+					: await api.getActiveSearch(),
+			);
 		} catch (error) {
 			if (!(error instanceof ApiError && error.status === 404)) {
-				notify("Failed to load active search round", "error");
+				notify("Failed to load search round", "error");
 			}
 		}
-	}, [notify]);
+	}, [notify, searchId]);
 
 	useEffect(() => {
 		void loadJobs();
-		void loadActiveSearch();
-	}, [loadJobs, loadActiveSearch]);
+		void loadSearchRound();
+	}, [loadJobs, loadSearchRound]);
 
 	// Sync the edit dialog with the URL param once jobs are loaded
 	useEffect(() => {
@@ -132,11 +144,11 @@ export default function JobManagementPage() {
 		const id = parseInt(jobId, 10);
 		const found = jobs.find((j) => j.id === id) ?? null;
 		if (!found) {
-			navigate("/jobs", { replace: true });
+			navigate(basePath, { replace: true });
 			return;
 		}
 		setEditJob(found);
-	}, [jobId, jobs, loading, navigate]);
+	}, [jobId, jobs, loading, navigate, basePath]);
 
 	useEffect(() => {
 		function onKeyDown(e: KeyboardEvent) {
@@ -160,16 +172,16 @@ export default function JobManagementPage() {
 
 	const openAdd = useCallback(() => setAddOpen(true), []);
 	const openEdit = useCallback(
-		(job: Job) => navigate(`/jobs/${job.id}`),
-		[navigate],
+		(job: Job) => navigate(`${basePath}/${job.id}`),
+		[navigate, basePath],
 	);
 	const closeDialog = useCallback(() => {
 		if (addOpen) {
 			setAddOpen(false);
 		} else {
-			navigate("/jobs");
+			navigate(basePath);
 		}
-	}, [addOpen, navigate]);
+	}, [addOpen, navigate, basePath]);
 
 	// The job being edited (null when in "add" mode)
 	const dialogJob = addOpen ? null : editJob;


### PR DESCRIPTION
## Summary
Third of six PRs implementing "view past job searches" (see `PAST_JOB_SEARCHES_DESIGN.md`).

- `api.listSearches()`, `api.getSearch(id)` — new wrappers around the read endpoints added in PR 1.
- `api.getJobs(searchId?)` — now accepts an optional round id, appending `&search_id=` when present.
- New routes in `App.tsx`: `/jobs/history/:searchId` and `/jobs/history/:searchId/:jobId`, both rendering `JobManagementPage`.
- `JobManagementPage` reads `searchId` from the URL via `useParams`. When present, it fetches that specific round (`api.getSearch`) and its jobs (`api.getJobs(searchId)`) instead of the active round; all internal navigation (`openEdit`, `closeDialog`, the not-found redirect) stays under the `/jobs/history/:searchId` base path so deep-linking and back/forward work correctly.

Still no entry point into these routes — reachable only by typing the URL directly, same as PR 1/2. No read-only UI treatment yet either (that's PR 4); the backend already rejects writes against closed rounds with 409 regardless.

## Test plan
- [x] `npm run tsc` passes
- [x] `npm run lint` / `npm run format:fix` clean
- [x] Full test suite: 1245/1245 passing (722 frontend + 523 backend), including new coverage for `api.getJobs(searchId)`, `api.listSearches`, `api.getSearch`, and `JobManagementPage` fetching/navigating correctly under `/jobs/history/:searchId`