### PR TITLE
PR 4: Read-only mode for viewing closed job search rounds

### DIFF
--- a/frontend/src/components/jobs/JobCard.spec.tsx
+++ b/frontend/src/components/jobs/JobCard.spec.tsx
@@ -401,4 +401,73 @@ describe("jobCard", () => {
 			expect(screen.getByText("Offer received")).toBeInTheDocument();
 		});
 	});
+
+	describe("readOnly", () => {
+		it("does not render the drag handle icon", () => {
+			render(
+				<JobCard
+					job={BASE_JOB}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+					readOnly
+				/>,
+			);
+			expect(screen.queryByTestId("DragIndicatorIcon")).not.toBeInTheDocument();
+		});
+
+		it("renders the drag handle icon when not readOnly", () => {
+			render(
+				<JobCard
+					job={BASE_JOB}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+				/>,
+			);
+			expect(screen.getByTestId("DragIndicatorIcon")).toBeInTheDocument();
+		});
+
+		it("disables the favorite toggle and does not call onToggleFavorite when clicked", () => {
+			const onToggleFavorite = vi.fn();
+			render(
+				<JobCard
+					job={BASE_JOB}
+					onCardClick={vi.fn()}
+					onToggleFavorite={onToggleFavorite}
+					readOnly
+				/>,
+			);
+			const button = screen.getByRole("button", { name: "Not favorited" });
+			expect(button).toBeDisabled();
+			fireEvent.click(button);
+			expect(onToggleFavorite).not.toHaveBeenCalled();
+		});
+
+		it("shows a 'Favorited'/'Not favorited' label instead of the edit tooltip", () => {
+			render(
+				<JobCard
+					job={{ ...BASE_JOB, favorite: true }}
+					onCardClick={vi.fn()}
+					onToggleFavorite={vi.fn()}
+					readOnly
+				/>,
+			);
+			expect(
+				screen.getByRole("button", { name: "Favorited" }),
+			).toBeInTheDocument();
+		});
+
+		it("still calls onCardClick when the card body is clicked", () => {
+			const onCardClick = vi.fn();
+			render(
+				<JobCard
+					job={BASE_JOB}
+					onCardClick={onCardClick}
+					onToggleFavorite={vi.fn()}
+					readOnly
+				/>,
+			);
+			fireEvent.click(screen.getByText("Software Engineer"));
+			expect(onCardClick).toHaveBeenCalledWith(BASE_JOB);
+		});
+	});
 });

--- a/frontend/src/components/jobs/JobCard.tsx
+++ b/frontend/src/components/jobs/JobCard.tsx
@@ -21,6 +21,20 @@ import type { FitScore, Job, JobStatus } from "../../types";
 import { STATUS_COLORS, TAG_LABELS, tagChipProps } from "../../constants";
 import { isPossiblyGhosted } from "../../jobUtils";
 
+function dragCursor(readOnly: boolean, isDragging: boolean): string {
+	if (readOnly) {
+		return "default";
+	}
+	return isDragging ? "grabbing" : "grab";
+}
+
+function favoriteTooltip(readOnly: boolean, favorite: boolean): string {
+	if (readOnly) {
+		return favorite ? "Favorited" : "Not favorited";
+	}
+	return favorite ? "Unfavorite" : "Favorite";
+}
+
 function formatDate(dateStr: string | null): string | null {
 	if (!dateStr) {
 		return null;
@@ -119,223 +133,235 @@ interface Props {
 	job: Job;
 	onCardClick: (job: Job) => void;
 	onToggleFavorite: (job: Job) => void;
+	readOnly?: boolean;
 }
 
-const JobCard = React.memo(({ job, onCardClick, onToggleFavorite }: Props) => {
-	const { attributes, listeners, setNodeRef, transform, isDragging } =
-		useDraggable({
-			data: { job },
-			id: String(job.id),
-		});
+const JobCard = React.memo(
+	({ job, onCardClick, onToggleFavorite, readOnly = false }: Props) => {
+		const { attributes, listeners, setNodeRef, transform, isDragging } =
+			useDraggable({
+				data: { job },
+				disabled: readOnly,
+				id: String(job.id),
+			});
 
-	const isGhosted = isPossiblyGhosted(job);
+		const isGhosted = isPossiblyGhosted(job);
 
-	const style = {
-		opacity: isDragging ? 0.4 : 1,
-		transform: CSS.Translate.toString(transform),
-	};
+		const style = {
+			opacity: isDragging ? 0.4 : 1,
+			transform: CSS.Translate.toString(transform),
+		};
 
-	return (
-		<Card
-			ref={setNodeRef}
-			style={style}
-			elevation={0}
-			sx={{
-				"&:hover": {
-					boxShadow: isGhosted
-						? `inset 3px 0 0 #ef5350, 0 0 0 1px rgba(239,83,80,0.5), 0 4px 12px rgba(239,83,80,0.2)`
-						: `0 0 0 1px rgba(99,102,241,0.3), 0 4px 12px rgba(0,0,0,0.1)`,
-				},
-				boxShadow: isGhosted ? "inset 3px 0 0 #ef5350" : undefined,
-				mb: 1.5,
-				transition: "box-shadow 0.15s",
-			}}
-			{...attributes}
-		>
-			{/* Card header — full row is the drag handle */}
-			<Box
-				{...listeners}
+		return (
+			<Card
+				ref={setNodeRef}
+				style={style}
+				elevation={0}
 				sx={{
-					alignItems: "center",
-					bgcolor: isDragging
-						? "rgba(0,0,0,0.035)"
-						: `${STATUS_COLORS[job.status]}26`,
-					borderBottom: isDragging
-						? "1px solid rgba(0,0,0,0.07)"
-						: `1px solid ${STATUS_COLORS[job.status]}40`,
-					cursor: isDragging ? "grabbing" : "grab",
-					display: "flex",
-					gap: 0.5,
-					px: 1,
-					py: 0.5,
-					touchAction: "none",
+					"&:hover": {
+						boxShadow: isGhosted
+							? `inset 3px 0 0 #ef5350, 0 0 0 1px rgba(239,83,80,0.5), 0 4px 12px rgba(239,83,80,0.2)`
+							: `0 0 0 1px rgba(99,102,241,0.3), 0 4px 12px rgba(0,0,0,0.1)`,
+					},
+					boxShadow: isGhosted ? "inset 3px 0 0 #ef5350" : undefined,
+					mb: 1.5,
+					transition: "box-shadow 0.15s",
 				}}
+				{...attributes}
 			>
-				<DragIndicatorIcon
-					sx={{ color: "text.disabled", flexShrink: 0, fontSize: 16 }}
-				/>
-				<CompanyLogo company={job.company} />
-				<Typography
-					variant="subtitle2"
-					noWrap
-					sx={{ flex: 1, fontWeight: 700, minWidth: 0 }}
+				{/* Card header — full row is the drag handle */}
+				<Box
+					{...listeners}
+					sx={{
+						alignItems: "center",
+						bgcolor: isDragging
+							? "rgba(0,0,0,0.035)"
+							: `${STATUS_COLORS[job.status]}26`,
+						borderBottom: isDragging
+							? "1px solid rgba(0,0,0,0.07)"
+							: `1px solid ${STATUS_COLORS[job.status]}40`,
+						cursor: dragCursor(readOnly, isDragging),
+						display: "flex",
+						gap: 0.5,
+						px: 1,
+						py: 0.5,
+						touchAction: "none",
+					}}
 				>
-					{job.company}
-				</Typography>
-
-				<Tooltip title="Open job listing">
-					<IconButton
-						size="small"
-						component="a"
-						href={job.link}
-						target="_blank"
-						rel="noopener noreferrer"
-						onPointerDown={(e) => e.stopPropagation()}
-						onClick={(e) => e.stopPropagation()}
-						sx={{ color: "text.disabled", flexShrink: 0, paddingX: "1px" }}
-					>
-						<OpenInNewIcon fontSize="small" />
-					</IconButton>
-				</Tooltip>
-				<Tooltip title={job.favorite ? "Unfavorite" : "Favorite"}>
-					<IconButton
-						size="small"
-						onPointerDown={(e) => e.stopPropagation()}
-						onClick={(e) => {
-							e.stopPropagation();
-							onToggleFavorite(job);
-						}}
-						sx={{
-							color: job.favorite ? "warning.main" : "text.disabled",
-							flexShrink: 0,
-							paddingX: "1px",
-						}}
-					>
-						{job.favorite ? (
-							<StarIcon fontSize="small" />
-						) : (
-							<StarBorderIcon fontSize="small" />
-						)}
-					</IconButton>
-				</Tooltip>
-			</Box>
-
-			{/* Card body — clickable to open edit dialog */}
-			<CardActionArea
-				onPointerDown={(e) => e.stopPropagation()}
-				onClick={() => onCardClick(job)}
-				sx={{ p: 0 }}
-			>
-				<CardContent sx={{ pb: "10px !important", pt: 1, px: 1.5 }}>
+					{!readOnly && (
+						<DragIndicatorIcon
+							sx={{ color: "text.disabled", flexShrink: 0, fontSize: 16 }}
+						/>
+					)}
+					<CompanyLogo company={job.company} />
 					<Typography
-						variant="body2"
-						color="text.secondary"
+						variant="subtitle2"
 						noWrap
-						sx={{ mb: job.recruiter ? 0.75 : 0 }}
+						sx={{ flex: 1, fontWeight: 700, minWidth: 0 }}
 					>
-						{job.role}
+						{job.company}
 					</Typography>
 
-					<Box
-						sx={{
-							alignItems: "center",
-							display: "flex",
-							flexWrap: "wrap",
-							gap: 0.5,
-							mb: 0.5,
-						}}
-					>
-						<Chip
-							label={job.salary ?? "$???"}
+					<Tooltip title="Open job listing">
+						<IconButton
 							size="small"
-							variant="filled"
-							sx={
-								job.salary
-									? { bgcolor: "#c8e6c9", color: "#1b5e20" }
-									: { bgcolor: "#e0e0e0", color: "#757575" }
-							}
-						/>
-						{job.fit_score && (
-							<Tooltip title={`Fit: ${job.fit_score}`} placement="top">
-								<Box
-									sx={{
-										alignItems: "center",
-										cursor: "default",
-										display: "flex",
-									}}
-								>
-									<FitScoreBars score={job.fit_score} />
-								</Box>
-							</Tooltip>
-						)}
-						{job.referred_by && (
-							<Chip
-								icon={<PeopleIcon />}
-								label={job.referred_by}
-								size="small"
-								variant="outlined"
-								sx={{ maxWidth: 120 }}
-							/>
-						)}
-						{isGhosted && (
-							<Tooltip title="No company response in 30+ days">
-								<Chip
-									label="👻 Possibly ghosted"
-									size="small"
-									variant="outlined"
-									sx={{ borderColor: "#ef5350", color: "#ef5350" }}
-								/>
-							</Tooltip>
-						)}
-					</Box>
-
-					{job.tags.length > 0 && (
-						<Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mb: 0.5 }}>
-							{job.tags.map((tag) => (
-								<Chip
-									key={tag}
-									label={TAG_LABELS[tag]}
-									size="small"
-									{...tagChipProps(tag)}
-									variant="outlined"
-									sx={{
-										fontSize: "0.65rem",
-										height: 18,
-										...tagChipProps(tag).sx,
-									}}
-								/>
-							))}
-						</Box>
-					)}
-
-					{job.recruiter && (
-						<Typography
-							variant="caption"
-							color="text.secondary"
-							sx={{ display: "block" }}
+							component="a"
+							href={job.link}
+							target="_blank"
+							rel="noopener noreferrer"
+							onPointerDown={(e) => e.stopPropagation()}
+							onClick={(e) => e.stopPropagation()}
+							sx={{ color: "text.disabled", flexShrink: 0, paddingX: "1px" }}
 						>
-							Recruiter: {job.recruiter}
-						</Typography>
-					)}
+							<OpenInNewIcon fontSize="small" />
+						</IconButton>
+					</Tooltip>
+					<Tooltip title={favoriteTooltip(readOnly, job.favorite)}>
+						<span>
+							<IconButton
+								size="small"
+								disabled={readOnly}
+								aria-label={favoriteTooltip(readOnly, job.favorite)}
+								onPointerDown={(e) => e.stopPropagation()}
+								onClick={(e) => {
+									e.stopPropagation();
+									onToggleFavorite(job);
+								}}
+								sx={{
+									color: job.favorite ? "warning.main" : "text.disabled",
+									flexShrink: 0,
+									paddingX: "1px",
+								}}
+							>
+								{job.favorite ? (
+									<StarIcon fontSize="small" />
+								) : (
+									<StarBorderIcon fontSize="small" />
+								)}
+							</IconButton>
+						</span>
+					</Tooltip>
+				</Box>
 
-					{(() => {
-						const { label, getDate } = STATUS_DATE_LABEL[job.status];
-						const date = getDate(job);
-						return (
+				{/* Card body — clickable to open edit dialog */}
+				<CardActionArea
+					onPointerDown={(e) => e.stopPropagation()}
+					onClick={() => onCardClick(job)}
+					sx={{ p: 0 }}
+				>
+					<CardContent sx={{ pb: "10px !important", pt: 1, px: 1.5 }}>
+						<Typography
+							variant="body2"
+							color="text.secondary"
+							noWrap
+							sx={{ mb: job.recruiter ? 0.75 : 0 }}
+						>
+							{job.role}
+						</Typography>
+
+						<Box
+							sx={{
+								alignItems: "center",
+								display: "flex",
+								flexWrap: "wrap",
+								gap: 0.5,
+								mb: 0.5,
+							}}
+						>
+							<Chip
+								label={job.salary ?? "$???"}
+								size="small"
+								variant="filled"
+								sx={
+									job.salary
+										? { bgcolor: "#c8e6c9", color: "#1b5e20" }
+										: { bgcolor: "#e0e0e0", color: "#757575" }
+								}
+							/>
+							{job.fit_score && (
+								<Tooltip title={`Fit: ${job.fit_score}`} placement="top">
+									<Box
+										sx={{
+											alignItems: "center",
+											cursor: "default",
+											display: "flex",
+										}}
+									>
+										<FitScoreBars score={job.fit_score} />
+									</Box>
+								</Tooltip>
+							)}
+							{job.referred_by && (
+								<Chip
+									icon={<PeopleIcon />}
+									label={job.referred_by}
+									size="small"
+									variant="outlined"
+									sx={{ maxWidth: 120 }}
+								/>
+							)}
+							{isGhosted && (
+								<Tooltip title="No company response in 30+ days">
+									<Chip
+										label="👻 Possibly ghosted"
+										size="small"
+										variant="outlined"
+										sx={{ borderColor: "#ef5350", color: "#ef5350" }}
+									/>
+								</Tooltip>
+							)}
+						</Box>
+
+						{job.tags.length > 0 && (
+							<Box
+								sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mb: 0.5 }}
+							>
+								{job.tags.map((tag) => (
+									<Chip
+										key={tag}
+										label={TAG_LABELS[tag]}
+										size="small"
+										{...tagChipProps(tag)}
+										variant="outlined"
+										sx={{
+											fontSize: "0.65rem",
+											height: 18,
+											...tagChipProps(tag).sx,
+										}}
+									/>
+								))}
+							</Box>
+						)}
+
+						{job.recruiter && (
 							<Typography
 								variant="caption"
-								color="text.disabled"
-								sx={{ display: "block", mt: 0.5 }}
+								color="text.secondary"
+								sx={{ display: "block" }}
 							>
-								{label}
-								{date ? ` ${date}` : ""}
+								Recruiter: {job.recruiter}
 							</Typography>
-						);
-					})()}
-				</CardContent>
-			</CardActionArea>
-		</Card>
-	);
-});
+						)}
+
+						{(() => {
+							const { label, getDate } = STATUS_DATE_LABEL[job.status];
+							const date = getDate(job);
+							return (
+								<Typography
+									variant="caption"
+									color="text.disabled"
+									sx={{ display: "block", mt: 0.5 }}
+								>
+									{label}
+									{date ? ` ${date}` : ""}
+								</Typography>
+							);
+						})()}
+					</CardContent>
+				</CardActionArea>
+			</Card>
+		);
+	},
+);
 
 export default JobCard;

--- a/frontend/src/components/jobs/JobDialog.spec.tsx
+++ b/frontend/src/components/jobs/JobDialog.spec.tsx
@@ -1235,4 +1235,69 @@ describe("jobDialog", () => {
 			});
 		});
 	});
+
+	describe("readOnly", () => {
+		it("disables the Company field", async () => {
+			render(<JobDialog {...DEFAULT_PROPS} jobId={BASE_JOB.id} readOnly />);
+			await waitFor(() => {
+				expect(screen.getByLabelText(/Company/)).toBeDisabled();
+			});
+		});
+
+		it("shows only a Close button, no Save/Delete/Cancel", async () => {
+			render(<JobDialog {...DEFAULT_PROPS} jobId={BASE_JOB.id} readOnly />);
+			await waitFor(() => {
+				expect(
+					screen.getByRole("button", { name: "Close" }),
+				).toBeInTheDocument();
+			});
+			expect(
+				screen.queryByRole("button", { name: "Delete" }),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: "Save" }),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: "Cancel" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("calls onClose when Close is clicked", async () => {
+			render(<JobDialog {...DEFAULT_PROPS} jobId={BASE_JOB.id} readOnly />);
+			await waitFor(() => {
+				expect(
+					screen.getByRole("button", { name: "Close" }),
+				).toBeInTheDocument();
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Close" }));
+			expect(DEFAULT_PROPS.onClose).toHaveBeenCalledOnce();
+		});
+
+		it("does not show the favorite toggle in the title bar", async () => {
+			render(<JobDialog {...DEFAULT_PROPS} jobId={BASE_JOB.id} readOnly />);
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: /Engineer/ }),
+				).toBeInTheDocument();
+			});
+			expect(
+				screen.queryByRole("button", { name: /favorite/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it("does not show an Add Interview button on the Interviews tab", async () => {
+			render(<JobDialog {...DEFAULT_PROPS} jobId={BASE_JOB.id} readOnly />);
+			await waitFor(() => {
+				expect(
+					screen.getByRole("heading", { name: /Engineer/ }),
+				).toBeInTheDocument();
+			});
+			fireEvent.click(screen.getByRole("tab", { name: /Interviews/ }));
+			await waitFor(() => {
+				expect(
+					screen.queryByRole("button", { name: "Add Interview" }),
+				).not.toBeInTheDocument();
+			});
+		});
+	});
 });

--- a/frontend/src/components/jobs/JobDialog.tsx
+++ b/frontend/src/components/jobs/JobDialog.tsx
@@ -83,6 +83,8 @@ interface Props {
 	onDelete: (id: number) => void;
 	/** Null = "add new job" mode; a number = edit the job with that ID */
 	jobId: number | null;
+	/** True when viewing a closed job search round — the dialog becomes view-only */
+	readOnly?: boolean;
 }
 
 export default function JobDialog({
@@ -91,6 +93,7 @@ export default function JobDialog({
 	onSave,
 	onDelete,
 	jobId,
+	readOnly = false,
 }: Props) {
 	const isEdit = jobId !== null;
 	const [form, setForm] = useState<JobFormData>(EMPTY);
@@ -306,11 +309,11 @@ export default function JobDialog({
 		</Dialog>
 	);
 
-	const formDisabled = loadingJob || Boolean(loadError);
+	const formDisabled = loadingJob || Boolean(loadError) || readOnly;
 
 	function actionsJustifyContent(): "space-between" | "flex-end" {
 		if (activeTab === 0) {
-			return isEdit ? "space-between" : "flex-end";
+			return isEdit && !readOnly ? "space-between" : "flex-end";
 		}
 		if (activeTab === 1) {
 			return viewingQuestionsFor ? "space-between" : "flex-end";
@@ -765,6 +768,7 @@ export default function JobDialog({
 								onCountChange={setInterviewCount}
 								viewingQuestionsFor={viewingQuestionsFor}
 								onViewingQuestionsChange={setViewingQuestionsFor}
+								readOnly={readOnly}
 							/>
 						)}
 						{isEdit && activeTab === 2 && form.status === "offer" && (
@@ -772,6 +776,7 @@ export default function JobDialog({
 								jobId={jobId!}
 								offerData={offerData}
 								onOfferChange={setOfferData}
+								readOnly={readOnly}
 							/>
 						)}
 					</Box>
@@ -784,31 +789,34 @@ export default function JobDialog({
 						py: 2,
 					}}
 				>
-					{activeTab === 0 && (
-						<>
-							{isEdit && (
-								<Button
-									color="error"
-									onClick={() => setConfirmDelete(true)}
-									disabled={formDisabled}
-								>
-									Delete
-								</Button>
-							)}
-							<div>
-								<Button onClick={handleClose} sx={{ mr: 1 }}>
-									Cancel
-								</Button>
-								<Button
-									variant="contained"
-									onClick={handleSave}
-									disabled={formDisabled}
-								>
-									{isEdit ? "Save" : "Add Job"}
-								</Button>
-							</div>
-						</>
-					)}
+					{activeTab === 0 &&
+						(readOnly ? (
+							<Button onClick={handleClose}>Close</Button>
+						) : (
+							<>
+								{isEdit && (
+									<Button
+										color="error"
+										onClick={() => setConfirmDelete(true)}
+										disabled={formDisabled}
+									>
+										Delete
+									</Button>
+								)}
+								<div>
+									<Button onClick={handleClose} sx={{ mr: 1 }}>
+										Cancel
+									</Button>
+									<Button
+										variant="contained"
+										onClick={handleSave}
+										disabled={formDisabled}
+									>
+										{isEdit ? "Save" : "Add Job"}
+									</Button>
+								</div>
+							</>
+						))}
 					{activeTab === 1 && (
 						<>
 							{viewingQuestionsFor && (

--- a/frontend/src/components/jobs/JobManagementPage.spec.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.spec.tsx
@@ -897,5 +897,59 @@ describe("jobManagementPage", () => {
 
 			await waitFor(() => expect(mockGetJob).toHaveBeenCalledWith(3));
 		});
+
+		it("passes readOnly=true to KanbanBoard", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetSearch.mockResolvedValue(
+				makeJobSearch({ id: 7, name: "Old Search" }),
+			);
+			renderPage("/jobs/history/7");
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+			expect(MockKanbanBoard).toHaveBeenCalledWith(
+				expect.objectContaining({ readOnly: true }),
+				undefined,
+			);
+		});
+
+		it("does not show the Add Job button", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetSearch.mockResolvedValue(
+				makeJobSearch({ id: 7, name: "Old Search" }),
+			);
+			renderPage("/jobs/history/7");
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+			expect(
+				screen.queryByRole("button", { name: "Add Job" }),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("live round route (/jobs)", () => {
+		it("passes readOnly=false to KanbanBoard", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			renderPage();
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+			expect(MockKanbanBoard).toHaveBeenCalledWith(
+				expect.objectContaining({ readOnly: false }),
+				undefined,
+			);
+		});
+
+		it("shows the Add Job button", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			renderPage();
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+			expect(
+				screen.getByRole("button", { name: "Add Job" }),
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/frontend/src/components/jobs/JobManagementPage.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.tsx
@@ -370,9 +370,11 @@ export default function JobManagementPage() {
 					zIndex: (theme) => theme.zIndex.appBar - 1,
 				}}
 			>
-				<Button variant="contained" startIcon={<AddIcon />} onClick={openAdd}>
-					Add Job
-				</Button>
+				{searchId === undefined && (
+					<Button variant="contained" startIcon={<AddIcon />} onClick={openAdd}>
+						Add Job
+					</Button>
+				)}
 
 				<TextField
 					placeholder="Search company or role… ( / )"
@@ -595,6 +597,7 @@ export default function JobManagementPage() {
 						onStatusChange={handleStatusChange}
 						onCardClick={openEdit}
 						onToggleFavorite={handleToggleFavorite}
+						readOnly={searchId !== undefined}
 					/>
 				</Box>
 			)}
@@ -604,6 +607,7 @@ export default function JobManagementPage() {
 				onClose={closeDialog}
 				onSave={handleSave}
 				onDelete={handleDelete}
+				readOnly={searchId !== undefined}
 				jobId={dialogJob?.id ?? null}
 			/>
 

--- a/frontend/src/components/jobs/KanbanBoard.spec.tsx
+++ b/frontend/src/components/jobs/KanbanBoard.spec.tsx
@@ -178,4 +178,24 @@ describe("kanbanBoard", () => {
 			expect(DEFAULT_PROPS.onStatusChange).not.toHaveBeenCalled();
 		});
 	});
+
+	describe("readOnly", () => {
+		it("does not render drag handles on any card", () => {
+			const jobs: Job[] = [
+				makeJob({ company: "Alpha", id: 1, status: "not_started" }),
+			];
+			render(<KanbanBoard {...DEFAULT_PROPS} jobs={jobs} readOnly />);
+			expect(screen.queryByTestId("DragIndicatorIcon")).not.toBeInTheDocument();
+		});
+
+		it("ignores a drag-end event and never calls onStatusChange", () => {
+			vi.clearAllMocks();
+			const job = makeJob({ company: "Acme", id: 1, status: "not_started" });
+			render(<KanbanBoard {...DEFAULT_PROPS} jobs={[job]} readOnly />);
+
+			dragJobTo(job, "applied");
+
+			expect(DEFAULT_PROPS.onStatusChange).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/frontend/src/components/jobs/KanbanBoard.tsx
+++ b/frontend/src/components/jobs/KanbanBoard.tsx
@@ -18,10 +18,17 @@ interface Props {
 	onStatusChange: (job: Job, newStatus: JobStatus) => void;
 	onCardClick: (job: Job) => void;
 	onToggleFavorite: (job: Job) => void;
+	readOnly?: boolean;
 }
 
 export default memo(
-	({ jobs, onStatusChange, onCardClick, onToggleFavorite }: Props) => {
+	({
+		jobs,
+		onStatusChange,
+		onCardClick,
+		onToggleFavorite,
+		readOnly = false,
+	}: Props) => {
 		const [activeJob, setActiveJob] = useState<Job | null>(null);
 		const [pendingStatusChange, setPendingStatusChange] = useState<{
 			job: Job;
@@ -48,7 +55,7 @@ export default memo(
 
 		function handleDragEnd({ active, over }: DragEndEvent) {
 			setActiveJob(null);
-			if (!over) {
+			if (readOnly || !over) {
 				return;
 			}
 			const job = (active.data.current as { job: Job } | undefined)?.job;
@@ -100,6 +107,7 @@ export default memo(
 							jobs={byStatus[status]}
 							onCardClick={onCardClick}
 							onToggleFavorite={onToggleFavorite}
+							readOnly={readOnly}
 						/>
 					))}
 				</Box>
@@ -110,6 +118,7 @@ export default memo(
 							job={activeJob}
 							onCardClick={() => {}}
 							onToggleFavorite={() => {}}
+							readOnly={readOnly}
 						/>
 					) : null}
 				</DragOverlay>

--- a/frontend/src/components/jobs/KanbanColumn.spec.tsx
+++ b/frontend/src/components/jobs/KanbanColumn.spec.tsx
@@ -80,4 +80,10 @@ describe("kanbanColumn", () => {
 		expect(screen.getByText("Alpha Corp")).toBeInTheDocument();
 		expect(screen.getByText("Beta Inc")).toBeInTheDocument();
 	});
+
+	it("passes readOnly through to each card, hiding the drag handle", () => {
+		const jobs = [makeJob({ id: 1, status: "not_started" })];
+		render(<KanbanColumn {...DEFAULT_PROPS} jobs={jobs} readOnly />);
+		expect(screen.queryByTestId("DragIndicatorIcon")).not.toBeInTheDocument();
+	});
 });

--- a/frontend/src/components/jobs/KanbanColumn.tsx
+++ b/frontend/src/components/jobs/KanbanColumn.tsx
@@ -10,10 +10,17 @@ interface Props {
 	jobs: Job[];
 	onCardClick: (job: Job) => void;
 	onToggleFavorite: (job: Job) => void;
+	readOnly?: boolean;
 }
 
 export default memo(
-	({ status, jobs, onCardClick, onToggleFavorite }: Props) => {
+	({
+		status,
+		jobs,
+		onCardClick,
+		onToggleFavorite,
+		readOnly = false,
+	}: Props) => {
 		const { setNodeRef, isOver } = useDroppable({ id: status });
 		const color = STATUS_COLORS[status];
 
@@ -92,6 +99,7 @@ export default memo(
 							job={job}
 							onCardClick={onCardClick}
 							onToggleFavorite={onToggleFavorite}
+							readOnly={readOnly}
 						/>
 					))}
 					{jobs.length === 0 && (

--- a/frontend/src/components/jobs/OfferTab.spec.tsx
+++ b/frontend/src/components/jobs/OfferTab.spec.tsx
@@ -40,7 +40,7 @@ const DEFAULT_PROPS = {
 	onOfferChange: vi.fn(),
 };
 
-function renderTab(props = DEFAULT_PROPS) {
+function renderTab(props: Parameters<typeof OfferTab>[0] = DEFAULT_PROPS) {
 	return render(
 		<SnackbarProvider>
 			<OfferTab {...props} />
@@ -342,6 +342,23 @@ describe("offerTab", () => {
 				42,
 				expect.objectContaining({ equity_vesting_years: 4 }),
 			);
+		});
+	});
+
+	describe("readOnly", () => {
+		it("does not render Save/Clear buttons", () => {
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER, readOnly: true });
+			expect(
+				screen.queryByRole("button", { name: "Save Offer" }),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: "Clear" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("disables the Base Pay field", () => {
+			renderTab({ ...DEFAULT_PROPS, offerData: BASE_OFFER, readOnly: true });
+			expect(screen.getByLabelText(/Base Pay/i)).toBeDisabled();
 		});
 	});
 });

--- a/frontend/src/components/jobs/OfferTab.tsx
+++ b/frontend/src/components/jobs/OfferTab.tsx
@@ -69,9 +69,15 @@ interface Props {
 	jobId: number;
 	offerData: Offer | null;
 	onOfferChange: (offer: Offer | null) => void;
+	readOnly?: boolean;
 }
 
-export default function OfferTab({ jobId, offerData, onOfferChange }: Props) {
+export default function OfferTab({
+	jobId,
+	offerData,
+	onOfferChange,
+	readOnly = false,
+}: Props) {
 	const notify = useNotify();
 	const [form, setForm] = useState<OfferFormData>(
 		offerData ? offerToForm(offerData) : EMPTY_FORM,
@@ -128,237 +134,249 @@ export default function OfferTab({ jobId, offerData, onOfferChange }: Props) {
 
 	return (
 		<Box>
-			<Grid container spacing={2} sx={{ pt: 0.5 }}>
-				{/* Row 1: base pay */}
-				<Grid size={{ sm: 6, xs: 12 }}>
-					<TextField
-						label="Base Pay ($/yr)"
-						type="number"
-						value={form.base_pay_amount ?? ""}
-						onChange={(e) =>
-							setField("base_pay_amount", parseAmount(e.target.value))
-						}
-						fullWidth
-						size="small"
-						slotProps={{ htmlInput: { min: 0 } }}
-					/>
-				</Grid>
+			<Box
+				component="fieldset"
+				disabled={readOnly}
+				sx={{ border: "none", m: 0, p: 0 }}
+			>
+				<Grid container spacing={2} sx={{ pt: 0.5 }}>
+					{/* Row 1: base pay */}
+					<Grid size={{ sm: 6, xs: 12 }}>
+						<TextField
+							label="Base Pay ($/yr)"
+							type="number"
+							value={form.base_pay_amount ?? ""}
+							onChange={(e) =>
+								setField("base_pay_amount", parseAmount(e.target.value))
+							}
+							fullWidth
+							size="small"
+							slotProps={{ htmlInput: { min: 0 } }}
+						/>
+					</Grid>
 
-				<Grid size={{ sm: 6, xs: 12 }}>
-					<TextField
-						label="Target Bonus %"
-						type="number"
-						value={form.target_bonus_percent ?? ""}
-						onChange={(e) =>
-							setField("target_bonus_percent", parsePercent(e.target.value))
-						}
-						fullWidth
-						size="small"
-						slotProps={{ htmlInput: { min: 0, step: 0.1 } }}
-					/>
-				</Grid>
+					<Grid size={{ sm: 6, xs: 12 }}>
+						<TextField
+							label="Target Bonus %"
+							type="number"
+							value={form.target_bonus_percent ?? ""}
+							onChange={(e) =>
+								setField("target_bonus_percent", parsePercent(e.target.value))
+							}
+							fullWidth
+							size="small"
+							slotProps={{ htmlInput: { min: 0, step: 0.1 } }}
+						/>
+					</Grid>
 
-				{/* Row 2: equity */}
-				<Grid size={{ sm: 4, xs: 12 }}>
-					<TextField
-						label="Equity Amount ($)"
-						type="number"
-						value={form.equity_amount ?? ""}
-						onChange={(e) =>
-							setField("equity_amount", parseAmount(e.target.value))
-						}
-						fullWidth
-						size="small"
-						slotProps={{
-							htmlInput: { min: 0 },
-							input: {
-								endAdornment: (
-									<InputAdornment position="end">
-										<Tooltip title="Enter total grant value at current fair market value">
-											<InfoOutlinedIcon
-												aria-label="Enter total grant value at current fair market value"
-												fontSize="small"
-												sx={{ color: "text.secondary" }}
-											/>
-										</Tooltip>
-									</InputAdornment>
-								),
-							},
-						}}
-					/>
-				</Grid>
+					{/* Row 2: equity */}
+					<Grid size={{ sm: 4, xs: 12 }}>
+						<TextField
+							label="Equity Amount ($)"
+							type="number"
+							value={form.equity_amount ?? ""}
+							onChange={(e) =>
+								setField("equity_amount", parseAmount(e.target.value))
+							}
+							fullWidth
+							size="small"
+							slotProps={{
+								htmlInput: { min: 0 },
+								input: {
+									endAdornment: (
+										<InputAdornment position="end">
+											<Tooltip title="Enter total grant value at current fair market value">
+												<InfoOutlinedIcon
+													aria-label="Enter total grant value at current fair market value"
+													fontSize="small"
+													sx={{ color: "text.secondary" }}
+												/>
+											</Tooltip>
+										</InputAdornment>
+									),
+								},
+							}}
+						/>
+					</Grid>
 
-				<Grid size={{ sm: 4, xs: 12 }}>
-					<TextField
-						label="Equity Vesting (years)"
-						type="number"
-						value={form.equity_vesting_years}
-						onChange={(e) => {
-							const n = parseInt(e.target.value, 10);
-							setField("equity_vesting_years", Number.isFinite(n) ? n : 4);
-						}}
-						fullWidth
-						size="small"
-						slotProps={{ htmlInput: { min: 1, max: 10 } }}
-					/>
-				</Grid>
+					<Grid size={{ sm: 4, xs: 12 }}>
+						<TextField
+							label="Equity Vesting (years)"
+							type="number"
+							value={form.equity_vesting_years}
+							onChange={(e) => {
+								const n = parseInt(e.target.value, 10);
+								setField("equity_vesting_years", Number.isFinite(n) ? n : 4);
+							}}
+							fullWidth
+							size="small"
+							slotProps={{ htmlInput: { min: 1, max: 10 } }}
+						/>
+					</Grid>
 
-				<Grid size={{ sm: 4, xs: 12 }}>
-					<TextField
-						select
-						label="Equity Type"
-						value={form.equity_type ?? ""}
-						onChange={(e) =>
-							setField(
-								"equity_type",
-								(e.target.value || null) as EquityType | null,
-							)
-						}
-						fullWidth
-						size="small"
-					>
-						<MenuItem value="">
-							<em>None</em>
-						</MenuItem>
-						{EQUITY_TYPES.map((t) => (
-							<MenuItem key={t} value={t}>
-								{EQUITY_TYPE_LABELS[t]}
+					<Grid size={{ sm: 4, xs: 12 }}>
+						<TextField
+							select
+							label="Equity Type"
+							value={form.equity_type ?? ""}
+							onChange={(e) =>
+								setField(
+									"equity_type",
+									(e.target.value || null) as EquityType | null,
+								)
+							}
+							fullWidth
+							size="small"
+						>
+							<MenuItem value="">
+								<em>None</em>
 							</MenuItem>
-						))}
-					</TextField>
-				</Grid>
+							{EQUITY_TYPES.map((t) => (
+								<MenuItem key={t} value={t}>
+									{EQUITY_TYPE_LABELS[t]}
+								</MenuItem>
+							))}
+						</TextField>
+					</Grid>
 
-				{/* Row 3: stipend / signing bonus */}
-				<Grid size={{ sm: 6, xs: 12 }}>
-					<TextField
-						label="Wellness Stipend ($/yr)"
-						type="number"
-						value={form.wellness_stipend_amount ?? ""}
-						onChange={(e) =>
-							setField("wellness_stipend_amount", parseAmount(e.target.value))
-						}
-						fullWidth
-						size="small"
-						slotProps={{ htmlInput: { min: 0 } }}
-					/>
-				</Grid>
+					{/* Row 3: stipend / signing bonus */}
+					<Grid size={{ sm: 6, xs: 12 }}>
+						<TextField
+							label="Wellness Stipend ($/yr)"
+							type="number"
+							value={form.wellness_stipend_amount ?? ""}
+							onChange={(e) =>
+								setField("wellness_stipend_amount", parseAmount(e.target.value))
+							}
+							fullWidth
+							size="small"
+							slotProps={{ htmlInput: { min: 0 } }}
+						/>
+					</Grid>
 
-				<Grid size={{ sm: 6, xs: 12 }}>
-					<TextField
-						label="Signing Bonus ($)"
-						type="number"
-						value={form.signing_bonus_amount ?? ""}
-						onChange={(e) =>
-							setField("signing_bonus_amount", parseAmount(e.target.value))
-						}
-						fullWidth
-						size="small"
-						slotProps={{ htmlInput: { min: 0 } }}
-					/>
-				</Grid>
+					<Grid size={{ sm: 6, xs: 12 }}>
+						<TextField
+							label="Signing Bonus ($)"
+							type="number"
+							value={form.signing_bonus_amount ?? ""}
+							onChange={(e) =>
+								setField("signing_bonus_amount", parseAmount(e.target.value))
+							}
+							fullWidth
+							size="small"
+							slotProps={{ htmlInput: { min: 0 } }}
+						/>
+					</Grid>
 
-				{/* Row 4: other */}
-				<Grid size={{ sm: 4, xs: 12 }}>
-					<TextField
-						label="Other Amount ($)"
-						type="number"
-						value={form.other_amount ?? ""}
-						onChange={(e) =>
-							setField("other_amount", parseAmount(e.target.value))
-						}
-						fullWidth
-						size="small"
-						slotProps={{ htmlInput: { min: 0 } }}
-					/>
-				</Grid>
+					{/* Row 4: other */}
+					<Grid size={{ sm: 4, xs: 12 }}>
+						<TextField
+							label="Other Amount ($)"
+							type="number"
+							value={form.other_amount ?? ""}
+							onChange={(e) =>
+								setField("other_amount", parseAmount(e.target.value))
+							}
+							fullWidth
+							size="small"
+							slotProps={{ htmlInput: { min: 0 } }}
+						/>
+					</Grid>
 
-				<Grid size={{ sm: 4, xs: 12 }}>
-					<TextField
-						label="Other Label"
-						value={form.other_label ?? ""}
-						onChange={(e) => setField("other_label", e.target.value || null)}
-						fullWidth
-						size="small"
-						placeholder="e.g. Car allowance"
-						slotProps={{ htmlInput: { maxLength: 128 } }}
-					/>
-				</Grid>
+					<Grid size={{ sm: 4, xs: 12 }}>
+						<TextField
+							label="Other Label"
+							value={form.other_label ?? ""}
+							onChange={(e) => setField("other_label", e.target.value || null)}
+							fullWidth
+							size="small"
+							placeholder="e.g. Car allowance"
+							slotProps={{ htmlInput: { maxLength: 128 } }}
+						/>
+					</Grid>
 
-				<Grid size={{ sm: 4, xs: 12 }}>
-					<FormControlLabel
-						control={
-							<Switch
-								checked={form.other_is_recurring}
-								onChange={(e) =>
-									setField("other_is_recurring", e.target.checked)
-								}
-								size="small"
-							/>
-						}
-						label="Other recurs annually"
-					/>
-				</Grid>
+					<Grid size={{ sm: 4, xs: 12 }}>
+						<FormControlLabel
+							control={
+								<Switch
+									checked={form.other_is_recurring}
+									onChange={(e) =>
+										setField("other_is_recurring", e.target.checked)
+									}
+									size="small"
+								/>
+							}
+							label="Other recurs annually"
+						/>
+					</Grid>
 
-				{/* Row 5: 401k / deadline */}
-				<Grid size={{ sm: 6, xs: 12 }}>
-					<TextField
-						label="401k Match %"
-						type="number"
-						value={form.k401_match_percent ?? ""}
-						onChange={(e) =>
-							setField("k401_match_percent", parsePercent(e.target.value))
-						}
-						fullWidth
-						size="small"
-						slotProps={{ htmlInput: { min: 0, step: 0.1 } }}
-					/>
-				</Grid>
+					{/* Row 5: 401k / deadline */}
+					<Grid size={{ sm: 6, xs: 12 }}>
+						<TextField
+							label="401k Match %"
+							type="number"
+							value={form.k401_match_percent ?? ""}
+							onChange={(e) =>
+								setField("k401_match_percent", parsePercent(e.target.value))
+							}
+							fullWidth
+							size="small"
+							slotProps={{ htmlInput: { min: 0, step: 0.1 } }}
+						/>
+					</Grid>
 
-				<Grid size={{ sm: 6, xs: 12 }}>
-					<TextField
-						label="Offer Deadline"
-						type="date"
-						value={form.offer_deadline ?? ""}
-						onChange={(e) => setField("offer_deadline", e.target.value || null)}
-						fullWidth
-						size="small"
-						slotProps={{ inputLabel: { shrink: true } }}
-					/>
-				</Grid>
+					<Grid size={{ sm: 6, xs: 12 }}>
+						<TextField
+							label="Offer Deadline"
+							type="date"
+							value={form.offer_deadline ?? ""}
+							onChange={(e) =>
+								setField("offer_deadline", e.target.value || null)
+							}
+							fullWidth
+							size="small"
+							slotProps={{ inputLabel: { shrink: true } }}
+						/>
+					</Grid>
 
-				{/* Row 6: notes */}
-				<Grid size={12}>
-					<TextField
-						label="Notes"
-						multiline
-						minRows={3}
-						value={form.notes ?? ""}
-						onChange={(e) => setField("notes", e.target.value || null)}
-						fullWidth
-						size="small"
-						slotProps={{ htmlInput: { maxLength: 20_000 } }}
-					/>
+					{/* Row 6: notes */}
+					<Grid size={12}>
+						<TextField
+							label="Notes"
+							multiline
+							minRows={3}
+							value={form.notes ?? ""}
+							onChange={(e) => setField("notes", e.target.value || null)}
+							fullWidth
+							size="small"
+							slotProps={{ htmlInput: { maxLength: 20_000 } }}
+						/>
+					</Grid>
 				</Grid>
-			</Grid>
-
-			<Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end", mt: 2 }}>
-				{offerData !== null && (
-					<Button
-						color="error"
-						disabled={saving}
-						onClick={() => void handleClear()}
-					>
-						Clear
-					</Button>
-				)}
-				<Button
-					variant="contained"
-					disabled={saving}
-					onClick={() => void handleSave()}
-				>
-					Save Offer
-				</Button>
 			</Box>
+
+			{!readOnly && (
+				<Box
+					sx={{ display: "flex", gap: 1, justifyContent: "flex-end", mt: 2 }}
+				>
+					{offerData !== null && (
+						<Button
+							color="error"
+							disabled={saving}
+							onClick={() => void handleClear()}
+						>
+							Clear
+						</Button>
+					)}
+					<Button
+						variant="contained"
+						disabled={saving}
+						onClick={() => void handleSave()}
+					>
+						Save Offer
+					</Button>
+				</Box>
+			)}
 		</Box>
 	);
 }

--- a/frontend/src/components/jobs/interviews/InterviewCard.tsx
+++ b/frontend/src/components/jobs/interviews/InterviewCard.tsx
@@ -38,6 +38,7 @@ export default function InterviewCard({
 	onEdit,
 	onDelete,
 	onViewQuestions,
+	readOnly = false,
 }: {
 	interview: Interview;
 	questionCount: number;
@@ -45,6 +46,7 @@ export default function InterviewCard({
 	onEdit: () => void;
 	onDelete: () => void;
 	onViewQuestions: () => void;
+	readOnly?: boolean;
 }) {
 	const TypeIcon =
 		interview.interview_stage === "phone_screen" ? PhoneIcon : BusinessIcon;
@@ -161,26 +163,28 @@ export default function InterviewCard({
 						{questionCount > 0 ? `Questions (${questionCount})` : "Questions"}
 					</Button>
 				</Box>
-				<Box sx={{ display: "flex", flexShrink: 0 }}>
-					<Tooltip title="Edit interview">
-						<IconButton
-							size="small"
-							onClick={onEdit}
-							aria-label="Edit interview"
-						>
-							<EditIcon fontSize="small" />
-						</IconButton>
-					</Tooltip>
-					<Tooltip title="Delete interview">
-						<IconButton
-							size="small"
-							onClick={onDelete}
-							aria-label="Delete interview"
-						>
-							<DeleteIcon fontSize="small" />
-						</IconButton>
-					</Tooltip>
-				</Box>
+				{!readOnly && (
+					<Box sx={{ display: "flex", flexShrink: 0 }}>
+						<Tooltip title="Edit interview">
+							<IconButton
+								size="small"
+								onClick={onEdit}
+								aria-label="Edit interview"
+							>
+								<EditIcon fontSize="small" />
+							</IconButton>
+						</Tooltip>
+						<Tooltip title="Delete interview">
+							<IconButton
+								size="small"
+								onClick={onDelete}
+								aria-label="Delete interview"
+							>
+								<DeleteIcon fontSize="small" />
+							</IconButton>
+						</Tooltip>
+					</Box>
+				)}
 			</Box>
 		</Box>
 	);

--- a/frontend/src/components/jobs/interviews/InterviewsTab.spec.tsx
+++ b/frontend/src/components/jobs/interviews/InterviewsTab.spec.tsx
@@ -663,4 +663,42 @@ describe("interviewsTab", () => {
 			});
 		});
 	});
+
+	describe("readOnly", () => {
+		it("does not show an Add Interview button", async () => {
+			vi.mocked(api.getInterviews).mockResolvedValue([]);
+			render(<InterviewsTab {...DEFAULT_PROPS} readOnly />);
+			await waitFor(() => {
+				expect(screen.getByText(/No interviews yet/i)).toBeInTheDocument();
+			});
+			expect(
+				screen.queryByRole("button", { name: "Add Interview" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("does not show Edit/Delete affordances on interview cards", async () => {
+			vi.mocked(api.getInterviews).mockResolvedValue([INTERVIEW_A]);
+			render(<InterviewsTab {...DEFAULT_PROPS} readOnly />);
+			await waitFor(() => {
+				expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+			});
+			expect(
+				screen.queryByRole("button", { name: "Edit interview" }),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: "Delete interview" }),
+			).not.toBeInTheDocument();
+		});
+
+		it("still allows viewing questions for an interview", async () => {
+			vi.mocked(api.getInterviews).mockResolvedValue([INTERVIEW_A]);
+			render(<InterviewsTab {...DEFAULT_PROPS} readOnly />);
+			await waitFor(() => {
+				expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+			});
+			expect(
+				screen.getByRole("button", { name: /Questions/ }),
+			).not.toBeDisabled();
+		});
+	});
 });

--- a/frontend/src/components/jobs/interviews/InterviewsTab.tsx
+++ b/frontend/src/components/jobs/interviews/InterviewsTab.tsx
@@ -17,6 +17,7 @@ interface Props {
 	onCountChange: (count: number) => void;
 	viewingQuestionsFor: Interview | null;
 	onViewingQuestionsChange: (interview: Interview | null) => void;
+	readOnly?: boolean;
 }
 
 export default function InterviewsTab({
@@ -25,6 +26,7 @@ export default function InterviewsTab({
 	onCountChange,
 	viewingQuestionsFor,
 	onViewingQuestionsChange,
+	readOnly = false,
 }: Props) {
 	const [interviews, setInterviews] = useState<Interview[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -274,6 +276,7 @@ export default function InterviewsTab({
 				onEdit={() => handleEditClick(interview)}
 				onDelete={() => setMode({ confirmDeleteId: interview.id })}
 				onViewQuestions={() => onViewingQuestionsChange(interview)}
+				readOnly={readOnly}
 			/>
 		);
 	};
@@ -336,7 +339,7 @@ export default function InterviewsTab({
 							mb: 1.5,
 						}}
 					>
-						{!isFormMode && (
+						{!isFormMode && !readOnly && (
 							<Button
 								size="small"
 								startIcon={<AddIcon />}
@@ -379,7 +382,11 @@ export default function InterviewsTab({
 				{/* Panel 2: Questions sub-view */}
 				<Box sx={{ minWidth: "50%", width: "50%" }}>
 					{displayedInterview && (
-						<QuestionSubView jobId={jobId} interview={displayedInterview} />
+						<QuestionSubView
+							jobId={jobId}
+							interview={displayedInterview}
+							readOnly={readOnly}
+						/>
 					)}
 				</Box>
 			</Box>

--- a/frontend/src/components/jobs/interviews/QuestionSubView.spec.tsx
+++ b/frontend/src/components/jobs/interviews/QuestionSubView.spec.tsx
@@ -469,4 +469,42 @@ describe("questionSubView", () => {
 			});
 		});
 	});
+
+	describe("readOnly", () => {
+		it("does not show the Add Question button when questions exist", async () => {
+			vi.mocked(api.getQuestions).mockResolvedValue([QUESTION_A]);
+			render(<QuestionSubView {...DEFAULT_PROPS} readOnly />);
+			await waitFor(() => {
+				expect(screen.getByText("Tell me about yourself")).toBeInTheDocument();
+			});
+			expect(
+				screen.queryByRole("button", { name: /Add Question/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it("shows the empty state without an 'Add one' link", async () => {
+			vi.mocked(api.getQuestions).mockResolvedValue([]);
+			render(<QuestionSubView {...DEFAULT_PROPS} readOnly />);
+			await waitFor(() => {
+				expect(
+					screen.getByText(/No questions recorded yet/i),
+				).toBeInTheDocument();
+			});
+			expect(screen.queryByText("Add one.")).not.toBeInTheDocument();
+		});
+
+		it("does not show Edit/Delete affordances on question cards", async () => {
+			vi.mocked(api.getQuestions).mockResolvedValue([QUESTION_A]);
+			render(<QuestionSubView {...DEFAULT_PROPS} readOnly />);
+			await waitFor(() => {
+				expect(screen.getByText("Tell me about yourself")).toBeInTheDocument();
+			});
+			expect(
+				screen.queryByRole("button", { name: "Edit question" }),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: "Delete question" }),
+			).not.toBeInTheDocument();
+		});
+	});
 });

--- a/frontend/src/components/jobs/interviews/QuestionSubView.tsx
+++ b/frontend/src/components/jobs/interviews/QuestionSubView.tsx
@@ -93,9 +93,14 @@ function formatDttm(dttm: string): string {
 interface Props {
 	jobId: number;
 	interview: Interview;
+	readOnly?: boolean;
 }
 
-export default function QuestionSubView({ jobId, interview }: Props) {
+export default function QuestionSubView({
+	jobId,
+	interview,
+	readOnly = false,
+}: Props) {
 	const [questions, setQuestions] = useState<InterviewQuestion[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [mode, setMode] = useState<QuestionMode>("list");
@@ -248,7 +253,7 @@ export default function QuestionSubView({ jobId, interview }: Props) {
 
 			{/* Add question button */}
 			<Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1.5 }}>
-				{!isFormMode && questions.length > 0 && (
+				{!isFormMode && !readOnly && questions.length > 0 && (
 					<Button
 						size="small"
 						startIcon={<AddIcon />}
@@ -333,6 +338,7 @@ export default function QuestionSubView({ jobId, interview }: Props) {
 								question={q}
 								onEdit={() => handleEditClick(q)}
 								onDelete={() => setMode({ confirmDeleteId: q.id })}
+								readOnly={readOnly}
 							/>
 						);
 					})}
@@ -344,18 +350,23 @@ export default function QuestionSubView({ jobId, interview }: Props) {
 							color="text.disabled"
 							sx={{ py: 3, textAlign: "center" }}
 						>
-							No questions recorded yet.{" "}
-							<Box
-								component="span"
-								onClick={handleAddClick}
-								sx={{
-									"&:hover": { textDecoration: "underline" },
-									color: "primary.main",
-									cursor: "pointer",
-								}}
-							>
-								Add one.
-							</Box>
+							No questions recorded yet.
+							{!readOnly && (
+								<>
+									{" "}
+									<Box
+										component="span"
+										onClick={handleAddClick}
+										sx={{
+											"&:hover": { textDecoration: "underline" },
+											color: "primary.main",
+											cursor: "pointer",
+										}}
+									>
+										Add one.
+									</Box>
+								</>
+							)}
 						</Typography>
 					)}
 
@@ -380,10 +391,12 @@ function QuestionCard({
 	question,
 	onEdit,
 	onDelete,
+	readOnly = false,
 }: {
 	question: InterviewQuestion;
 	onEdit: () => void;
 	onDelete: () => void;
+	readOnly?: boolean;
 }) {
 	const chipSx = QUESTION_TYPE_CHIP_SX[question.question_type];
 	const typeLabel = QUESTION_TYPE_LABELS[question.question_type];
@@ -418,26 +431,28 @@ function QuestionCard({
 					<Chip label={typeLabel} size="small" sx={chipSx} />
 					<DifficultySelector value={question.difficulty} readOnly />
 				</Box>
-				<Box sx={{ display: "flex", flexShrink: 0 }}>
-					<Tooltip title="Edit question">
-						<IconButton
-							size="small"
-							onClick={onEdit}
-							aria-label="Edit question"
-						>
-							<EditIcon fontSize="small" />
-						</IconButton>
-					</Tooltip>
-					<Tooltip title="Delete question">
-						<IconButton
-							size="small"
-							onClick={onDelete}
-							aria-label="Delete question"
-						>
-							<DeleteIcon fontSize="small" />
-						</IconButton>
-					</Tooltip>
-				</Box>
+				{!readOnly && (
+					<Box sx={{ display: "flex", flexShrink: 0 }}>
+						<Tooltip title="Edit question">
+							<IconButton
+								size="small"
+								onClick={onEdit}
+								aria-label="Edit question"
+							>
+								<EditIcon fontSize="small" />
+							</IconButton>
+						</Tooltip>
+						<Tooltip title="Delete question">
+							<IconButton
+								size="small"
+								onClick={onDelete}
+								aria-label="Delete question"
+							>
+								<DeleteIcon fontSize="small" />
+							</IconButton>
+						</Tooltip>
+					</Box>
+				)}
 			</Box>
 			<Typography variant="body2">{question.question_text}</Typography>
 			{question.question_notes && (


### PR DESCRIPTION
## Summary
Fourth of six PRs implementing "view past job searches" (see `PAST_JOB_SEARCHES_DESIGN.md`).

Threads a `readOnly` prop through the two component trees the historical route (from PR 3) needs to lock down, driven by `JobManagementPage`'s `searchId !== undefined` check:

**Kanban tree** (`KanbanBoard` → `KanbanColumn` → `JobCard`):
- Drag disabled via dnd-kit's native `disabled` option on `useDraggable` — prevents drag initiation entirely, not just a visual/CSS change.
- Drag handle icon hidden; favorite toggle disabled (with an explicit `aria-label` since MUI's `Tooltip` clones its label onto the `<span>` wrapper required for disabled buttons, not the button itself — matches the existing pattern in `InterviewForm.tsx`).
- "Add Job" toolbar button hidden.

**Job dialog stack** (`JobDialog` → `InterviewsTab`/`OfferTab` → `InterviewCard`/`QuestionSubView`):
- `JobDialog` extends its existing `formDisabled` (previously just loading/error) to include `readOnly`, reusing the `<fieldset disabled>` wrapper already in place around the Details tab — no new plumbing needed for that tab's fields.
- Footer shows only a "Close" button — no Save/Delete/Cancel.
- Add/Edit/Delete affordances hidden across interviews and interview questions; viewing existing interviews/questions still works normally.
- `OfferTab` fields disabled (same fieldset technique) and its Save/Clear row hidden.

Backend write guards from PR 2 remain the actual enforcement (409 on any write against a closed round) — this PR is the UI layer making that read-only behavior legible rather than confusing (buttons that would just 409 silently).

No visual "you're viewing history" banner/chip yet (PR 5) and still no discovery entry point (PR 6) — this remains reachable only via a typed URL.

## Test plan
- [x] `npm run tsc` passes
- [x] `npm run lint` / `npm run format:fix` clean
- [x] Full test suite: 1270/1270 passing (747 frontend + 523 backend), including new `readOnly` coverage in `JobCard`, `KanbanColumn`, `KanbanBoard`, `JobDialog`, `InterviewsTab`, `QuestionSubView`, `OfferTab`, and `JobManagementPage` specs