### PR TITLE
PR 5: Visual indicator for historical job search rounds

### DIFF
--- a/frontend/src/components/jobs/JobManagementPage.spec.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.spec.tsx
@@ -898,6 +898,59 @@ describe("jobManagementPage", () => {
 			await waitFor(() => expect(mockGetJob).toHaveBeenCalledWith(3));
 		});
 
+		it("shows a read-only banner with the round name and closed date", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetSearch.mockResolvedValue(
+				makeJobSearch({
+					// No trailing Z: parsed as local time so the date doesn't shift across the UTC boundary
+					closed_at: "2026-02-15T12:00:00",
+					id: 7,
+					name: "Old Search",
+				}),
+			);
+			renderPage("/jobs/history/7");
+			await waitFor(() => {
+				expect(screen.getByRole("alert")).toBeInTheDocument();
+			});
+			const banner = screen.getByRole("alert");
+			expect(banner).toHaveTextContent("Viewing");
+			expect(banner).toHaveTextContent("Old Search");
+			expect(banner).toHaveTextContent("closed Feb 15, 2026");
+			expect(banner).toHaveTextContent("read-only");
+		});
+
+		it("navigates to /jobs when 'Back to current search' is clicked", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetSearch.mockResolvedValue(
+				makeJobSearch({ id: 7, name: "Old Search" }),
+			);
+			renderPage("/jobs/history/7");
+			await waitFor(() => {
+				expect(
+					screen.getByRole("button", { name: "Back to current search" }),
+				).toBeInTheDocument();
+			});
+			fireEvent.click(
+				screen.getByRole("button", { name: "Back to current search" }),
+			);
+			await waitFor(() => {
+				expect(mockGetJobs).toHaveBeenCalledWith(undefined);
+			});
+		});
+
+		it("shows the round chip with a history icon and read-only tooltip", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetSearch.mockResolvedValue(
+				makeJobSearch({ id: 7, name: "Old Search" }),
+			);
+			renderPage("/jobs/history/7");
+			await waitFor(() => {
+				expect(screen.getByText("Old Search")).toBeInTheDocument();
+			});
+			// One HistoryIcon in the banner, one in the round chip
+			expect(screen.getAllByTestId("HistoryIcon")).toHaveLength(2);
+		});
+
 		it("passes readOnly=true to KanbanBoard", async () => {
 			mockGetJobs.mockResolvedValue([]);
 			mockGetSearch.mockResolvedValue(
@@ -950,6 +1003,30 @@ describe("jobManagementPage", () => {
 			expect(
 				screen.getByRole("button", { name: "Add Job" }),
 			).toBeInTheDocument();
+		});
+
+		it("does not show the read-only banner", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetActiveSearch.mockResolvedValue(
+				makeJobSearch({ name: "Search 1" }),
+			);
+			renderPage();
+			await waitFor(() =>
+				expect(screen.queryByRole("progressbar")).not.toBeInTheDocument(),
+			);
+			expect(screen.queryByText(/read-only/)).not.toBeInTheDocument();
+		});
+
+		it("does not show a history icon on the round chip", async () => {
+			mockGetJobs.mockResolvedValue([]);
+			mockGetActiveSearch.mockResolvedValue(
+				makeJobSearch({ name: "Search 1" }),
+			);
+			renderPage();
+			await waitFor(() => {
+				expect(screen.getByText("Search 1")).toBeInTheDocument();
+			});
+			expect(screen.queryByTestId("HistoryIcon")).not.toBeInTheDocument();
 		});
 	});
 });

--- a/frontend/src/components/jobs/JobManagementPage.tsx
+++ b/frontend/src/components/jobs/JobManagementPage.tsx
@@ -7,6 +7,7 @@ import React, {
 	useState,
 } from "react";
 import {
+	Alert,
 	Badge,
 	Box,
 	Button,
@@ -25,6 +26,7 @@ import {
 	Typography,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
+import HistoryIcon from "@mui/icons-material/History";
 import SearchIcon from "@mui/icons-material/Search";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
@@ -57,6 +59,21 @@ import EndingStatusDialog from "./EndingStatusDialog";
 function toSummaryJob(job: Job): Job {
 	const { notes: _n, job_description: _jd, ...rest } = job;
 	return rest;
+}
+
+function formatClosedDate(closedAt: string | null): string | null {
+	if (!closedAt) {
+		return null;
+	}
+	const d = new Date(closedAt);
+	if (isNaN(d.getTime())) {
+		return null;
+	}
+	return d.toLocaleDateString("en-US", {
+		day: "numeric",
+		month: "short",
+		year: "numeric",
+	});
 }
 
 // Minimum fit score filter: show jobs at or above this threshold
@@ -355,6 +372,29 @@ export default function JobManagementPage() {
 
 	return (
 		<>
+			{searchId !== undefined && activeSearch && (
+				<Alert
+					severity="info"
+					icon={<HistoryIcon fontSize="inherit" />}
+					action={
+						<Button
+							color="inherit"
+							size="small"
+							onClick={() => navigate("/jobs")}
+						>
+							Back to current search
+						</Button>
+					}
+					sx={{ alignItems: "center", borderRadius: 0 }}
+				>
+					Viewing &ldquo;{activeSearch.name}&rdquo;
+					{formatClosedDate(activeSearch.closed_at)
+						? ` — closed ${formatClosedDate(activeSearch.closed_at)}`
+						: ""}
+					. This search is read-only.
+				</Alert>
+			)}
+
 			{/* Board toolbar: Add Job button + filters */}
 			<Box
 				sx={{
@@ -405,7 +445,7 @@ export default function JobManagementPage() {
 				/>
 
 				<Box sx={{ alignItems: "center", display: "flex", gap: 1, ml: "auto" }}>
-					{activeSearch && (
+					{activeSearch && searchId === undefined && (
 						<Tooltip title="Current job search">
 							<Chip
 								label={activeSearch.name}
@@ -413,6 +453,22 @@ export default function JobManagementPage() {
 								sx={{
 									bgcolor: "rgba(255,255,255,0.15)",
 									color: "white",
+									fontWeight: 500,
+								}}
+							/>
+						</Tooltip>
+					)}
+					{activeSearch && searchId !== undefined && (
+						<Tooltip title="Past job search (read-only)">
+							<Chip
+								icon={
+									<HistoryIcon sx={{ color: "text.secondary !important" }} />
+								}
+								label={activeSearch.name}
+								size="small"
+								sx={{
+									bgcolor: "rgba(255,255,255,0.85)",
+									color: "text.primary",
 									fontWeight: 500,
 								}}
 							/>


### PR DESCRIPTION
## Summary
Fifth of six PRs implementing "view past job searches" (see `PAST_JOB_SEARCHES_DESIGN.md`).

- Persistent `Alert severity="info"` banner above the board toolbar, shown only when `searchId` is present in the URL: `Viewing "{name}" — closed {date}. This search is read-only.`, with a "Back to current search" button that navigates to `/jobs`.
- The existing round chip (top-right of the toolbar) swaps to a `HistoryIcon` + neutral (white/dark-text) styling and a "Past job search (read-only)" tooltip when viewing history, instead of the active round's translucent-on-primary styling and "Current job search" tooltip.

This is purely additive UI on top of PR 3 (routing/data) and PR 4 (read-only interaction) — makes the already-enforced read-only state visually legible instead of just a board with disabled buttons and no explanation.

Still no discovery entry point — `/jobs/history/:searchId` remains reachable only via a typed URL until PR 6 adds the "Past Job Searches" list in the `AppShell` user menu.

## Test plan
- [x] `npm run tsc` passes
- [x] `npm run lint` / `npm run format:fix` clean
- [x] Full test suite: 1275/1275 passing (752 frontend + 523 backend), including new coverage for the banner (name/date/read-only text, "Back to current search" navigation) and chip swap (history icon present on `/jobs/history/*`, absent on `/jobs`)