### PR TITLE
PR 6: Add Past Job Searches entry point

### DIFF
--- a/frontend/src/components/shared/AppShell.spec.tsx
+++ b/frontend/src/components/shared/AppShell.spec.tsx
@@ -35,6 +35,7 @@ vi.mock(import("../../api"), () => {
 		ApiError: MockApiError,
 		api: {
 			getActiveSearch: vi.fn(),
+			listSearches: vi.fn(),
 			startNewSearch: vi.fn(),
 		},
 	} as any;
@@ -42,6 +43,7 @@ vi.mock(import("../../api"), () => {
 
 const mockGetActiveSearch = vi.mocked(api.getActiveSearch);
 const mockStartNewSearch = vi.mocked(api.startNewSearch);
+const mockListSearches = vi.mocked(api.listSearches);
 
 const MOCK_USER: User = {
 	avatarUrl: null,
@@ -272,6 +274,97 @@ describe("appShell", () => {
 					screen.queryByText("Start new job search?"),
 				).not.toBeInTheDocument(),
 			);
+		});
+	});
+
+	describe("past job searches", () => {
+		it("shows a 'Past Job Searches' item in the user menu", () => {
+			renderAppShell();
+			openUserMenu();
+			expect(
+				screen.getByRole("menuitem", { name: /Past Job Searches/ }),
+			).toBeInTheDocument();
+		});
+
+		it("opens the dialog and closes the user menu when clicked", () => {
+			mockListSearches.mockReturnValue(new Promise(() => {}));
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(
+				screen.getByRole("menuitem", { name: /Past Job Searches/ }),
+			);
+
+			expect(
+				screen.getByRole("heading", { name: "Past Job Searches" }),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole("menuitem", { name: /Sign Out/ }),
+			).not.toBeInTheDocument();
+		});
+
+		it("excludes the active (still-open) round from the list", async () => {
+			mockListSearches.mockResolvedValue([
+				makeJobSearch({ closed_at: null, id: 1, name: "Current Search" }),
+				makeJobSearch({
+					closed_at: "2026-01-01T00:00:00.000Z",
+					id: 2,
+					name: "Old Search",
+				}),
+			]);
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(
+				screen.getByRole("menuitem", { name: /Past Job Searches/ }),
+			);
+
+			await waitFor(() => {
+				expect(screen.getByText("Old Search")).toBeInTheDocument();
+			});
+			expect(screen.queryByText("Current Search")).not.toBeInTheDocument();
+		});
+
+		it("shows an empty state when there are no closed rounds", async () => {
+			mockListSearches.mockResolvedValue([
+				makeJobSearch({ closed_at: null, id: 1, name: "Current Search" }),
+			]);
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(
+				screen.getByRole("menuitem", { name: /Past Job Searches/ }),
+			);
+
+			await waitFor(() => {
+				expect(
+					screen.getByText(/No past job searches yet/i),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("navigates to the history route and closes the dialog when a round is clicked", async () => {
+			mockListSearches.mockResolvedValue([
+				makeJobSearch({
+					closed_at: "2026-01-01T00:00:00.000Z",
+					id: 2,
+					name: "Old Search",
+				}),
+			]);
+			renderAppShell();
+			openUserMenu();
+			fireEvent.click(
+				screen.getByRole("menuitem", { name: /Past Job Searches/ }),
+			);
+
+			await waitFor(() => {
+				expect(screen.getByText("Old Search")).toBeInTheDocument();
+			});
+			fireEvent.click(screen.getByText("Old Search"));
+
+			expect(mockNavigate).toHaveBeenCalledWith("/jobs/history/2");
+			await waitFor(() => {
+				expect(
+					screen.queryByRole("heading", { name: "Past Job Searches" }),
+				).not.toBeInTheDocument();
+			});
 		});
 	});
 });

--- a/frontend/src/components/shared/AppShell.tsx
+++ b/frontend/src/components/shared/AppShell.tsx
@@ -17,6 +17,7 @@ import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import LogoutOutlinedIcon from "@mui/icons-material/LogoutOutlined";
 import CalendarMonthOutlinedIcon from "@mui/icons-material/CalendarMonthOutlined";
 import CompareArrowsIcon from "@mui/icons-material/CompareArrows";
+import HistoryIcon from "@mui/icons-material/History";
 import InsightsIcon from "@mui/icons-material/Insights";
 import PsychologyOutlinedIcon from "@mui/icons-material/PsychologyOutlined";
 import RadarIcon from "@mui/icons-material/Radar";
@@ -29,6 +30,7 @@ import type { BlockingJob, JobSearch, User } from "../../types";
 import Footer from "./Footer";
 import NewSearchRoundDialog from "./NewSearchRoundDialog";
 import NewSearchRoundConfirmDialog from "./NewSearchRoundConfirmDialog";
+import PastSearchesDialog from "./PastSearchesDialog";
 
 const NAV_ITEMS = [
 	{ icon: <ViewKanbanOutlinedIcon />, label: "Board", path: "/jobs" },
@@ -64,6 +66,7 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 	// Bumped whenever a new job search starts, forcing routed pages to remount and refetch.
 	const [roundVersion, setRoundVersion] = useState(0);
 	const [newSearchOpen, setNewSearchOpen] = useState(false);
+	const [pastSearchesOpen, setPastSearchesOpen] = useState(false);
 	const [pendingSearch, setPendingSearch] = useState<{
 		name: string;
 		notes: string | null;
@@ -93,6 +96,19 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 		setNewSearchOpen(false);
 		setBlockingJobs(null);
 	}, []);
+
+	const openPastSearches = useCallback(() => {
+		setUserMenuAnchor(null);
+		setPastSearchesOpen(true);
+	}, []);
+
+	const handleSelectPastSearch = useCallback(
+		(search: JobSearch) => {
+			setPastSearchesOpen(false);
+			navigate(`/jobs/history/${search.id}`);
+		},
+		[navigate],
+	);
 
 	const handleNameEntered = useCallback(
 		(name: string, notes: string | null) => {
@@ -184,6 +200,12 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 								<AutorenewIcon fontSize="small" />
 							</ListItemIcon>
 							<ListItemText>New Job Search</ListItemText>
+						</MenuItem>
+						<MenuItem onClick={openPastSearches}>
+							<ListItemIcon>
+								<HistoryIcon fontSize="small" />
+							</ListItemIcon>
+							<ListItemText>Past Job Searches</ListItemText>
 						</MenuItem>
 						<Divider />
 						<MenuItem
@@ -282,6 +304,12 @@ export default function AppShell({ currentUser, onLogout }: Props) {
 				newSearchName={pendingSearch?.name ?? ""}
 				onConfirm={handleConfirmStart}
 				onCancel={() => setPendingSearch(null)}
+			/>
+
+			<PastSearchesDialog
+				open={pastSearchesOpen}
+				onClose={() => setPastSearchesOpen(false)}
+				onSelect={handleSelectPastSearch}
 			/>
 		</Box>
 	);

--- a/frontend/src/components/shared/PastSearchesDialog.spec.tsx
+++ b/frontend/src/components/shared/PastSearchesDialog.spec.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import PastSearchesDialog from "./PastSearchesDialog";
+import { api } from "../../api";
+import { SnackbarProvider } from "../../useSnackbar";
+import { makeJobSearch } from "../../testUtils";
+
+vi.mock(
+	import("../../api"),
+	() =>
+		({
+			api: {
+				listSearches: vi.fn(),
+			},
+		}) as any,
+);
+
+const mockListSearches = vi.mocked(api.listSearches);
+
+const DEFAULT_PROPS = {
+	onClose: vi.fn(),
+	onSelect: vi.fn(),
+	open: true,
+};
+
+function renderDialog(props = DEFAULT_PROPS) {
+	return render(
+		<SnackbarProvider>
+			<PastSearchesDialog {...props} />
+		</SnackbarProvider>,
+	);
+}
+
+describe("pastSearchesDialog", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("renders nothing meaningful when open=false", () => {
+		renderDialog({ ...DEFAULT_PROPS, open: false });
+		expect(
+			screen.queryByRole("heading", { name: "Past Job Searches" }),
+		).not.toBeInTheDocument();
+		expect(mockListSearches).not.toHaveBeenCalled();
+	});
+
+	it("shows a loading spinner while fetching", () => {
+		mockListSearches.mockReturnValue(new Promise(() => {}));
+		renderDialog();
+		expect(screen.getByRole("progressbar")).toBeInTheDocument();
+	});
+
+	it("shows an empty state when there are no closed rounds", async () => {
+		mockListSearches.mockResolvedValue([
+			makeJobSearch({ closed_at: null, id: 1, name: "Current Search" }),
+		]);
+		renderDialog();
+		await waitFor(() => {
+			expect(screen.getByText(/No past job searches yet/i)).toBeInTheDocument();
+		});
+	});
+
+	it("excludes the active round and lists closed rounds", async () => {
+		mockListSearches.mockResolvedValue([
+			makeJobSearch({ closed_at: null, id: 1, name: "Current Search" }),
+			makeJobSearch({
+				closed_at: "2026-01-01T12:00:00",
+				id: 2,
+				name: "Old Search",
+				started_at: "2025-06-01T12:00:00",
+			}),
+		]);
+		renderDialog();
+		await waitFor(() => {
+			expect(screen.getByText("Old Search")).toBeInTheDocument();
+		});
+		expect(screen.queryByText("Current Search")).not.toBeInTheDocument();
+		expect(screen.getByText(/Started Jun 1, 2025/)).toBeInTheDocument();
+	});
+
+	it("calls onSelect with the search when a row is clicked", async () => {
+		const search = makeJobSearch({
+			closed_at: "2026-01-01T12:00:00",
+			id: 2,
+			name: "Old Search",
+		});
+		mockListSearches.mockResolvedValue([search]);
+		renderDialog();
+		await waitFor(() => {
+			expect(screen.getByText("Old Search")).toBeInTheDocument();
+		});
+		fireEvent.click(screen.getByText("Old Search"));
+		expect(DEFAULT_PROPS.onSelect).toHaveBeenCalledWith(search);
+	});
+
+	it("calls onClose when the Close button is clicked", async () => {
+		mockListSearches.mockResolvedValue([]);
+		renderDialog();
+		await waitFor(() => {
+			expect(screen.getByText(/No past job searches yet/i)).toBeInTheDocument();
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Close" }));
+		expect(DEFAULT_PROPS.onClose).toHaveBeenCalledOnce();
+	});
+
+	it("shows an error notification and an empty list when the fetch fails", async () => {
+		mockListSearches.mockRejectedValue(new Error("network error"));
+		renderDialog();
+		await waitFor(() => {
+			expect(
+				screen.getByText("Failed to load past job searches"),
+			).toBeInTheDocument();
+		});
+		expect(screen.getByText(/No past job searches yet/i)).toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/shared/PastSearchesDialog.tsx
+++ b/frontend/src/components/shared/PastSearchesDialog.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from "react";
+import {
+	Box,
+	CircularProgress,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Button,
+	IconButton,
+	List,
+	ListItemButton,
+	ListItemText,
+	Typography,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import HistoryIcon from "@mui/icons-material/History";
+import { api } from "../../api";
+import { useNotify } from "../../useSnackbar";
+import type { JobSearch } from "../../types";
+
+function formatStartedDate(startedAt: string): string {
+	const d = new Date(startedAt);
+	if (isNaN(d.getTime())) {
+		return startedAt;
+	}
+	return d.toLocaleDateString("en-US", {
+		day: "numeric",
+		month: "short",
+		year: "numeric",
+	});
+}
+
+interface Props {
+	open: boolean;
+	onClose: () => void;
+	onSelect: (search: JobSearch) => void;
+}
+
+export default function PastSearchesDialog({ open, onClose, onSelect }: Props) {
+	const [searches, setSearches] = useState<JobSearch[] | null>(null);
+	const notify = useNotify();
+
+	useEffect(() => {
+		if (!open) {
+			setSearches(null);
+			return;
+		}
+		let cancelled = false;
+		api
+			.listSearches()
+			.then((all) => {
+				if (!cancelled) {
+					setSearches(all.filter((s) => s.closed_at !== null));
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					notify("Failed to load past job searches", "error");
+					setSearches([]);
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, notify]);
+
+	return (
+		<Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+			<DialogTitle
+				sx={{
+					alignItems: "center",
+					display: "flex",
+					justifyContent: "space-between",
+				}}
+			>
+				Past Job Searches
+				<IconButton onClick={onClose} size="small">
+					<CloseIcon />
+				</IconButton>
+			</DialogTitle>
+			<DialogContent dividers sx={{ p: searches?.length ? 0 : 2 }}>
+				{searches === null && (
+					<Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+						<CircularProgress size={28} />
+					</Box>
+				)}
+				{searches !== null && searches.length === 0 && (
+					<Typography
+						variant="body2"
+						color="text.disabled"
+						sx={{ py: 2, textAlign: "center" }}
+					>
+						No past job searches yet — closed rounds will show up here.
+					</Typography>
+				)}
+				{searches !== null && searches.length > 0 && (
+					<List dense disablePadding>
+						{searches.map((search) => (
+							<ListItemButton key={search.id} onClick={() => onSelect(search)}>
+								<HistoryIcon
+									fontSize="small"
+									sx={{ color: "text.disabled", flexShrink: 0, mr: 1.5 }}
+								/>
+								<ListItemText
+									primary={search.name}
+									secondary={`Started ${formatStartedDate(search.started_at)}`}
+								/>
+							</ListItemButton>
+						))}
+					</List>
+				)}
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onClose}>Close</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
## Summary
Sixth and final PR implementing "view past job searches" (see `PAST_JOB_SEARCHES_DESIGN.md`).

- New `PastSearchesDialog` component: fetches all rounds via `api.listSearches()`, filters out the still-open active round (`closed_at === null`), and lists the rest (already newest-first from the API) with name + "Started {date}". Loading spinner while fetching, empty state when there are no closed rounds yet, error notification + empty list on fetch failure.
- Clicking a row calls `onSelect`, which in `AppShell` navigates to `/jobs/history/:searchId` and closes the dialog.
- New "Past Job Searches" item in the `AppShell` user menu (below "New Job Search"), opening the dialog and closing the menu.

This is the last piece — PRs 1–5 built the backend read API, the write guards that make closed rounds actually read-only, the `/jobs/history/:searchId` route, the read-only UI treatment, and the visual "you're viewing history" indicator, but none of it was reachable without typing a URL directly. This PR makes it discoverable.

## Test plan
- [x] `npm run tsc` passes
- [x] `npm run lint` / `npm run format:fix` clean
- [x] Full test suite: 1287/1287 passing (764 frontend + 523 backend), including new coverage in `PastSearchesDialog.spec.tsx` (loading/empty/error states, active-round exclusion, row click → `onSelect`) and `AppShell.spec.tsx` (menu item presence, dialog open/close, navigation on row click)