### PR TITLE
feat(db): seed Coinbase application-limit policy in target_companies

### DIFF
--- a/backend/db.ts
+++ b/backend/db.ts
@@ -241,7 +241,7 @@ db.exec(`
     ('LinkedIn',   'faang_adjacent', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
     ('Spotify',    'faang_adjacent', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
     ('Block',      'faang_adjacent', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-    ('Coinbase',   'faang_adjacent', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    ('Coinbase',   'faang_adjacent', NULL, NULL, NULL, 'Max 3 applications within a 6-month period', 'official', 3, 180),
     ('Robinhood',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
     ('Pinterest',  'faang_adjacent', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
     ('Reddit',     'faang_adjacent', NULL, NULL, NULL, NULL, NULL, NULL, NULL),


### PR DESCRIPTION
## Summary

Coinbase job postings state candidates may submit a max of 3 applications within a 6-month period. Seeds this policy into the `target_companies` row for Coinbase.

## Details

- Sets `max_apps_per_period = 3`, `apps_period_days = 180`
- Sets `policy_summary` and `policy_confidence = 'official'` (sourced directly from the posting text)
- Note: the seed block uses `INSERT OR IGNORE`, so this only affects fresh databases. Existing local/prod rows for Coinbase need a direct `UPDATE` (already applied to local `jobman.db` manually — prod will pick it up via the normal DB sync flow).

## Test plan

- [x] `npm run tsc`
- [x] `npm run lint:fix`
- [x] `npm run format:fix`
- [x] Confirm Coinbase's application-limit policy displays correctly on the Radar page

🤖 Generated with [Claude Code](https://claude.ai/claude-code)