### PR TITLE
fix(radar): don't count not_started jobs toward Active Pipeline eligibility

### DIFF
--- a/backend/db/radar.spec.ts
+++ b/backend/db/radar.spec.ts
@@ -124,6 +124,29 @@ describe("getRadar", () => {
 		expect(result.entries[0]!.eligibility).toBe("active");
 	});
 
+	it("does not treat a not_started job as active (still clear to apply)", () => {
+		const db = makeDb();
+		insertCompany(db, { name: "Acme" });
+		insertJob(db, { company: "Acme", status: "not_started" });
+		const result = getRadar(db, USER_ID);
+		expect(result.entries[0]!.eligibility).toBe("clear");
+		expect(result.entries[0]!.active_job_id).toBeNull();
+	});
+
+	it("falls back to a non-terminal job when a not_started job also exists", () => {
+		const db = makeDb();
+		insertCompany(db, { name: "Acme" });
+		insertJob(db, { company: "Acme", status: "not_started" });
+		const activeId = insertJob(db, {
+			company: "Acme",
+			status: "applied",
+			date_applied: daysAgo(5),
+		});
+		const result = getRadar(db, USER_ID);
+		expect(result.entries[0]!.eligibility).toBe("active");
+		expect(result.entries[0]!.active_job_id).toBe(activeId);
+	});
+
 	it("returns eligibility=cooling_down within the application cooldown window", () => {
 		const db = makeDb();
 		insertCompany(db, { name: "Acme", application_cooldown_days: 30 });

--- a/backend/db/radar.ts
+++ b/backend/db/radar.ts
@@ -257,7 +257,9 @@ export function getRadar(
 		const latestActiveStatus = bestRank > 0 ? (RANK_TO_STATUS[bestRank] ?? null) : null;
 
 		const activeJob =
-			companyJobs.find((j) => j.status !== "rejected_or_withdrawn") ?? null;
+			companyJobs.find(
+				(j) => j.status !== "rejected_or_withdrawn" && j.status !== "not_started",
+			) ?? null;
 
 		// Compute the earliest date each cooldown expires
 		const unlockCandidates: Date[] = [];


### PR DESCRIPTION
## Summary

The radar view's "Active Pipeline" chip was triggering for companies where the only job on the board was still `not_started`, i.e. added by a scan but never actually applied to. That blocked the company from correctly showing "Clear to Apply."

## Details

- `backend/db/radar.ts`: `activeJob` now excludes `not_started` in addition to `rejected_or_withdrawn`, so eligibility only reads "active" when there's a real, non-terminal application (`applied`, `phone_screen`, `interviewing`, or `offer`) in flight.
- Added two tests: a lone `not_started` job now resolves to `eligibility: "clear"` with `active_job_id: null`; when both a `not_started` job and a real applied job exist for the same company, the real job correctly wins and populates `active_job_id`.

## Test plan

- [x] `npm run tsc`
- [x] `npm run lint:fix`
- [x] `npm run format:fix`
- [x] Backend suite: 557 passing (2 new)
- [x] Verified against local data: Stripe (which had several `not_started` jobs added by a scan but no active application) now correctly shows `eligibility: "clear"` instead of `"active"`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)